### PR TITLE
chore: replace nix build with graph-browser actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:
@@ -11,18 +12,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: paolino/dev-assets/setup-nix@v0.0.1
-        with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - run: nix build
-      - name: Validate graph data
-        uses: lambdasistemi/graph-browser/validate-action@main
+      - uses: lambdasistemi/graph-browser/validate-action@main
+      - uses: lambdasistemi/graph-browser/build-action@main
       - name: Deploy PR preview
         if: github.event_name == 'pull_request'
-        run: |
-          cp -rL result dist-preview
-          npx surge dist-preview ${{ github.repository_owner }}-${{ github.event.repository.name }}-pr-${{ github.event.number }}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+        run: npx surge site ${{ github.repository_owner }}-${{ github.event.repository.name }}-pr-${{ github.event.number }}.surge.sh --token ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,12 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: paolino/dev-assets/setup-nix@v0.0.1
-        with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - run: nix build
+      - uses: lambdasistemi/graph-browser/validate-action@main
+      - uses: lambdasistemi/graph-browser/build-action@main
       - uses: actions/upload-pages-artifact@v4
         with:
-          path: result
+          path: site
       - id: deployment
         uses: actions/deploy-pages@v5


### PR DESCRIPTION
Drops nix dependency from CI and Pages deploy. Uses validate-action + build-action instead.