### PR TITLE
chore: replace inline validation with graph-browser action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,18 +20,7 @@ jobs:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - run: nix build
       - name: Validate graph data
-        run: |
-          node -e "
-            const d=require('./data/graph.json');
-            const ids=new Set(d.nodes.map(n=>n.id));
-            let ok=true;
-            d.edges.forEach((e,i)=>{
-              if(!ids.has(e.source)){console.error('BAD source e'+i+': '+e.source);ok=false}
-              if(!ids.has(e.target)){console.error('BAD target e'+i+': '+e.target);ok=false}
-            });
-            if(!ok)process.exit(1);
-            console.log(d.nodes.length+' nodes, '+d.edges.length+' edges — OK');
-          "
+        uses: lambdasistemi/graph-browser/validate-action@main
       - name: Deploy PR preview
         if: github.event_name == 'pull_request'
         run: |


### PR DESCRIPTION
Replaces inline node script with lambdasistemi/graph-browser/validate-action@main