### PR TITLE
Adopt graph-browser multi-source RDF input

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,17 @@ This repo is **data-only**. The viewer is provided by [graph-browser](https://gi
 
 ### Data files
 
-- `data/rdf/graph.ttl` — the graph (Turtle RDF, source of truth)
+- `data/rdf/graph.ttl` — graph-browser instance data and edge descriptions
+- `data/rdf/core-ontology.ttl` — graph-browser core ontology used by ontology views
+- `data/rdf/application-ontology.ttl` — repo-specific graph-browser vocabulary
 - `data/rdf/cardano.ttl` — Cardano domain ontology (W3C vocabularies)
-- `data/config.json` — viewer configuration (kinds, colors, shapes)
+- `data/config.json` — viewer configuration, including the ordered RDF sources to merge at runtime
 - `data/queries.json` — SPARQL query catalog
 - `data/tutorials/` — guided tours
 
 ## Contributing
 
-Edit `data/rdf/graph.ttl` (Turtle RDF) to add or modify nodes and edges. Edit `data/queries.json` for queries, `data/tutorials/` for tours. CI validates schemas and RDF syntax automatically.
+Edit `data/rdf/graph.ttl` for graph-browser nodes and relationships, and `data/rdf/cardano.ttl` for Cardano ontology classes and properties. Keep `data/queries.json` and `data/tutorials/` aligned with those node ids. CI validates every RDF source declared in `data/config.json`.
 
 ## Disclaimer
 

--- a/data/config.json
+++ b/data/config.json
@@ -2,10 +2,24 @@
   "title": "Cardano Knowledge Maps",
   "description": "Interactive knowledge maps of the Cardano ecosystem — governance, smart contracts, and more.",
   "sourceUrl": "https://github.com/lambdasistemi/cardano-knowledge-maps",
-  "graphSource": {
-    "format": "text/turtle",
-    "path": "data/rdf/graph.ttl"
-  },
+  "graphSources": [
+    {
+      "format": "text/turtle",
+      "path": "data/rdf/graph.ttl"
+    },
+    {
+      "format": "text/turtle",
+      "path": "data/rdf/core-ontology.ttl"
+    },
+    {
+      "format": "text/turtle",
+      "path": "data/rdf/application-ontology.ttl"
+    },
+    {
+      "format": "text/turtle",
+      "path": "data/rdf/cardano.ttl"
+    }
+  ],
   "kinds": {
     "actor": {
       "label": "Actor",

--- a/data/queries.json
+++ b/data/queries.json
@@ -119,7 +119,7 @@
     "id": "neighbors-of",
     "name": "Neighborhood",
     "description": "A node and everything directly connected to it.",
-    "sparql": "PREFIX gb: <https://lambdasistemi.github.io/graph-browser/vocab/terms#>\nSELECT DISTINCT ?node WHERE {\n  { BIND(<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/$nodeId> AS ?node) }\n  UNION { ?e a gb:EdgeAssertion ; gb:from <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/$nodeId> ; gb:to ?node }\n  UNION { ?e a gb:EdgeAssertion ; gb:to <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/$nodeId> ; gb:from ?node }\n}",
+    "sparql": "SELECT DISTINCT ?node WHERE {\n  { BIND(<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/$nodeId> AS ?node) }\n  UNION {\n    <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/$nodeId> ?predicate ?node .\n    FILTER(isIRI(?node))\n  }\n  UNION {\n    ?node ?predicate <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/$nodeId> .\n    FILTER(isIRI(?node))\n  }\n}",
     "parameters": [
       {
         "name": "nodeId",
@@ -211,7 +211,7 @@
   },
   {
     "id": "ontology-subtree",
-    "name": "Ontology Subtree",
+    "name": "Ontology Subtrees",
     "description": "A class and all descendants beneath a selected ontology root.",
     "sparql": "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\nSELECT DISTINCT ?node WHERE {\n  ?class rdfs:subClassOf* ?ancestor .\n  FILTER(isIRI(?class) && isIRI(?ancestor))\n  BIND(CONCAT(\"owl-\", LCASE(REPLACE(REPLACE(STR(?class), \"^.*(#|/)\", \"\"), \"[^A-Za-z0-9]+\", \"-\"))) AS ?node)\n  BIND(CONCAT(\"owl-\", LCASE(REPLACE(REPLACE(STR(?ancestor), \"^.*(#|/)\", \"\"), \"[^A-Za-z0-9]+\", \"-\"))) AS ?ancestorNode)\n  FILTER(?ancestorNode = \"$root\")\n}",
     "parameters": [{ "name": "root", "label": "Root Class", "type": "node" }],

--- a/data/rdf/core-ontology.mmd
+++ b/data/rdf/core-ontology.mmd
@@ -3,8 +3,6 @@ flowchart LR
   Dataset["gb:Dataset"]
   Node["gb:Node"]
   Group["gb:Group"]
-  EdgeAssertion["gb:EdgeAssertion"]
-  ExternalLink["gb:ExternalLink"]
   Tutorial["gb:Tutorial"]
   TutorialStop["gb:TutorialStop"]
   View["gb:View"]
@@ -16,8 +14,6 @@ flowchart LR
   Core --> Dataset
   Core --> Node
   Core --> Group
-  Core --> EdgeAssertion
-  Core --> ExternalLink
   Core --> Tutorial
   Core --> TutorialStop
   Core --> View
@@ -31,7 +27,6 @@ flowchart LR
   Dataset -->|has views| View
   Dataset -->|has query catalogs| QueryCatalog
   Node -->|belongs to 1| Group
-  Node -->|links to| ExternalLink
   Tutorial -->|has stops 0..*| TutorialStop
   TutorialStop -->|focuses on| Node
   View -->|has edge refs 0..*| EdgeReference
@@ -40,6 +35,3 @@ flowchart LR
   EdgeReference -->|edge target| Node
   QueryCatalog -->|has named queries 0..*| NamedQuery
   NamedQuery -->|has parameters 0..*| QueryParameter
-  EdgeAssertion -->|from 1| Node
-  EdgeAssertion -->|to 1| Node
-  EdgeAssertion -->|predicate 1| EdgeRelation

--- a/data/rdf/core-ontology.ttl
+++ b/data/rdf/core-ontology.ttl
@@ -3,11 +3,12 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://lambdasistemi.github.io/graph-browser/vocab/ontology> a owl:Ontology ;
   rdfs:label "Graph Browser core vocabulary" ;
-  dcterms:description "Shared graph-browser ontology for datasets, views, tutorials, queries, and edge assertions." ;
+  dcterms:description "Shared graph-browser ontology for datasets, views, tutorials, and queries, aligned to standard RDF descriptions and links." ;
   owl:versionInfo "0.1.0" .
 
 gb:Dataset a owl:Class ;
@@ -21,14 +22,6 @@ gb:Node a owl:Class ;
 gb:Group a owl:Class ;
   rdfs:label "Group" ;
   dcterms:description "An organizational group used by graph-browser nodes." .
-
-gb:EdgeAssertion a owl:Class ;
-  rdfs:label "Edge assertion" ;
-  dcterms:description "Metadata resource preserving the original graph-browser edge record." .
-
-gb:ExternalLink a owl:Class ;
-  rdfs:label "External link" ;
-  dcterms:description "External URL associated with a graph-browser node." .
 
 gb:Tutorial a owl:Class ;
   rdfs:label "Tutorial" ;
@@ -119,24 +112,6 @@ gb:QueryParameter rdfs:subClassOf
     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
     owl:onDataRange xsd:string
   ] .
-
-gb:EdgeAssertion rdfs:subClassOf
-  [ a owl:Restriction ;
-    owl:onProperty gb:from ;
-    owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-    owl:onClass gb:Node
-  ] ,
-  [ a owl:Restriction ;
-    owl:onProperty gb:to ;
-    owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-    owl:onClass gb:Node
-  ] ,
-  [ a owl:Restriction ;
-    owl:onProperty gb:predicate ;
-    owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-    owl:onClass rdf:Property
-  ] .
-
 gb:EdgeRelation a owl:ObjectProperty ;
   rdfs:label "edge relation" ;
   dcterms:description "A direct relationship predicate between two graph-browser nodes." ;
@@ -183,21 +158,6 @@ gb:group a owl:ObjectProperty ;
   rdfs:label "group" ;
   rdfs:domain gb:Node ;
   rdfs:range gb:Group .
-
-gb:description a owl:DatatypeProperty ;
-  rdfs:label "description" ;
-  rdfs:domain gb:Node ;
-  rdfs:range xsd:string .
-
-gb:externalLink a owl:ObjectProperty ;
-  rdfs:label "external link" ;
-  rdfs:domain gb:Node ;
-  rdfs:range gb:ExternalLink .
-
-gb:url a owl:DatatypeProperty ;
-  rdfs:label "url" ;
-  rdfs:domain gb:ExternalLink ;
-  rdfs:range xsd:anyURI .
 
 gb:hasTutorial a owl:ObjectProperty ;
   rdfs:label "has tutorial" ;
@@ -298,23 +258,7 @@ gb:tag a owl:DatatypeProperty ;
   rdfs:label "tag" ;
   rdfs:domain gb:NamedQuery ;
   rdfs:range xsd:string .
-
-gb:predicate a owl:ObjectProperty ;
-  rdfs:label "predicate" ;
-  rdfs:domain gb:EdgeAssertion ;
-  rdfs:range rdf:Property .
-
-gb:from a owl:ObjectProperty ;
-  rdfs:label "from" ;
-  rdfs:domain gb:EdgeAssertion ;
-  rdfs:range gb:Node .
-
-gb:to a owl:ObjectProperty ;
-  rdfs:label "to" ;
-  rdfs:domain gb:EdgeAssertion ;
-  rdfs:range gb:Node .
-
 gb:edgeIndex a owl:DatatypeProperty ;
   rdfs:label "edge index" ;
-  rdfs:domain gb:EdgeAssertion ;
+  rdfs:domain rdf:Statement ;
   rdfs:range xsd:integer .

--- a/data/rdf/graph.ttl
+++ b/data/rdf/graph.ttl
@@ -1,2351 +1,1595 @@
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/128> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-88 provides a standard for declaring token metadata linked to a minting policy, enabling verifiable token information." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "registers metadata for" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#registers%20metadata%20for> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-88> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 128 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/128> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-88> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#registers%20metadata%20for> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> ;
+	<http://purl.org/dc/terms/description> "CIP-88 provides a standard for declaring token metadata linked to a minting policy, enabling verifiable token information." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-88> <https://lambdasistemi.github.io/graph-browser/vocab/edges#registers%20metadata%20for> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/127> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-85 replaces Scott-encoded data with native sums-of-products in Plutus Core, reducing script size and execution cost." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "optimizes" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#optimizes> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-85> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 127 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/127> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-85> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#optimizes> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
+	<http://purl.org/dc/terms/description> "CIP-85 replaces Scott-encoded data with native sums-of-products in Plutus Core, reducing script size and execution cost." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-85> <https://lambdasistemi.github.io/graph-browser/vocab/edges#optimizes> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/126> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-381 adds BLS12-381 curve operations as Plutus Core built-in functions for on-chain cryptographic verification." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "adds built-ins to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#adds%20built-ins%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-381> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 126 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/126> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-381> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#adds%20built-ins%20to> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
+	<http://purl.org/dc/terms/description> "CIP-381 adds BLS12-381 curve operations as Plutus Core built-in functions for on-chain cryptographic verification." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-381> <https://lambdasistemi.github.io/graph-browser/vocab/edges#adds%20built-ins%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/125> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-69 unifies the argument interface across all Plutus script purposes, enabling multi-purpose validators." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "unifies script types in" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#unifies%20script%20types%20in> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-69> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 125 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/125> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-69> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#unifies%20script%20types%20in> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
+	<http://purl.org/dc/terms/description> "CIP-69 unifies the argument interface across all Plutus script purposes, enabling multi-purpose validators." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-69> <https://lambdasistemi.github.io/graph-browser/vocab/edges#unifies%20script%20types%20in> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/124> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "GovTool reads and displays DRep profile metadata structured according to CIP-119." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "renders profiles from" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#renders%20profiles%20from> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-119> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 124 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/124> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#renders%20profiles%20from> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-119> ;
+	<http://purl.org/dc/terms/description> "GovTool reads and displays DRep profile metadata structured according to CIP-119." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> <https://lambdasistemi.github.io/graph-browser/vocab/edges#renders%20profiles%20from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-119> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/123> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "DReps publish their profile metadata following CIP-119, enabling voters to discover and evaluate representatives through governance tools." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "profile follows" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#profile%20follows> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-119> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 123 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/123> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#profile%20follows> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-119> ;
+	<http://purl.org/dc/terms/description> "DReps publish their profile metadata following CIP-119, enabling voters to discover and evaluate representatives through governance tools." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> <https://lambdasistemi.github.io/graph-browser/vocab/edges#profile%20follows> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-119> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/122> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-119 builds on CIP-100's base governance metadata format, adding DRep-specific fields like display name, bio, motivations, and qualifications." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "extends" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-100> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-119> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 122 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/122> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-119> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-100> ;
+	<http://purl.org/dc/terms/description> "CIP-119 builds on CIP-100's base governance metadata format, adding DRep-specific fields like display name, bio, motivations, and qualifications." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-119> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-100> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/121> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Mesh SDK uses CIP-30 to interact with browser-based Cardano wallets." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "uses" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-30> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 121 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/121> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-30> ;
+	<http://purl.org/dc/terms/description> "Mesh SDK uses CIP-30 to interact with browser-based Cardano wallets." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-30> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/120> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Lucid Evolution uses CIP-30 to connect to browser wallets for transaction signing and submission." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "uses" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-30> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 120 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/120> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-30> ;
+	<http://purl.org/dc/terms/description> "Lucid Evolution uses CIP-30 to connect to browser wallets for transaction signing and submission." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-30> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/119> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-95 extends the CIP-30 wallet connector with Conway-era governance capabilities: DRep registration, vote delegation, and governance action submission." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "extends" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-30> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-95> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 119 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/119> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-95> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-30> ;
+	<http://purl.org/dc/terms/description> "CIP-95 extends the CIP-30 wallet connector with Conway-era governance capabilities: DRep registration, vote delegation, and governance action submission." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-95> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-30> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/118> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Lucid can auto-generate off-chain bindings from CIP-57 Plutus blueprints." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "consumes" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#consumes> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 118 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/118> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#consumes> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57> ;
+	<http://purl.org/dc/terms/description> "Lucid can auto-generate off-chain bindings from CIP-57 Plutus blueprints." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> <https://lambdasistemi.github.io/graph-browser/vocab/edges#consumes> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/117> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Demeter provides cloud infrastructure for developing, testing, and deploying Plutus-based dApps." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "hosts infrastructure for" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#hosts%20infrastructure%20for> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/demeter> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 117 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/117> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/demeter> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#hosts%20infrastructure%20for> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
+	<http://purl.org/dc/terms/description> "Demeter provides cloud infrastructure for developing, testing, and deploying Plutus-based dApps." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/demeter> <https://lambdasistemi.github.io/graph-browser/vocab/edges#hosts%20infrastructure%20for> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/116> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Blockfrost indexes the UTxO set and provides REST APIs for querying chain state, script datums, and transaction history." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "indexes" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#indexes> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 116 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/116> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#indexes> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> ;
+	<http://purl.org/dc/terms/description> "Blockfrost indexes the UTxO set and provides REST APIs for querying chain state, script datums, and transaction history." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost> <https://lambdasistemi.github.io/graph-browser/vocab/edges#indexes> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/115> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Mesh SDK provides high-level TypeScript APIs for building transactions that interact with smart contracts." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "builds transactions for" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#builds%20transactions%20for> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 115 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/115> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#builds%20transactions%20for> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
+	<http://purl.org/dc/terms/description> "Mesh SDK provides high-level TypeScript APIs for building transactions that interact with smart contracts." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk> <https://lambdasistemi.github.io/graph-browser/vocab/edges#builds%20transactions%20for> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/114> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Lucid Evolution constructs off-chain transactions that interact with Plutus validators, handling datum/redeemer serialization." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "builds transactions for" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#builds%20transactions%20for> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 114 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/114> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#builds%20transactions%20for> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
+	<http://purl.org/dc/terms/description> "Lucid Evolution constructs off-chain transactions that interact with Plutus validators, handling datum/redeemer serialization." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> <https://lambdasistemi.github.io/graph-browser/vocab/edges#builds%20transactions%20for> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/113> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Djed stablecoin uses Plutus validators with formally verified peg stability properties." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "built on" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#built%20on> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/djed> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 113 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/113> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/djed> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#built%20on> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
+	<http://purl.org/dc/terms/description> "Djed stablecoin uses Plutus validators with formally verified peg stability properties." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/djed> <https://lambdasistemi.github.io/graph-browser/vocab/edges#built%20on> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/112> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Hydra L2 heads replicate the full EUTxO model off-chain with the same smart contract semantics." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "replicates" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#replicates> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 112 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/112> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#replicates> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> ;
+	<http://purl.org/dc/terms/description> "Hydra L2 heads replicate the full EUTxO model off-chain with the same smart contract semantics." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra> <https://lambdasistemi.github.io/graph-browser/vocab/edges#replicates> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/111> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Liqwid uses Plutarch for performance-critical lending/borrowing validators." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "written in" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#written%20in> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liqwid> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 111 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/111> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liqwid> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#written%20in> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch> ;
+	<http://purl.org/dc/terms/description> "Liqwid uses Plutarch for performance-critical lending/borrowing validators." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liqwid> <https://lambdasistemi.github.io/graph-browser/vocab/edges#written%20in> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/110> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Minswap V2 validators are written in Aiken for production-grade AMM DEX." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "written in" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#written%20in> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 110 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/110> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#written%20in> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> ;
+	<http://purl.org/dc/terms/description> "Minswap V2 validators are written in Aiken for production-grade AMM DEX." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap> <https://lambdasistemi.github.io/graph-browser/vocab/edges#written%20in> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/109> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Aiken automatically generates CIP-57 Plutus blueprints from contract source code." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "generates" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#generates> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 109 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/109> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#generates> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57> ;
+	<http://purl.org/dc/terms/description> "Aiken automatically generates CIP-57 Plutus blueprints from contract source code." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> <https://lambdasistemi.github.io/graph-browser/vocab/edges#generates> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/108> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-57 blueprints provide machine-readable interface documentation for Plutus contracts." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "documents" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#documents> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 108 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/108> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#documents> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
+	<http://purl.org/dc/terms/description> "CIP-57 blueprints provide machine-readable interface documentation for Plutus contracts." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57> <https://lambdasistemi.github.io/graph-browser/vocab/edges#documents> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/107> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-68 is the successor to CIP-25, adding mutability and richer metadata capabilities." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "succeeds" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#succeeds> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 107 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/107> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#succeeds> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25> ;
+	<http://purl.org/dc/terms/description> "CIP-68 is the successor to CIP-25, adding mutability and richer metadata capabilities." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68> <https://lambdasistemi.github.io/graph-browser/vocab/edges#succeeds> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/106> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-68 stores rich metadata in UTxO datums, enabling mutable token metadata." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "uses" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 106 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/106> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> ;
+	<http://purl.org/dc/terms/description> "CIP-68 stores rich metadata in UTxO datums, enabling mutable token metadata." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/105> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-25 defines how NFT metadata is attached to minting transactions via label 721." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "extends" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 105 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/105> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> ;
+	<http://purl.org/dc/terms/description> "CIP-25 defines how NFT metadata is attached to minting transactions via label 721." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/104> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Oracles publish data in UTxO datums; consumers read via reference inputs without contention." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "uses" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 104 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/104> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs> ;
+	<http://purl.org/dc/terms/description> "Oracles publish data in UTxO datums; consumers read via reference inputs without contention." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/103> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "State machines store contract state in the datum, with validators enforcing valid transitions." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "uses" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 103 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/103> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> ;
+	<http://purl.org/dc/terms/description> "State machines store contract state in the datum, with validators enforcing valid transitions." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/102> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The withdraw-zero pattern reduces validation cost from O(n²) to O(n) by consolidating logic in a staking validator." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "optimizes" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#optimizes> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/staking-validator> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 102 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/102> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/staking-validator> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#optimizes> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> ;
+	<http://purl.org/dc/terms/description> "The withdraw-zero pattern reduces validation cost from O(n²) to O(n) by consolidating logic in a staking validator." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/staking-validator> <https://lambdasistemi.github.io/graph-browser/vocab/edges#optimizes> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/101> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Marlowe financial contracts compile to Plutus Core validators with formal verification guarantees." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "compiles to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 101 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/101> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
+	<http://purl.org/dc/terms/description> "Marlowe financial contracts compile to Plutus Core validators with formal verification guarantees." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/100> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "plu-ts constructs UPLC AST directly in TypeScript." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "compiles to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plu-ts> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 100 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/100> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plu-ts> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
+	<http://purl.org/dc/terms/description> "plu-ts constructs UPLC AST directly in TypeScript." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plu-ts> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/99> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Plutarch generates UPLC with fine-grained control, producing highly optimized validators." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "compiles to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 99 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/99> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
+	<http://purl.org/dc/terms/description> "Plutarch generates UPLC with fine-grained control, producing highly optimized validators." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/98> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Scalus compiles Scala 3 to UPLC with compile-time partial evaluation." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "compiles to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 98 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/98> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
+	<http://purl.org/dc/terms/description> "Scalus compiles Scala 3 to UPLC with compile-time partial evaluation." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/97> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Helios compiles its TypeScript-embedded DSL to Plutus Core." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "compiles to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/helios> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 97 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/97> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/helios> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
+	<http://purl.org/dc/terms/description> "Helios compiles its TypeScript-embedded DSL to Plutus Core." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/helios> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/96> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "OpShin compiles Python syntax to UPLC, enforcing a strict type system at compile time." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "compiles to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 96 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/96> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
+	<http://purl.org/dc/terms/description> "OpShin compiles Python syntax to UPLC, enforcing a strict type system at compile time." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/95> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Plinth (formerly PlutusTx) compiles a Haskell subset to Plutus Core via GHC plugin." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "compiles to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 95 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/95> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
+	<http://purl.org/dc/terms/description> "Plinth (formerly PlutusTx) compiles a Haskell subset to Plutus Core via GHC plugin." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/94> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Aiken compiles directly to UPLC (Untyped Plutus Core) with aggressive optimization passes." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "compiles to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 94 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/94> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
+	<http://purl.org/dc/terms/description> "Aiken compiles directly to UPLC (Untyped Plutus Core) with aggressive optimization passes." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/93> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Parameter changes can modify ExUnits prices, changing how much ada scripts cost to run." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "affects" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#affects> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 93 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/93> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#affects> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> ;
+	<http://purl.org/dc/terms/description> "Parameter changes can modify ExUnits prices, changing how much ada scripts cost to run." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> <https://lambdasistemi.github.io/graph-browser/vocab/edges#affects> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/92> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Parameter change governance actions can update cost model values, affecting smart contract execution costs." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "can modify" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20modify> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 92 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/92> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20modify> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> ;
+	<http://purl.org/dc/terms/description> "Parameter change governance actions can update cost model values, affecting smart contract execution costs." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20modify> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/91> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The on-chain guardrails script is a Plutus validator that enforces constitutional rules on governance parameter changes." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "written in" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#written%20in> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 91 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/91> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#written%20in> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
+	<http://purl.org/dc/terms/description> "The on-chain guardrails script is a Plutus validator that enforces constitutional rules on governance parameter changes." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> <https://lambdasistemi.github.io/graph-browser/vocab/edges#written%20in> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/90> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Minting policies are Plutus scripts that control native token creation and destruction." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "type of" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#type%20of> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 90 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/90> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#type%20of> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
+	<http://purl.org/dc/terms/description> "Minting policies are Plutus scripts that control native token creation and destruction." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> <https://lambdasistemi.github.io/graph-browser/vocab/edges#type%20of> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/89> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Inline datums store the full datum in the UTxO, eliminating off-chain datum management." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "improves" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#improves> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/inline-datums> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 89 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/89> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/inline-datums> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#improves> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> ;
+	<http://purl.org/dc/terms/description> "Inline datums store the full datum in the UTxO, eliminating off-chain datum management." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/inline-datums> <https://lambdasistemi.github.io/graph-browser/vocab/edges#improves> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/88> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Reference inputs add read-only UTxO access to the EUTxO model, enabling oracle and shared state patterns." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "extends" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 88 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/88> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> ;
+	<http://purl.org/dc/terms/description> "Reference inputs add read-only UTxO access to the EUTxO model, enabling oracle and shared state patterns." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/87> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Reference scripts reduce costs by allowing scripts to be stored on-chain once and reused across transactions." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "optimizes" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#optimizes> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 87 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/87> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#optimizes> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
+	<http://purl.org/dc/terms/description> "Reference scripts reduce costs by allowing scripts to be stored on-chain once and reused across transactions." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts> <https://lambdasistemi.github.io/graph-browser/vocab/edges#optimizes> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/86> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The EUTxO model is what makes Plutus smart contracts possible — validators receive datum, redeemer, and context." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "enables" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#enables> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 86 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/86> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#enables> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
+	<http://purl.org/dc/terms/description> "The EUTxO model is what makes Plutus smart contracts possible — validators receive datum, redeemer, and context." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> <https://lambdasistemi.github.io/graph-browser/vocab/edges#enables> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/85> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The script context gives validators full visibility into the transaction being validated." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "provides" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#provides> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 85 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/85> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#provides> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> ;
+	<http://purl.org/dc/terms/description> "The script context gives validators full visibility into the transaction being validated." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context> <https://lambdasistemi.github.io/graph-browser/vocab/edges#provides> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/84> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Redeemers provide the action/input mechanism for EUTxO script validation." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "extends" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/redeemer> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 84 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/84> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/redeemer> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> ;
+	<http://purl.org/dc/terms/description> "Redeemers provide the action/input mechanism for EUTxO script validation." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/redeemer> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/83> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Datums are the key extension that transforms the UTxO model into EUTxO, enabling stateful contracts." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "extends" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 83 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/83> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> ;
+	<http://purl.org/dc/terms/description> "Datums are the key extension that transforms the UTxO model into EUTxO, enabling stateful contracts." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/82> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Cost model parameters are part of the technical parameter group." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "belongs to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#belongs%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 82 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/82> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#belongs%20to> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical> ;
+	<http://purl.org/dc/terms/description> "Cost model parameters are part of the technical parameter group." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> <https://lambdasistemi.github.io/graph-browser/vocab/edges#belongs%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/81> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "ExUnits are converted to ada fees using price parameters from the cost model." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "priced by" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#priced%20by> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 81 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/81> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#priced%20by> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> ;
+	<http://purl.org/dc/terms/description> "ExUnits are converted to ada fees using price parameters from the cost model." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> <https://lambdasistemi.github.io/graph-browser/vocab/edges#priced%20by> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/80> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The CEK machine tracks CPU steps and memory units during script evaluation, enforcing ExUnits budgets." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "consumes" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#consumes> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 80 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/80> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#consumes> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> ;
+	<http://purl.org/dc/terms/description> "The CEK machine tracks CPU steps and memory units during script evaluation, enforcing ExUnits budgets." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine> <https://lambdasistemi.github.io/graph-browser/vocab/edges#consumes> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/79> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Plutus Core programs are evaluated by the CEK machine, which tracks resource consumption." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "evaluated by" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluated%20by> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 79 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/79> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluated%20by> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine> ;
+	<http://purl.org/dc/terms/description> "Plutus Core programs are evaluated by the CEK machine, which tracks resource consumption." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> <https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluated%20by> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/78> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Plutus Tx (Haskell) compiles to Plutus Core, the on-chain language executed by the CEK machine." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "compiles to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 78 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/78> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
+	<http://purl.org/dc/terms/description> "Plutus Tx (Haskell) compiles to Plutus Core, the on-chain language executed by the CEK machine." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/77> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The Guardrails Script implements the per-parameter threshold exceptions on-chain. When a Protocol Parameter Change governance action is submitted, the script checks not just the permitted value ranges but also whether the correct voting bodies and thresholds apply for each specific parameter being changed." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "enforces" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#enforces> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 77 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/77> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#enforces> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions> ;
+	<http://purl.org/dc/terms/description> "The Guardrails Script implements the per-parameter threshold exceptions on-chain. When a Protocol Parameter Change governance action is submitted, the script checks not just the permitted value ranges but also whether the correct voting bodies and thresholds apply for each specific parameter being changed." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> <https://lambdasistemi.github.io/graph-browser/vocab/edges#enforces> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/76> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Per-parameter threshold exceptions change which bodies vote and at what thresholds for specific parameter changes. For example, committeeMaxTermLength only requires DRep 67% with no CC or SPO vote — a unique exception where the CC is excluded because the parameter directly governs CC member terms, and self-governance would be a conflict of interest." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "modifies voting for" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#modifies%20voting%20for> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 76 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/76> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#modifies%20voting%20for> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
+	<http://purl.org/dc/terms/description> "Per-parameter threshold exceptions change which bodies vote and at what thresholds for specific parameter changes. For example, committeeMaxTermLength only requires DRep 67% with no CC or SPO vote — a unique exception where the CC is excluded because the parameter directly governs CC member terms, and self-governance would be a conflict of interest." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions> <https://lambdasistemi.github.io/graph-browser/vocab/edges#modifies%20voting%20for> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/75> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Some parameters that belong to the Economic or Technical groups are constitutionally elevated to Governance group thresholds (DRep 75% + CC 2/3). This includes dRepDeposit, stakePoolDeposit, stakeAddressDeposit, minPoolCost, and committeeMinSize. The Constitution treats these as governance-critical despite their technical classification." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "overrides thresholds from" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#overrides%20thresholds%20from> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-governance> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 75 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/75> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#overrides%20thresholds%20from> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-governance> ;
+	<http://purl.org/dc/terms/description> "Some parameters that belong to the Economic or Technical groups are constitutionally elevated to Governance group thresholds (DRep 75% + CC 2/3). This includes dRepDeposit, stakePoolDeposit, stakeAddressDeposit, minPoolCost, and committeeMinSize. The Constitution treats these as governance-critical despite their technical classification." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions> <https://lambdasistemi.github.io/graph-browser/vocab/edges#overrides%20thresholds%20from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-governance> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/74> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Info Actions, despite having no direct on-chain effect, are the mechanism for the treasury budgeting process. Net Change Limits and Budget approvals are submitted as Info Actions with effective voting thresholds of DRep 50% + CC 2/3. This repurposes the Info Action type for binding community decisions that gate subsequent Treasury Withdrawals." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "used for" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#used%20for> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 74 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/74> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#used%20for> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting> ;
+	<http://purl.org/dc/terms/description> "Info Actions, despite having no direct on-chain effect, are the mechanism for the treasury budgeting process. Net Change Limits and Budget approvals are submitted as Info Actions with effective voting thresholds of DRep 50% + CC 2/3. This repurposes the Info Action type for binding community decisions that gate subsequent Treasury Withdrawals." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> <https://lambdasistemi.github.io/graph-browser/vocab/edges#used%20for> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/73> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Treasury Withdrawals can only be submitted after a Net Change Limit and Budget have been approved. The Net Change Limit (Info Action, DRep 50% + CC 2/3) sets the maximum withdrawal amount per period. Budget proposals (also Info Actions, DRep 50% + CC 2/3) allocate portions of that limit. Only then can Treasury Withdrawal governance actions be submitted against the approved budget." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "gates" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#gates> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 73 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/73> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#gates> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> ;
+	<http://purl.org/dc/terms/description> "Treasury Withdrawals can only be submitted after a Net Change Limit and Budget have been approved. The Net Change Limit (Info Action, DRep 50% + CC 2/3) sets the maximum withdrawal amount per period. Budget proposals (also Info Actions, DRep 50% + CC 2/3) allocate portions of that limit. Only then can Treasury Withdrawal governance actions be submitted against the approved budget." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting> <https://lambdasistemi.github.io/graph-browser/vocab/edges#gates> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/72> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Cost model updates go through Protocol Parameter Change governance: the Plutus team benchmarks builtins, fits cost functions via R scripts, and the new coefficients are submitted as a governance action requiring CC 2/3 and DRep 67% (Technical group threshold)." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "updated via" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#updated%20via> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 72 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/72> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#updated%20via> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
+	<http://purl.org/dc/terms/description> "Cost model updates go through Protocol Parameter Change governance: the Plutus team benchmarks builtins, fits cost functions via R scripts, and the new coefficients are submitted as a governance action requiring CC 2/3 and DRep 67% (Technical group threshold)." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> <https://lambdasistemi.github.io/graph-browser/vocab/edges#updated%20via> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/71> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "SanchoNet was a dedicated governance testnet (launched 2023) where the community tested CIP-1694 features before mainnet. It validated the Conway implementation and allowed governance tooling development against a live environment." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "tested" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#tested> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/conway-era> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/sanchonet> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 71 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/71> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/sanchonet> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#tested> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/conway-era> ;
+	<http://purl.org/dc/terms/description> "SanchoNet was a dedicated governance testnet (launched 2023) where the community tested CIP-1694 features before mainnet. It validated the Conway implementation and allowed governance tooling development against a live environment." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/sanchonet> <https://lambdasistemi.github.io/graph-browser/vocab/edges#tested> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/conway-era> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/70> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "GovTool provides a web interface for DRep registration and delegation, handling certificate submission and deposit payment without CLI tools." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "enables registration as" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#enables%20registration%20as> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 70 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/70> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#enables%20registration%20as> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
+	<http://purl.org/dc/terms/description> "GovTool provides a web interface for DRep registration and delegation, handling certificate submission and deposit payment without CLI tools." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> <https://lambdasistemi.github.io/graph-browser/vocab/edges#enables%20registration%20as> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/69> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "GovTool connects to wallets via CIP-95 and enables viewing governance actions, reading metadata, and casting votes on-chain. It makes governance accessible to non-technical participants." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "enables" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#enables> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 69 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/69> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#enables> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting> ;
+	<http://purl.org/dc/terms/description> "GovTool connects to wallets via CIP-95 and enables viewing governance actions, reading metadata, and casting votes on-chain. It makes governance accessible to non-technical participants." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> <https://lambdasistemi.github.io/graph-browser/vocab/edges#enables> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/68> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The CF evaluates governance actions for constitutional compliance and governance merit through its Governance Advisory Team. It publishes vote rationales and created the Proposal Examiner tool for structured evaluation." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "evaluates and votes on" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluates%20and%20votes%20on> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 68 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/68> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluates%20and%20votes%20on> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
+	<http://purl.org/dc/terms/description> "The CF evaluates governance actions for constitutional compliance and governance merit through its Governance Advisory Team. It publishes vote rationales and created the Proposal Examiner tool for structured evaluation." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation> <https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluates%20and%20votes%20on> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/67> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The CF registered as a DRep to actively participate in governance, bringing institutional expertise and a Governance Advisory Team. It publishes detailed vote rationales, setting a standard for transparent governance engagement." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "registered as" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#registered%20as> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 67 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/67> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#registered%20as> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
+	<http://purl.org/dc/terms/description> "The CF registered as a DRep to actively participate in governance, bringing institutional expertise and a Governance Advisory Team. It publishes detailed vote rationales, setting a standard for transparent governance engagement." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation> <https://lambdasistemi.github.io/graph-browser/vocab/edges#registered%20as> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/66> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Intersect provides off-chain governance infrastructure: Parameter Committee, CC elections, working groups, hard fork coordination, CIP process, and GovTool. It fills the coordination gap between decentralized on-chain governance and the practical need for organized deliberation." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "facilitates" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#facilitates> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/intersect> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 66 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/66> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/intersect> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#facilitates> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> ;
+	<http://purl.org/dc/terms/description> "Intersect provides off-chain governance infrastructure: Parameter Committee, CC elections, working groups, hard fork coordination, CIP process, and GovTool. It fills the coordination gap between decentralized on-chain governance and the practical need for organized deliberation." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/intersect> <https://lambdasistemi.github.io/graph-browser/vocab/edges#facilitates> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/65> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-105 specifies how wallets derive governance key pairs (for DRep registration and voting) from a master seed, ensuring keys are recoverable from a mnemonic phrase." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "derives keys for" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#derives%20keys%20for> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-105> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 65 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/65> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-105> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#derives%20keys%20for> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
+	<http://purl.org/dc/terms/description> "CIP-105 specifies how wallets derive governance key pairs (for DRep registration and voting) from a master seed, ensuring keys are recoverable from a mnemonic phrase." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-105> <https://lambdasistemi.github.io/graph-browser/vocab/edges#derives%20keys%20for> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/64> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-129 defines canonical governance action IDs used across wallets, explorers, and governance tools for consistent cross-tool reference." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "standardizes IDs for" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#standardizes%20IDs%20for> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-129> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 64 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/64> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-129> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#standardizes%20IDs%20for> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
+	<http://purl.org/dc/terms/description> "CIP-129 defines canonical governance action IDs used across wallets, explorers, and governance tools for consistent cross-tool reference." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-129> <https://lambdasistemi.github.io/graph-browser/vocab/edges#standardizes%20IDs%20for> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/63> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-129 defines canonical string representations for DRep IDs, ensuring all tools display the same identifier for the same representative." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "standardizes IDs for" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#standardizes%20IDs%20for> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-129> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 63 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/63> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-129> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#standardizes%20IDs%20for> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
+	<http://purl.org/dc/terms/description> "CIP-129 defines canonical string representations for DRep IDs, ensuring all tools display the same identifier for the same representative." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-129> <https://lambdasistemi.github.io/graph-browser/vocab/edges#standardizes%20IDs%20for> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/62> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CC members publish structured vote rationales using CIP-136 metadata. This format requires citing specific constitutional articles, creating a public record of constitutional interpretation that builds governance case law." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "publishes rationales via" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#publishes%20rationales%20via> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-136> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 62 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/62> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#publishes%20rationales%20via> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-136> ;
+	<http://purl.org/dc/terms/description> "CC members publish structured vote rationales using CIP-136 metadata. This format requires citing specific constitutional articles, creating a public record of constitutional interpretation that builds governance case law." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <https://lambdasistemi.github.io/graph-browser/vocab/edges#publishes%20rationales%20via> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-136> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/61> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "GovTool uses CIP-95 to connect to users' browser wallets. CIP-95 extends the CIP-30 wallet connector with governance capabilities: DRep registration, delegation, and voting transactions." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "connects wallets via" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#connects%20wallets%20via> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-95> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 61 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/61> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#connects%20wallets%20via> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-95> ;
+	<http://purl.org/dc/terms/description> "GovTool uses CIP-95 to connect to users' browser wallets. CIP-95 extends the CIP-30 wallet connector with governance capabilities: DRep registration, delegation, and voting transactions." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> <https://lambdasistemi.github.io/graph-browser/vocab/edges#connects%20wallets%20via> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-95> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/60> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-108 builds on CIP-100's base metadata format, adding governance-action-specific fields (title, abstract, motivation, rationale). CIP-100 defines the general anchor structure; CIP-108 defines what goes inside it for governance actions." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "extends" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-100> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-108> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 60 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/60> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-108> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-100> ;
+	<http://purl.org/dc/terms/description> "CIP-108 builds on CIP-100's base metadata format, adding governance-action-specific fields (title, abstract, motivation, rationale). CIP-100 defines the general anchor structure; CIP-108 defines what goes inside it for governance actions." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-108> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-100> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/59> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Governance action metadata is structured according to CIP-108, which defines required fields: title, abstract, motivation, rationale, and references. This ensures voters have consistent information when evaluating proposals." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "structured as" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#structured%20as> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-108> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 59 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/59> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#structured%20as> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-108> ;
+	<http://purl.org/dc/terms/description> "Governance action metadata is structured according to CIP-108, which defines required fields: title, abstract, motivation, rationale, and references. This ensures voters have consistent information when evaluating proposals." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> <https://lambdasistemi.github.io/graph-browser/vocab/edges#structured%20as> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-108> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/58> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Every governance action includes a metadata anchor (URL + hash) following CIP-100's general governance metadata format. The metadata is stored off-chain but its hash is recorded on-chain for integrity verification." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "metadata follows" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#metadata%20follows> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-100> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 58 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/58> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#metadata%20follows> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-100> ;
+	<http://purl.org/dc/terms/description> "Every governance action includes a metadata anchor (URL + hash) following CIP-100's general governance metadata format. The metadata is stored off-chain but its hash is recorded on-chain for integrity verification." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> <https://lambdasistemi.github.io/graph-browser/vocab/edges#metadata%20follows> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-100> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/57> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "DRep registration requires 500 ada (refundable on retirement). This prevents spam registrations while keeping registration accessible. The amount is a Governance group protocol parameter changeable with 75% DRep threshold." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "requires" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#requires> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/deposit-mechanism> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 57 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/57> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#requires> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/deposit-mechanism> ;
+	<http://purl.org/dc/terms/description> "DRep registration requires 500 ada (refundable on retirement). This prevents spam registrations while keeping registration accessible. The amount is a Governance group protocol parameter changeable with 75% DRep threshold." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> <https://lambdasistemi.github.io/graph-browser/vocab/edges#requires> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/deposit-mechanism> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/56> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Submitting a governance action requires 100,000 ada (refundable). This anti-spam mechanism prevents frivolous proposals from flooding the chain. The amount is a Governance group parameter, also classified as security-relevant (requires SPO approval to change)." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "requires" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#requires> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/deposit-mechanism> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 56 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/56> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#requires> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/deposit-mechanism> ;
+	<http://purl.org/dc/terms/description> "Submitting a governance action requires 100,000 ada (refundable). This anti-spam mechanism prevents frivolous proposals from flooding the chain. The amount is a Governance group parameter, also classified as security-relevant (requires SPO approval to change)." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> <https://lambdasistemi.github.io/graph-browser/vocab/edges#requires> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/deposit-mechanism> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/55> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CC uses one-member-one-vote with a configurable threshold (currently 2/3). Expired members cannot vote. Minimum committee size is 7 on mainnet. The threshold is changeable via the Update Committee governance action." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "subject to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#subject%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc-threshold> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 55 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/55> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#subject%20to> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc-threshold> ;
+	<http://purl.org/dc/terms/description> "CC uses one-member-one-vote with a configurable threshold (currently 2/3). Expired members cannot vote. Minimum committee size is 7 on mainnet. The threshold is changeable via the Update Committee governance action." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <https://lambdasistemi.github.io/graph-browser/vocab/edges#subject%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc-threshold> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/54> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "SPO votes are tallied at 51% of active pool stake for all applicable actions: No-Confidence (Q1), Committee Update (Q2a/Q2b), Hard Fork (Q4), security parameters (Q5), and Info (100% fixed)." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "subject to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#subject%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo-thresholds> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 54 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/54> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#subject%20to> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo-thresholds> ;
+	<http://purl.org/dc/terms/description> "SPO votes are tallied at 51% of active pool stake for all applicable actions: No-Confidence (Q1), Committee Update (Q2a/Q2b), Hard Fork (Q4), security parameters (Q5), and Info (100% fixed)." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> <https://lambdasistemi.github.io/graph-browser/vocab/edges#subject%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo-thresholds> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/53> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "DRep votes are tallied against action-type-specific thresholds of active voting stake: No-Confidence 67%, Committee Update 67%/60%, New Constitution 75%, Hard Fork 60%, Network/Economic/Technical params 67%, Governance params 75%, Treasury 67%, Info 100%." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "subject to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#subject%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep-thresholds> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 53 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/53> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#subject%20to> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep-thresholds> ;
+	<http://purl.org/dc/terms/description> "DRep votes are tallied against action-type-specific thresholds of active voting stake: No-Confidence 67%, Committee Update 67%/60%, New Constitution 75%, Hard Fork 60%, Network/Economic/Technical params 67%, Governance params 75%, Treasury 67%, Info 100%." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> <https://lambdasistemi.github.io/graph-browser/vocab/edges#subject%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep-thresholds> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/52> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Conway began with a bootstrap phase where only CC could approve parameter changes and CC + SPOs could approve hard forks. DRep participation was not required. This phased rollout prevented governance deadlocks while DRep registration ramped up. Ended with the Plomin hard fork in December 2024." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "started with" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#started%20with> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/bootstrap-phase> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/conway-era> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 52 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/52> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/conway-era> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#started%20with> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/bootstrap-phase> ;
+	<http://purl.org/dc/terms/description> "Conway began with a bootstrap phase where only CC could approve parameter changes and CC + SPOs could approve hard forks. DRep participation was not required. This phased rollout prevented governance deadlocks while DRep registration ramped up. Ended with the Plomin hard fork in December 2024." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/conway-era> <https://lambdasistemi.github.io/graph-browser/vocab/edges#started%20with> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/bootstrap-phase> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/51> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-1694 was implemented in the Conway ledger era via two phases: Chang #1 (August 2024, bootstrap) and Plomin hard fork (December 2024, full activation). Conway is the current ledger era, representing the Voltaire phase of Cardano's roadmap." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "implemented in" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#implemented%20in> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/conway-era> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-1694> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 51 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/51> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-1694> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#implemented%20in> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/conway-era> ;
+	<http://purl.org/dc/terms/description> "CIP-1694 was implemented in the Conway ledger era via two phases: Chang #1 (August 2024, bootstrap) and Plomin hard fork (December 2024, full activation). Conway is the current ledger era, representing the Voltaire phase of Cardano's roadmap." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-1694> <https://lambdasistemi.github.io/graph-browser/vocab/edges#implemented%20in> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/conway-era> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/50> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-1694 formally specifies the entire on-chain governance mechanism: three bodies, seven action types, voting/ratification rules, CC structure, DRep mechanics, deposits, action chaining, and the full governance lifecycle. It is the authoritative technical specification." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "specifies" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#specifies> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-1694> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 50 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/50> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-1694> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#specifies> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> ;
+	<http://purl.org/dc/terms/description> "CIP-1694 formally specifies the entire on-chain governance mechanism: three bodies, seven action types, voting/ratification rules, CC structure, DRep mechanics, deposits, action chaining, and the full governance lifecycle. It is the authoritative technical specification." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-1694> <https://lambdasistemi.github.io/graph-browser/vocab/edges#specifies> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/49> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The CC forms the third governance body with one-member-one-vote (not stake-weighted). Its role is purely constitutional review. It votes on actions that change protocol rules but not on actions about its own composition, preventing self-dealing." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "governance body" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 49 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/49> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
+	<http://purl.org/dc/terms/description> "The CC forms the third governance body with one-member-one-vote (not stake-weighted). Its role is purely constitutional review. It votes on actions that change protocol rules but not on actions about its own composition, preventing self-dealing." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/48> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "SPOs form the second governance body, representing the infrastructure layer. They vote on a limited subset: Hard Forks, No-Confidence, Committee Updates, security parameters, and Info. This focused scope ensures operators have voice on matters affecting their operations." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "governance body" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 48 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/48> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> ;
+	<http://purl.org/dc/terms/description> "SPOs form the second governance body, representing the infrastructure layer. They vote on a limited subset: Hard Forks, No-Confidence, Committee Updates, security parameters, and Info. This focused scope ensures operators have voice on matters affecting their operations." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/47> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "DReps form the first of three governance bodies, representing all ada holders who delegate to them. They vote on all seven action types with stake-weighted voting, providing the democratic legitimacy layer of governance." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "governance body" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 47 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/47> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
+	<http://purl.org/dc/terms/description> "DReps form the first of three governance bodies, representing all ada holders who delegate to them. They vote on all seven action types with stake-weighted voting, providing the democratic legitimacy layer of governance." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/46> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Cardano's governance combines direct and representative democracy. Ada holders can vote directly (as DReps) or delegate. Delegation is fluid — changeable at any time with immediate effect. This ensures all stake can participate without requiring every holder to be actively engaged." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "implements" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#implements> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liquid-democracy> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 46 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/46> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#implements> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liquid-democracy> ;
+	<http://purl.org/dc/terms/description> "Cardano's governance combines direct and representative democracy. Ada holders can vote directly (as DReps) or delegate. Delegation is fluid — changeable at any time with immediate effect. This ensures all stake can participate without requiring every holder to be actively engaged." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> <https://lambdasistemi.github.io/graph-browser/vocab/edges#implements> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liquid-democracy> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/45> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The sole mechanism for modifying CC membership, terms, and approval threshold. Can add new members with term expirations, remove members, and adjust the approval fraction. Used both for routine updates and to replace a committee in no-confidence state." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "changes membership of" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#changes%20membership%20of> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-update-committee> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 45 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/45> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-update-committee> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#changes%20membership%20of> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
+	<http://purl.org/dc/terms/description> "The sole mechanism for modifying CC membership, terms, and approval threshold. Can add new members with term expirations, remove members, and adjust the approval fraction. Used both for routine updates and to replace a committee in no-confidence state." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-update-committee> <https://lambdasistemi.github.io/graph-browser/vocab/edges#changes%20membership%20of> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/44> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "When ratified, the CC enters no-confidence state and cannot approve any governance actions. This blocks all action types requiring CC approval. Recovery requires electing a new committee via Update Committee, which has a lower DRep threshold (60% vs 67%) in no-confidence state." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "puts into no-confidence state" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#puts%20into%20no-confidence%20state> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-no-confidence> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 44 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/44> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-no-confidence> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#puts%20into%20no-confidence%20state> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
+	<http://purl.org/dc/terms/description> "When ratified, the CC enters no-confidence state and cannot approve any governance actions. This blocks all action types requiring CC approval. Recovery requires electing a new committee via Update Committee, which has a lower DRep threshold (60% vs 67%) in no-confidence state." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-no-confidence> <https://lambdasistemi.github.io/graph-browser/vocab/edges#puts%20into%20no-confidence%20state> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/43> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Can optionally include a new Guardrails Script hash. This is the only mechanism for updating the enforcement script, ensuring it stays synchronized with constitutional amendments." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "can update" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20update> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 43 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/43> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20update> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> ;
+	<http://purl.org/dc/terms/description> "Can optionally include a new Guardrails Script hash. This is the only mechanism for updating the enforcement script, ensuring it stays synchronized with constitutional amendments." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20update> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/42> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The only mechanism for amending the Cardano Constitution. The action includes an anchor to the new text. Requires DRep 75% and CC 2/3 majority. The current Constitution was ratified at the Buenos Aires Constitutional Convention in December 2024." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "modifies" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#modifies> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 42 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/42> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#modifies> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution> ;
+	<http://purl.org/dc/terms/description> "The only mechanism for amending the Cardano Constitution. The action includes an anchor to the new text. Requires DRep 75% and CC 2/3 majority. The current Constitution was ratified at the Buenos Aires Constitutional Convention in December 2024." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> <https://lambdasistemi.github.io/graph-browser/vocab/edges#modifies> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/41> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The Constitution's enforceable rules — particularly Appendix I's parameter ranges and treasury limits — are codified in the on-chain Guardrails Script. The Constitution provides the authoritative rules; the script automates enforcement of the programmatically expressible subset." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "codified in" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#codified%20in> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 41 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/41> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#codified%20in> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> ;
+	<http://purl.org/dc/terms/description> "The Constitution's enforceable rules — particularly Appendix I's parameter ranges and treasury limits — are codified in the on-chain Guardrails Script. The Constitution provides the authoritative rules; the script automates enforcement of the programmatically expressible subset." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution> <https://lambdasistemi.github.io/graph-browser/vocab/edges#codified%20in> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/40> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The Guardrails Script enforces treasury withdrawal limits (TREASURY-01a through TREASURY-04a). This automated enforcement ensures treasury funds cannot be drained beyond constitutional bounds even if sufficient votes are gathered." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "constrains" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#constrains> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 40 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/40> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#constrains> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> ;
+	<http://purl.org/dc/terms/description> "The Guardrails Script enforces treasury withdrawal limits (TREASURY-01a through TREASURY-04a). This automated enforcement ensures treasury funds cannot be drained beyond constitutional bounds even if sufficient votes are gathered." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> <https://lambdasistemi.github.io/graph-browser/vocab/edges#constrains> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/39> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The Guardrails Script checks that proposed parameter values fall within permitted ranges from the Constitution's Appendix I. Named guardrails PARAM-01 through PARAM-06a define rules. The script rejects non-compliant transactions before they reach voting." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "constrains" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#constrains> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 39 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/39> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#constrains> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
+	<http://purl.org/dc/terms/description> "The Guardrails Script checks that proposed parameter values fall within permitted ranges from the Constitution's Appendix I. Named guardrails PARAM-01 through PARAM-06a define rules. The script rejects non-compliant transactions before they reach voting." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> <https://lambdasistemi.github.io/graph-browser/vocab/edges#constrains> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/38> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "govActionDeposit is the only Governance group security-relevant parameter. Currently 100,000 ada, it prevents spam governance actions. SPO approval at Q5 = 51% is required to change it." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "some params are" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#some%20params%20are> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-governance> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 38 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/38> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-governance> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#some%20params%20are> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> ;
+	<http://purl.org/dc/terms/description> "govActionDeposit is the only Governance group security-relevant parameter. Currently 100,000 ada, it prevents spam governance actions. SPO approval at Q5 = 51% is required to change it." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-governance> <https://lambdasistemi.github.io/graph-browser/vocab/edges#some%20params%20are> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/37> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Economic security-relevant parameters: txFeePerByte, txFeeFixed, utxoCostPerByte, minFeeRefScriptCostPerByte. Setting these too low enables denial-of-service via cheap spam transactions. SPO approval at Q5 = 51% is required." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "some params are" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#some%20params%20are> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-economic> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 37 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/37> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-economic> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#some%20params%20are> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> ;
+	<http://purl.org/dc/terms/description> "Economic security-relevant parameters: txFeePerByte, txFeeFixed, utxoCostPerByte, minFeeRefScriptCostPerByte. Setting these too low enables denial-of-service via cheap spam transactions. SPO approval at Q5 = 51% is required." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-economic> <https://lambdasistemi.github.io/graph-browser/vocab/edges#some%20params%20are> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/36> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Network security-relevant parameters: maxBlockBodySize, maxTxSize, maxBlockHeaderSize, maxValueSize, maxBlockExecutionUnits. Changes to these additionally require SPO approval at Q5 = 51%, giving infrastructure operators a veto." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "some params are" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#some%20params%20are> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-network> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 36 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/36> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-network> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#some%20params%20are> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> ;
+	<http://purl.org/dc/terms/description> "Network security-relevant parameters: maxBlockBodySize, maxTxSize, maxBlockHeaderSize, maxValueSize, maxBlockExecutionUnits. Changes to these additionally require SPO approval at Q5 = 51%, giving infrastructure operators a veto." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-network> <https://lambdasistemi.github.io/graph-browser/vocab/edges#some%20params%20are> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/35> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Plutus cost models assign abstract CPU and memory costs to each builtin function, calibrated by benchmarking on a reference machine. These are consensus-critical — every node must compute identical ExUnits. Updates go through the Technical group governance threshold." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "contains" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#contains> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 35 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/35> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#contains> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> ;
+	<http://purl.org/dc/terms/description> "Plutus cost models assign abstract CPU and memory costs to each builtin function, calibrated by benchmarking on a reference machine. These are consensus-critical — every node must compute identical ExUnits. Updates go through the Technical group governance threshold." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical> <https://lambdasistemi.github.io/graph-browser/vocab/edges#contains> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/34> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Governance group includes all 15 voting thresholds, govActionLifetime, govActionDeposit, dRepDeposit, dRepActivity, committeeMinSize, and committeeMaxTermLength. Changes require the highest DRep threshold at 75% plus CC 2/3, reflecting the self-referential nature of changing governance rules." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "can change" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-governance> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 34 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/34> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-governance> ;
+	<http://purl.org/dc/terms/description> "Governance group includes all 15 voting thresholds, govActionLifetime, govActionDeposit, dRepDeposit, dRepActivity, committeeMinSize, and committeeMaxTermLength. Changes require the highest DRep threshold at 75% plus CC 2/3, reflecting the self-referential nature of changing governance rules." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-governance> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/33> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Technical group includes poolPledgeInfluence, poolRetireMaxEpoch, stakePoolTargetNum, costModels, and collateralPercentage. The costModels parameter determines Plutus builtin pricing. Changes require CC 2/3 and DRep 67%." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "can change" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 33 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/33> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical> ;
+	<http://purl.org/dc/terms/description> "Technical group includes poolPledgeInfluence, poolRetireMaxEpoch, stakePoolTargetNum, costModels, and collateralPercentage. The costModels parameter determines Plutus builtin pricing. Changes require CC 2/3 and DRep 67%." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/32> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Economic group includes txFeePerByte, txFeeFixed, stakeAddressDeposit, stakePoolDeposit, monetaryExpansion, treasuryCut, minPoolCost, utxoCostPerByte, executionUnitPrices, and minFeeRefScriptCostPerByte. Changes require CC 2/3 and DRep 67%." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "can change" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-economic> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 32 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/32> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-economic> ;
+	<http://purl.org/dc/terms/description> "Economic group includes txFeePerByte, txFeeFixed, stakeAddressDeposit, stakePoolDeposit, monetaryExpansion, treasuryCut, minPoolCost, utxoCostPerByte, executionUnitPrices, and minFeeRefScriptCostPerByte. Changes require CC 2/3 and DRep 67%." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-economic> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/31> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Network group includes maxBlockBodySize, maxTxSize, maxBlockHeaderSize, maxValueSize, maxTxExecutionUnits, maxBlockExecutionUnits, and maxCollateralInputs. Changes require CC 2/3 and DRep 67%. Several are security-relevant, additionally requiring SPO 51%." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "can change" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-network> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 31 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/31> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-network> ;
+	<http://purl.org/dc/terms/description> "Network group includes maxBlockBodySize, maxTxSize, maxBlockHeaderSize, maxValueSize, maxTxExecutionUnits, maxBlockExecutionUnits, and maxCollateralInputs. Changes require CC 2/3 and DRep 67%. Several are security-relevant, additionally requiring SPO 51%." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-network> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/30> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Info Action has no on-chain effect and uses a fixed 100% threshold. It records community sentiment and polls stakeholders before committing to binding actions. Does not require action chaining." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "is a type of" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 30 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/30> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
+	<http://purl.org/dc/terms/description> "Info Action has no on-chain effect and uses a fixed 100% threshold. It records community sentiment and polls stakeholders before committing to binding actions. Does not require action chaining." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/29> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Treasury Withdrawal disburses ada from the treasury. Requires CC 2/3 and DRep 67%. Does not require action chaining, allowing multiple independent withdrawals to proceed concurrently." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "is a type of" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 29 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/29> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
+	<http://purl.org/dc/terms/description> "Treasury Withdrawal disburses ada from the treasury. Requires CC 2/3 and DRep 67%. Does not require action chaining, allowing multiple independent withdrawals to proceed concurrently." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/28> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Protocol Parameter Changes modify one or more of ~30 updatable parameters in four groups (Network, Economic, Technical, Governance). Each group has its own DRep threshold. Security-relevant parameters additionally require SPO approval." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "is a type of" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 28 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
+	<http://purl.org/dc/terms/description> "Protocol Parameter Changes modify one or more of ~30 updatable parameters in four groups (Network, Economic, Technical, Governance). Each group has its own DRep threshold. Security-relevant parameters additionally require SPO approval." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/27> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Hard Fork Initiation is the only action requiring all three bodies: CC 2/3, DReps 60%, SPOs 51%. It specifies a new major protocol version. A ratified hard fork delays all other pending ratifications." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "is a type of" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 27 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/27> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
+	<http://purl.org/dc/terms/description> "Hard Fork Initiation is the only action requiring all three bodies: CC 2/3, DReps 60%, SPOs 51%. It specifies a new major protocol version. A ratified hard fork delays all other pending ratifications." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/26> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "New Constitution / Guardrails Script requires the highest DRep threshold at 75% plus CC 2/3 majority. SPOs do not vote. It can update both the Constitution text and the automated enforcement script." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "is a type of" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 26 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/26> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
+	<http://purl.org/dc/terms/description> "New Constitution / Guardrails Script requires the highest DRep threshold at 75% plus CC 2/3 majority. SPOs do not vote. It can update both the Constitution text and the automated enforcement script." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/25> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Update Committee can add/remove CC members, set term expirations, and adjust the CC threshold. The CC does not vote. Thresholds differ by CC state: normal DRep 67% + SPO 51%; no-confidence DRep 60% + SPO 51%." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "is a type of" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-update-committee> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 25 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/25> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-update-committee> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
+	<http://purl.org/dc/terms/description> "Update Committee can add/remove CC members, set term expirations, and adjust the CC threshold. The CC does not vote. Thresholds differ by CC state: normal DRep 67% + SPO 51%; no-confidence DRep 60% + SPO 51%." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-update-committee> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/24> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Motion of No-Confidence is the highest-priority action type. It requires DRep 67% and SPO 51%. The CC does not vote. When ratified, it blocks the CC from participating until a new committee is elected." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "is a type of" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-no-confidence> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 24 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/24> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-no-confidence> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
+	<http://purl.org/dc/terms/description> "Motion of No-Confidence is the highest-priority action type. It requires DRep 67% and SPO 51%. The CC does not vote. When ratified, it blocks the CC from participating until a new committee is elected." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-no-confidence> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/23> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Most action types (except Treasury and Info) must reference the most recently enacted action of the same type. This prevents conflicting same-type actions from both ratifying when they assume incompatible starting states." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "uses" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-chaining> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 23 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/23> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-chaining> ;
+	<http://purl.org/dc/terms/description> "Most action types (except Treasury and Info) must reference the most recently enacted action of the same type. This prevents conflicting same-type actions from both ratifying when they assume incompatible starting states." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-chaining> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/22> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Accumulated votes determine whether an action meets its thresholds. At each epoch boundary, a fresh tally is calculated using the current stake snapshot. An action is ratified when all required thresholds are simultaneously met." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "determines" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#determines> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ratification> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 22 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/22> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#determines> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ratification> ;
+	<http://purl.org/dc/terms/description> "Accumulated votes determine whether an action meets its thresholds. At each epoch boundary, a fresh tally is calculated using the current stake snapshot. An action is ratified when all required thresholds are simultaneously met." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting> <https://lambdasistemi.github.io/graph-browser/vocab/edges#determines> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ratification> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/21> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Once submitted, a governance action is immediately available for voting. DRep and SPO votes are stake-weighted; CC votes are one-member-one-vote. Votes can be changed at any time before ratification. Registered stake that did not vote counts as 'No'." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "open for" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#open%20for> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 21 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/21> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#open%20for> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting> ;
+	<http://purl.org/dc/terms/description> "Once submitted, a governance action is immediately available for voting. DRep and SPO votes are stake-weighted; CC votes are one-member-one-vote. Votes can be changed at any time before ratification. Registered stake that did not vote counts as 'No'." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> <https://lambdasistemi.github.io/graph-browser/vocab/edges#open%20for> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/20> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Ratified actions are enacted at the next epoch boundary. There is always at least a one-epoch gap. If a high-priority action (No-Confidence, Committee Update, New Constitution, or Hard Fork) is ratified, it delays ratification of all other pending actions until after its enactment." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "leads to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#leads%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/enactment> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ratification> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 20 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/20> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ratification> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#leads%20to> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/enactment> ;
+	<http://purl.org/dc/terms/description> "Ratified actions are enacted at the next epoch boundary. There is always at least a one-epoch gap. If a high-priority action (No-Confidence, Committee Update, New Constitution, or Hard Fork) is ratified, it delays ratification of all other pending actions until after its enactment." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ratification> <https://lambdasistemi.github.io/graph-browser/vocab/edges#leads%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/enactment> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/19> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Every governance action enters ratification for up to govActionLifetime epochs (currently 6 / ~30 days). Ratification is checked only at epoch boundaries. An action can become ratified without new votes if delegation changes shift the stake distribution." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "undergoes" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#undergoes> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ratification> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 19 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/19> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#undergoes> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ratification> ;
+	<http://purl.org/dc/terms/description> "Every governance action enters ratification for up to govActionLifetime epochs (currently 6 / ~30 days). Ratification is checked only at epoch boundaries. An action can become ratified without new votes if delegation changes shift the stake distribution." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> <https://lambdasistemi.github.io/graph-browser/vocab/edges#undergoes> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ratification> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/18> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CC members use a hot/cold key credential system. The cold key is the member's identity, kept offline. The hot key is used for day-to-day voting. If compromised, the hot key can be rotated without changing the member's identity or requiring a Committee Update governance action." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "uses" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hot-cold-keys> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 18 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hot-cold-keys> ;
+	<http://purl.org/dc/terms/description> "CC members use a hot/cold key credential system. The cold key is the member's identity, kept offline. The hot key is used for day-to-day voting. If compromised, the hot key can be rotated without changing the member's identity or requiring a Committee Update governance action." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hot-cold-keys> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/17> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The CC's sole mandate is constitutional review — it evaluates whether governance actions comply with the Cardano Constitution. The CC does NOT assess merit or desirability; it only checks constitutionality. CC members cite specific articles when publishing vote rationales via CIP-136." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "evaluates actions against" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluates%20actions%20against> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 17 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/17> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluates%20actions%20against> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution> ;
+	<http://purl.org/dc/terms/description> "The CC's sole mandate is constitutional review — it evaluates whether governance actions comply with the Cardano Constitution. The CC does NOT assess merit or desirability; it only checks constitutionality. CC members cite specific articles when publishing vote rationales via CIP-136." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluates%20actions%20against> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/16> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The CC can vote on Info actions to signal its position. CC members may use CIP-136 metadata to cite specific constitutional articles in their vote rationale, providing constitutional analysis even on non-binding proposals." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "votes on" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 16 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/16> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> ;
+	<http://purl.org/dc/terms/description> "The CC can vote on Info actions to signal its position. CC members may use CIP-136 metadata to cite specific constitutional articles in their vote rationale, providing constitutional analysis even on non-binding proposals." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/15> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The CC reviews treasury withdrawals for constitutional compliance, including requirements that withdrawals specify purpose, expected costs, and provide for auditable accounts. CC approval at 2/3 is required alongside DRep approval at 67%." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "votes on" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 15 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/15> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> ;
+	<http://purl.org/dc/terms/description> "The CC reviews treasury withdrawals for constitutional compliance, including requirements that withdrawals specify purpose, expected costs, and provide for auditable accounts. CC approval at 2/3 is required alongside DRep approval at 67%." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/14> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The CC reviews parameter changes for constitutional compliance, particularly against Appendix I which defines permitted parameter ranges. CC approval at 2/3 majority is required for all parameter groups." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "votes on" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 14 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/14> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
+	<http://purl.org/dc/terms/description> "The CC reviews parameter changes for constitutional compliance, particularly against Appendix I which defines permitted parameter ranges. CC approval at 2/3 majority is required for all parameter groups." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/13> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The CC reviews hard fork proposals for constitutional compliance — whether the upgrade respects tenets on transaction freedom, predictable costs, and backward compatibility. CC approval at 2/3 is required alongside DRep and SPO approval." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "votes on" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 13 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/13> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork> ;
+	<http://purl.org/dc/terms/description> "The CC reviews hard fork proposals for constitutional compliance — whether the upgrade respects tenets on transaction freedom, predictable costs, and backward compatibility. CC approval at 2/3 is required alongside DRep and SPO approval." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/12> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The CC must approve constitutional amendments because its mandate is ensuring governance actions comply with the Constitution. CC approval at 2/3 majority is required alongside the highest DRep threshold (75%)." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "votes on" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 12 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/12> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> ;
+	<http://purl.org/dc/terms/description> "The CC must approve constitutional amendments because its mandate is ensuring governance actions comply with the Constitution. CC approval at 2/3 majority is required alongside the highest DRep threshold (75%)." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/11> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "SPOs can vote on Info actions to signal their position on community proposals. Since Info actions have no on-chain effect and use a fixed 100% threshold, SPO votes serve purely as a gauge of infrastructure operator sentiment." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "votes on" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 11 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/11> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> ;
+	<http://purl.org/dc/terms/description> "SPOs can vote on Info actions to signal their position on community proposals. Since Info actions have no on-chain effect and use a fixed 100% threshold, SPO votes serve purely as a gauge of infrastructure operator sentiment." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/10> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Security-relevant parameters (maxBlockBodySize, maxTxSize, txFeePerByte, etc.) directly affect node resource requirements. SPO approval at Q5 = 51% gives infrastructure operators a veto over modifications that could make block production uneconomical or destabilize the network." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "votes on changes to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on%20changes%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 10 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/10> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on%20changes%20to> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> ;
+	<http://purl.org/dc/terms/description> "Security-relevant parameters (maxBlockBodySize, maxTxSize, txFeePerByte, etc.) directly affect node resource requirements. SPO approval at Q5 = 51% gives infrastructure operators a veto over modifications that could make block production uneconomical or destabilize the network." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on%20changes%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/9> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Hard Fork Initiation requires approval from all three bodies. SPOs must approve at Q4 = 51% because they must actually upgrade their node software. Guardrail HARDFORK-04a requires at least 85% of stake pools to have upgraded before enactment." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "votes on" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 9 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork> ;
+	<http://purl.org/dc/terms/description> "Hard Fork Initiation requires approval from all three bodies. SPOs must approve at Q4 = 51% because they must actually upgrade their node software. Guardrail HARDFORK-04a requires at least 85% of stake pools to have upgraded before enactment." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/8> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "SPOs vote on Committee Updates because the CC's role in ratifying hard forks and security parameter changes directly affects node operators. SPO approval at Q2a/Q2b = 51% is required." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "votes on" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-update-committee> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 8 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/8> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-update-committee> ;
+	<http://purl.org/dc/terms/description> "SPOs vote on Committee Updates because the CC's role in ratifying hard forks and security parameter changes directly affects node operators. SPO approval at Q2a/Q2b = 51% is required." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-update-committee> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/7> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "SPOs vote on Motions of No-Confidence because a dysfunctional CC could block critical protocol upgrades. SPO approval at Q1 = 51% is required alongside DRep approval at 67%." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "votes on" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-no-confidence> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 7 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-no-confidence> ;
+	<http://purl.org/dc/terms/description> "SPOs vote on Motions of No-Confidence because a dysfunctional CC could block critical protocol upgrades. SPO approval at Q1 = 51% is required alongside DRep approval at 67%." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-no-confidence> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/6> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "DReps vote Yes, No, or Abstain on all seven types of governance actions. Their vote weight equals the total lovelace delegated to them. DReps must vote regularly or become inactive after the dRepActivity period (currently 20 epochs / 100 days)." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "votes on" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 6 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
+	<http://purl.org/dc/terms/description> "DReps vote Yes, No, or Abstain on all seven types of governance actions. Their vote weight equals the total lovelace delegated to them. DReps must vote regularly or become inactive after the dRepActivity period (currently 20 epochs / 100 days)." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/5> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Any ada holder can register as a DRep by paying a refundable dRepDeposit (currently 500 ada). Self-delegation means the holder votes with their own stake weight. This is the 'direct democracy' path in Cardano's liquid democracy model." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "can register as" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20register%20as> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 5 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20register%20as> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
+	<http://purl.org/dc/terms/description> "Any ada holder can register as a DRep by paying a refundable dRepDeposit (currently 500 ada). Self-delegation means the holder votes with their own stake weight. This is the 'direct democracy' path in Cardano's liquid democracy model." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20register%20as> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/4> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Any ada holder can submit a governance action on-chain by paying the govActionDeposit (currently 100,000 ada, refundable). The submitter must include a metadata anchor following CIP-100/CIP-108 standards and, for most action types, a reference to the most recently enacted action of the same type." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "submits" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#submits> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 4 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#submits> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
+	<http://purl.org/dc/terms/description> "Any ada holder can submit a governance action on-chain by paying the govActionDeposit (currently 100,000 ada, refundable). The submitter must include a metadata anchor following CIP-100/CIP-108 standards and, for most action types, a reference to the most recently enacted action of the same type." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> <https://lambdasistemi.github.io/graph-browser/vocab/edges#submits> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/3> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Ada holders delegate stake to stake pools for block production via Ouroboros Praos. This is separate from DRep delegation — ada holders independently choose who produces blocks and who votes on governance. The pool's total stake also determines the SPO's governance voting weight." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "delegates stake to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#delegates%20stake%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 3 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#delegates%20stake%20to> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> ;
+	<http://purl.org/dc/terms/description> "Ada holders delegate stake to stake pools for block production via Ouroboros Praos. This is separate from DRep delegation — ada holders independently choose who produces blocks and who votes on governance. The pool's total stake also determines the SPO's governance voting weight." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> <https://lambdasistemi.github.io/graph-browser/vocab/edges#delegates%20stake%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Ada holders who distrust the current governance state can delegate to No Confidence. This stake IS counted in the active voting stake and automatically votes 'Yes' on every Motion of No-Confidence and 'No' on all other governance actions." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "can delegate to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20delegate%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/no-confidence-option> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 2 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20delegate%20to> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/no-confidence-option> ;
+	<http://purl.org/dc/terms/description> "Ada holders who distrust the current governance state can delegate to No Confidence. This stake IS counted in the active voting stake and automatically votes 'Yes' on every Motion of No-Confidence and 'No' on all other governance actions." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20delegate%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/no-confidence-option> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Ada holders who do not wish to participate in governance can delegate to the pre-defined Abstain option. Stake delegated to Abstain is excluded from the active voting stake denominator, meaning it neither helps nor blocks ratification of any governance action." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "can delegate to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20delegate%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/abstain-option> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 1 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20delegate%20to> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/abstain-option> ;
+	<http://purl.org/dc/terms/description> "Ada holders who do not wish to participate in governance can delegate to the pre-defined Abstain option. Stake delegated to Abstain is excluded from the active voting stake denominator, meaning it neither helps nor blocks ratification of any governance action." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20delegate%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/abstain-option> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Under CIP-1694's liquid democracy model, ada holders delegate their voting power to any registered DRep. The delegated stake counts toward the DRep's vote weight on governance actions. Unlike stake pool delegation, DRep delegation takes effect immediately with no two-epoch lag and can be changed at any time." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "delegates voting power to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#delegates%20voting%20power%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 0 ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#delegates%20voting%20power%20to> ;
+	<http://www.w3.org/1999/02/22-rdf-syntax-ns#object> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
+	<http://purl.org/dc/terms/description> "Under CIP-1694's liquid democracy model, ada holders delegate their voting power to any registered DRep. The delegated stake counts toward the DRep's vote weight on governance actions. Unlike stake pool delegation, DRep delegation takes effect immediately with no two-epoch lag and can be changed at any time." .
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> <https://lambdasistemi.github.io/graph-browser/vocab/edges#delegates%20voting%20power%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://gov.tools"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GovTool" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.cardano.org/about-cardano/governance-overview"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Voting (docs.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Each governance body votes Yes, No, or Abstain on applicable governance actions. Votes are recorded on-chain via transactions. DRep and SPO votes are weighted by delegated stake; CC votes are one-member-one-vote. Votes can be changed at any time before the action is ratified. The voting period lasts up to govActionLifetime epochs (currently 6 epochs / ~30 days). Abstain votes are NOT counted in the active voting stake denominator. Post-bootstrap: ada holders must delegate to a DRep (or Abstain/No Confidence) to withdraw staking rewards." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting> <http://xmlns.com/foaf/0.1/page> <https://gov.tools> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://docs.cardano.org/about-cardano/governance-overview> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting> <http://purl.org/dc/terms/description> "Each governance body votes Yes, No, or Abstain on applicable governance actions. Votes are recorded on-chain via transactions. DRep and SPO votes are weighted by delegated stake; CC votes are one-member-one-vote. Votes can be changed at any time before the action is ratified. The voting period lasts up to govActionLifetime epochs (currently 6 epochs / ~30 days). Abstain votes are NOT counted in the active voting stake denominator. Post-bootstrap: ada holders must delegate to a DRep (or Abstain/No Confidence) to withdraw staking rewards." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#lifecycle> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Voting" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "voting" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#process> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/cardano-foundation/cardano-org/tree/main/src/data"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CF Chart Data (source)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cardano.org/insights/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Action Charts" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Treasury withdrawals follow a multi-step budgeting process defined by the Cardano Constitution. First, a Net Change Limit must be approved via an Info Action (DRep 50% + CC 2/3) to set the maximum amount that can be withdrawn in a period. Then, individual Budget proposals are approved (also Info Actions with DRep 50% + CC 2/3). Only after both are in place can Treasury Withdrawal governance actions be submitted against the approved budget. This layered process prevents unchecked treasury spending." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting> <http://xmlns.com/foaf/0.1/page> <https://github.com/cardano-foundation/cardano-org/tree/main/src/data> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://cardano.org/insights/governance-actions/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting> <http://purl.org/dc/terms/description> "Treasury withdrawals follow a multi-step budgeting process defined by the Cardano Constitution. First, a Net Change Limit must be approved via an Info Action (DRep 50% + CC 2/3) to set the maximum amount that can be withdrawn in a period. Then, individual Budget proposals are approved (also Info Actions with DRep 50% + CC 2/3). Only after both are in place can Treasury Withdrawal governance actions be submitted against the approved budget. This layered process prevents unchecked treasury spending." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#lifecycle> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Treasury Budgeting Process" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "treasury-budgeting" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#process> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/input-output-hk/plutus-pioneer-program"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Plutus Pioneer: State Machines" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://scalus.org/docs/design-patterns"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Scalus: State Machines" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/Anastasia-Labs/design-patterns"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Design Patterns" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Model contract state as a datum on a UTxO. The validator checks that input datum + redeemer produces a valid output datum, enforcing legal state transitions. Used for multi-step protocols: escrow, auctions, governance, DEX order matching." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine> <http://xmlns.com/foaf/0.1/page> <https://github.com/input-output-hk/plutus-pioneer-program> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://scalus.org/docs/design-patterns> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://github.com/Anastasia-Labs/design-patterns> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine> <http://purl.org/dc/terms/description> "Model contract state as a datum on a UTxO. The validator checks that input datum + redeemer produces a valid output datum, enforcing legal state transitions. Used for multi-step protocols: escrow, auctions, governance, DEX order matching." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "State Machine Pattern" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "state-machine" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/staking-validator> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/staking-validator/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/staking-validator/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://anastasia-labs.com/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Anastasia Labs" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/staking-validator> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/staking-validator/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/staking-validator/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/Anastasia-Labs/design-patterns"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Withdraw Zero Pattern" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/staking-validator> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Validators attached to staking credentials. The \"withdraw zero\" pattern delegates expensive validation logic to a staking validator (called once per transaction) instead of a spending validator (called per input), reducing cost from O(n²) to O(n). Key optimization pattern." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/staking-validator> <http://xmlns.com/foaf/0.1/page> <https://anastasia-labs.com/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/staking-validator> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://github.com/Anastasia-Labs/design-patterns> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/staking-validator> <http://purl.org/dc/terms/description> "Validators attached to staking credentials. The \"withdraw zero\" pattern delegates expensive validation logic to a staking validator (called once per transaction) instead of a spending validator (called per input), reducing cost from O(n²) to O(n). Key optimization pattern." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Staking Validators" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "staking-validator" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo-thresholds> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo-thresholds/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo-thresholds/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-1694#ratification"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-1694 — Ratification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo-thresholds> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "SPO thresholds are expressed as a fraction of active pool stake. SPOs only vote on specific action types. Current mainnet values: No-Confidence (Q1) = 51%, Committee Update normal (Q2a) = 51%, Committee Update no-confidence (Q2b) = 51%, Hard Fork (Q4) = 51%, Security-relevant params (Q5) = 51%, Info = 100% (fixed). SPOs do NOT vote on: New Constitution, non-security parameter changes, or Treasury Withdrawals." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo-thresholds> <http://xmlns.com/foaf/0.1/page> <https://cips.cardano.org/cip/CIP-1694#ratification> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo-thresholds> <http://purl.org/dc/terms/description> "SPO thresholds are expressed as a fraction of active pool stake. SPOs only vote on specific action types. Current mainnet values: No-Confidence (Q1) = 51%, Committee Update normal (Q2a) = 51%, Committee Update no-confidence (Q2b) = 51%, Hard Fork (Q4) = 51%, Security-relevant params (Q5) = 51%, Info = 100% (fixed). SPOs do NOT vote on: New Constitution, non-security parameter changes, or Treasury Withdrawals." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#thresholds> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "SPO Voting Thresholds" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "spo-thresholds" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-model/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Model (developers.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Block producers who also participate in governance voting. SPOs vote on a specific subset of governance action types: No Confidence motions, Committee updates, Hard Fork Initiation, security-relevant protocol parameter changes, and Info actions. Their voting power is proportional to the total stake delegated to their pool. SPOs implement approved protocol upgrades (hard forks) on their infrastructure." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> <http://xmlns.com/foaf/0.1/page> <https://developers.cardano.org/docs/governance/cardano-governance/governance-model/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> <http://purl.org/dc/terms/description> "Block producers who also participate in governance voting. SPOs vote on a specific subset of governance action types: No Confidence motions, Committee updates, Hard Fork Initiation, security-relevant protocol parameter changes, and Info actions. Their voting power is proportional to the total stake delegated to their pool. SPOs implement approved protocol upgrades (hard forks) on their infrastructure." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actors> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Stake Pool Operator (SPO)" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "spo" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#actor> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-1694"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-1694 — Security-relevant parameters" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "A subset of protocol parameters that additionally require SPO approval (at Q5 = 51% threshold) when changed. These parameters directly affect network security and node operator costs. The list: maxBlockBodySize, maxTxSize, maxBlockHeaderSize, maxValueSize, maxBlockExecutionUnits, txFeePerByte, txFeeFixed, utxoCostPerByte, govActionDeposit, minFeeRefScriptCostPerByte. This gives SPOs a veto over changes that could destabilize the network or make block production uneconomical." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> <http://xmlns.com/foaf/0.1/page> <https://cips.cardano.org/cip/CIP-1694> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> <http://purl.org/dc/terms/description> "A subset of protocol parameters that additionally require SPO approval (at Q5 = 51% threshold) when changed. These parameters directly affect network security and node operator costs. The list: maxBlockBodySize, maxTxSize, maxBlockHeaderSize, maxValueSize, maxBlockExecutionUnits, txFeePerByte, txFeeFixed, utxoCostPerByte, govActionDeposit, minFeeRefScriptCostPerByte. This gives SPOs a veto over changes that could destabilize the network or make block production uneconomical." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#parameters> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Security-Relevant Parameters" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "security-params" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://plutus.cardano.intersectmbo.org/docs/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Plutus Ledger API" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://aiken-lang.org/fundamentals/getting-started"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Aiken ScriptContext" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/smart-contracts/plutus/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Script Context Reference" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The full transaction context passed to a Plutus validator. Includes all inputs, outputs, minting, certificates, withdrawals, validity range, signatories, and datum map. Scripts can inspect any part of the transaction to enforce arbitrary conditions." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context> <http://xmlns.com/foaf/0.1/page> <https://plutus.cardano.intersectmbo.org/docs/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://aiken-lang.org/fundamentals/getting-started> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://developers.cardano.org/docs/smart-contracts/plutus/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context> <http://purl.org/dc/terms/description> "The full transaction context passed to a Plutus validator. Includes all inputs, outputs, minting, certificates, withdrawals, validity range, signatories, and datum map. Scripts can inspect any part of the transaction to enforce arbitrary conditions." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Script Context" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "script-context" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://scalus.org/docs/design-patterns"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Design Patterns" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/scalus3/scalus"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://scalus.org/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Scalus" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Write smart contracts in Scala 3, compiled to UPLC. Runs on JVM, JS, and Native. UPLC optimizer with compile-time partial evaluation produces competitive script sizes. Full ScalaTest/ScalaCheck support for property-based testing." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus> <http://xmlns.com/foaf/0.1/page> <https://scalus.org/docs/design-patterns> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://github.com/scalus3/scalus> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://scalus.org/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus> <http://purl.org/dc/terms/description> "Write smart contracts in Scala 3, compiled to UPLC. Runs on JVM, JS, and Native. UPLC optimizer with compile-time partial evaluation produces competitive script sizes. Full ScalaTest/ScalaCheck support for property-based testing." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#languages> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Scalus" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "scalus" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#language> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/sanchonet> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/sanchonet/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/sanchonet/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://sancho.network"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "SanchoNet" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/sanchonet> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "A dedicated governance testnet for experimenting with CIP-1694 features. Launched in 2023, it allowed the community to test DRep registration, voting, governance action submission, and the full lifecycle before Conway went live on mainnet. Named after Sancho Panza (Don Quixote's practical companion)." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/sanchonet> <http://xmlns.com/foaf/0.1/page> <https://sancho.network> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/sanchonet> <http://purl.org/dc/terms/description> "A dedicated governance testnet for experimenting with CIP-1694 features. Launched in 2023, it allowed the community to test DRep registration, voting, governance action submission, and the full lifecycle before Conway went live on mainnet. Named after Sancho Panza (Don Quixote's practical companion)." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#ecosystem> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "SanchoNet" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "sanchonet" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#tool> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.cardano.org/about-cardano/evolution/upgrades/vasil/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Vasil Upgrade" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/smart-contracts/plutus/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Developer Guide" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0033"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-33" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-33 feature allowing scripts to be stored on-chain in a UTxO and referenced by transactions without including the script in the transaction body. Dramatically reduces transaction size and fees for popular contracts. The reference script UTxO is not spent." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts> <http://xmlns.com/foaf/0.1/page> <https://docs.cardano.org/about-cardano/evolution/upgrades/vasil/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://developers.cardano.org/docs/smart-contracts/plutus/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://cips.cardano.org/cip/CIP-0033> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts> <http://purl.org/dc/terms/description> "CIP-33 feature allowing scripts to be stored on-chain in a UTxO and referenced by transactions without including the script in the transaction body. Dramatically reduces transaction size and fees for popular contracts. The reference script UTxO is not spent." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Reference Scripts" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "reference-scripts" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/Anastasia-Labs/design-patterns"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Oracle Pattern with Ref Inputs" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/smart-contracts/plutus/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Developer Guide" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0031"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-31" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-31 feature allowing transactions to read UTxOs without spending them. Enables oracle patterns, shared state, and read-only access to on-chain data. Referenced UTxOs appear in the script context but remain unspent." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs> <http://xmlns.com/foaf/0.1/page> <https://github.com/Anastasia-Labs/design-patterns> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://developers.cardano.org/docs/smart-contracts/plutus/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://cips.cardano.org/cip/CIP-0031> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs> <http://purl.org/dc/terms/description> "CIP-31 feature allowing transactions to read UTxOs without spending them. Enables oracle patterns, shared state, and read-only access to on-chain data. Referenced UTxOs appear in the script context but remain unspent." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Reference Inputs" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "reference-inputs" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/redeemer> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/redeemer/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/redeemer/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://aiken-lang.org/fundamentals/getting-started"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Aiken Tutorial" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/redeemer> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/redeemer/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/redeemer/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/smart-contracts/plutus/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Datums and Redeemers" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/redeemer> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "User-provided data included in a transaction to unlock a script-locked UTxO. The redeemer represents the action the user wants to perform. The validator script receives the datum, redeemer, and script context and decides whether to allow the spending." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/redeemer> <http://xmlns.com/foaf/0.1/page> <https://aiken-lang.org/fundamentals/getting-started> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/redeemer> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://developers.cardano.org/docs/smart-contracts/plutus/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/redeemer> <http://purl.org/dc/terms/description> "User-provided data included in a transaction to unlock a script-locked UTxO. The redeemer represents the action the user wants to perform. The validator script receives the datum, redeemer, and script context and decides whether to allow the spending." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Redeemer" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "redeemer" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ratification> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ratification/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ratification/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-1694#ratification"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-1694 — Ratification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ratification> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The process by which a governance action accumulates enough votes to be approved. Ratification is checked ONLY at epoch boundaries — a new tally is calculated each epoch using the current stake snapshot. An action can become ratified even without new votes if delegation changes shift the stake distribution. Votes can be changed at any time before ratification. Registered stake that did not vote counts as 'No'. Unregistered stake counts as 'Abstain'. Each action type has specific thresholds for each governance body. A successful No-Confidence, Committee Update, New Constitution, or Hard Fork delays ratification of ALL other pending actions until after enactment." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ratification> <http://xmlns.com/foaf/0.1/page> <https://cips.cardano.org/cip/CIP-1694#ratification> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ratification> <http://purl.org/dc/terms/description> "The process by which a governance action accumulates enough votes to be approved. Ratification is checked ONLY at epoch boundaries — a new tally is calculated each epoch using the current stake snapshot. An action can become ratified even without new votes if delegation changes shift the stake distribution. Votes can be changed at any time before ratification. Registered stake that did not vote counts as 'No'. Unregistered stake counts as 'Abstain'. Each action type has specific thresholds for each governance body. A successful No-Confidence, Committee Update, New Constitution, or Hard Fork delays ratification of ALL other pending actions until after enactment." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#lifecycle> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Ratification" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "ratification" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#process> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://plutus.cardano.intersectmbo.org/docs/reference/cardano/plutus-core-builtins-ref/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Built-in Functions Reference" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/IntersectMBO/plutus"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://plutus.cardano.intersectmbo.org/resources/plutus-core-spec.pdf"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Plutus Core Spec" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The low-level language that Plutus scripts compile to. An untyped lambda calculus with built-in functions for cryptography, arithmetic, and data manipulation. Executed by the CEK machine on-chain. Each built-in function has an associated cost in CPU and memory units defined by the cost model." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> <http://xmlns.com/foaf/0.1/page> <https://plutus.cardano.intersectmbo.org/docs/reference/cardano/plutus-core-builtins-ref/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://github.com/IntersectMBO/plutus> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://plutus.cardano.intersectmbo.org/resources/plutus-core-spec.pdf> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> <http://purl.org/dc/terms/description> "The low-level language that Plutus scripts compile to. An untyped lambda calculus with built-in functions for cryptography, arithmetic, and data manipulation. Executed by the CEK machine on-chain. Each built-in function has an associated cost in CPU and memory units defined by the cost model." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Plutus Core" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "plutus-core" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#runtime> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus/link/3> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus/link/3> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://plutus.cardano.intersectmbo.org/resources/plutus-core-spec.pdf"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Plutus Core Spec" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/smart-contracts/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Developer Portal" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/input-output-hk/plutus-pioneer-program"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Plutus Pioneer Program" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://plutus.cardano.intersectmbo.org/docs/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Plutus Documentation" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The native smart contract platform for Cardano. Plutus scripts are written in PureScript-like Haskell, compiled to Plutus Core (an untyped lambda calculus), and executed on-chain by the Plutus evaluator. Scripts validate transactions — they receive a datum, redeemer, and script context, returning true or false." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> <http://xmlns.com/foaf/0.1/page> <https://plutus.cardano.intersectmbo.org/resources/plutus-core-spec.pdf> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://developers.cardano.org/docs/smart-contracts/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://github.com/input-output-hk/plutus-pioneer-program> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://plutus.cardano.intersectmbo.org/docs/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> <http://purl.org/dc/terms/description> "The native smart contract platform for Cardano. Plutus scripts are written in PureScript-like Haskell, compiled to Plutus Core (an untyped lambda calculus), and executed on-chain by the Plutus evaluator. Scripts validate transactions — they receive a datum, redeemer, and script context, returning true or false." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Plutus" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "plutus" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/Plutonomicon/plutonomicon"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Plutonomicon" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/Plutonomicon/plutarch-plutus"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Haskell eDSL giving fine-grained control over generated UPLC. Produces significantly more efficient validators than PlutusTx. Created by Liqwid Labs / MLabs. Used by several high-TVL protocols for performance-critical validators." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch> <http://xmlns.com/foaf/0.1/page> <https://github.com/Plutonomicon/plutonomicon> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://github.com/Plutonomicon/plutarch-plutus> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch> <http://purl.org/dc/terms/description> "Haskell eDSL giving fine-grained control over generated UPLC. Produces significantly more efficient validators than PlutusTx. Created by Liqwid Labs / MLabs. Used by several high-TVL protocols for performance-critical validators." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#languages> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Plutarch" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "plutarch" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#language> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plu-ts> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plu-ts/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plu-ts/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/HarmonicLabs/plu-ts"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plu-ts> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plu-ts/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plu-ts/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://pluts.harmoniclabs.tech/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Docs" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plu-ts> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "TypeScript-embedded DSL for on-chain smart contracts plus off-chain transaction building. Constructs UPLC AST directly in TypeScript. Single-language stack for JS/TS developers. Maintained by Harmonic Labs." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plu-ts> <http://xmlns.com/foaf/0.1/page> <https://github.com/HarmonicLabs/plu-ts> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plu-ts> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://pluts.harmoniclabs.tech/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plu-ts> <http://purl.org/dc/terms/description> "TypeScript-embedded DSL for on-chain smart contracts plus off-chain transaction building. Constructs UPLC AST directly in TypeScript. Single-language stack for JS/TS developers. Maintained by Harmonic Labs." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#languages> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "plu-ts" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "plu-ts" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#language> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/input-output-hk/plutus-pioneer-program"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Pioneer Program" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/IntersectMBO/plutus"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://plutus.cardano.intersectmbo.org/docs/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Plutus Docs" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Write smart contracts in a subset of Haskell, compiled to UPLC. Formerly PlutusTx, rebranded in February 2025. The original on-chain language maintained by IntersectMBO. Tight integration with the Haskell ecosystem and GHC type system." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth> <http://xmlns.com/foaf/0.1/page> <https://github.com/input-output-hk/plutus-pioneer-program> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://github.com/IntersectMBO/plutus> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://plutus.cardano.intersectmbo.org/docs/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth> <http://purl.org/dc/terms/description> "Write smart contracts in a subset of Haskell, compiled to UPLC. Formerly PlutusTx, rebranded in February 2025. The original on-chain language maintained by IntersectMBO. Tight integration with the Haskell ecosystem and GHC type system." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#languages> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Plinth" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "plinth" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#language> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/CostModelGeneration.md"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Plutus Cost Model Generation" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Protocol Parameters" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Protocol parameters related to stake pool mechanics, Plutus execution, and script validation. DRep voting threshold: 67% (P5c). Includes: poolPledgeInfluence (0.1–1.0), poolRetireMaxEpoch, stakePoolTargetNum (250–2,000), costModels (the Plutus cost model parameters — benchmarked values for each builtin function), collateralPercentage (100–200). The costModels parameter is what gets updated when the Plutus team reprices builtins based on new benchmarks." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical> <http://xmlns.com/foaf/0.1/page> <https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/CostModelGeneration.md> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical> <http://purl.org/dc/terms/description> "Protocol parameters related to stake pool mechanics, Plutus execution, and script validation. DRep voting threshold: 67% (P5c). Includes: poolPledgeInfluence (0.1–1.0), poolRetireMaxEpoch, stakePoolTargetNum (250–2,000), costModels (the Plutus cost model parameters — benchmarked values for each builtin function), collateralPercentage (100–200). The costModels parameter is what gets updated when the Plutus team reprices builtins based on new benchmarks." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#parameters> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Technical Parameter Group" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "param-group-technical" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#param-group> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-network> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-network/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-network/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Protocol Parameters" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-network> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Protocol parameters related to network capacity and transaction limits. DRep voting threshold: 67% (P5a). Includes: maxBlockBodySize (24,576–122,880 bytes), maxTxSize (up to 32,768 bytes), maxBlockHeaderSize (up to 5,000 bytes), maxValueSize (up to 12,288 bytes), maxTxExecutionUnits (memory and steps), maxBlockExecutionUnits (memory and steps), maxCollateralInputs (minimum 1). Guardrail NETWORK-01: should not change more than once per 2 epochs. NETWORK-02: only one parameter should change per epoch unless correlated." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-network> <http://xmlns.com/foaf/0.1/page> <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-network> <http://purl.org/dc/terms/description> "Protocol parameters related to network capacity and transaction limits. DRep voting threshold: 67% (P5a). Includes: maxBlockBodySize (24,576–122,880 bytes), maxTxSize (up to 32,768 bytes), maxBlockHeaderSize (up to 5,000 bytes), maxValueSize (up to 12,288 bytes), maxTxExecutionUnits (memory and steps), maxBlockExecutionUnits (memory and steps), maxCollateralInputs (minimum 1). Guardrail NETWORK-01: should not change more than once per 2 epochs. NETWORK-02: only one parameter should change per epoch unless correlated." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#parameters> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Network Parameter Group" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "param-group-network" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#param-group> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-governance> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-governance/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-governance/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Protocol Parameters" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-governance> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Protocol parameters that govern governance itself. DRep voting threshold: 75% (P5d) — the highest threshold for parameter changes, reflecting the self-referential nature of changing governance rules. Includes: all 15 voting thresholds (P1–P6 for DReps, Q1–Q5 for SPOs), govActionLifetime (1–15 epochs), govActionDeposit (1M–10T lovelace), dRepDeposit (1M–100B lovelace), dRepActivity (13–37 epochs), committeeMinSize (3–10), committeeMaxTermLength (18–293 epochs)." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-governance> <http://xmlns.com/foaf/0.1/page> <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-governance> <http://purl.org/dc/terms/description> "Protocol parameters that govern governance itself. DRep voting threshold: 75% (P5d) — the highest threshold for parameter changes, reflecting the self-referential nature of changing governance rules. Includes: all 15 voting thresholds (P1–P6 for DReps, Q1–Q5 for SPOs), govActionLifetime (1–15 epochs), govActionDeposit (1M–10T lovelace), dRepDeposit (1M–100B lovelace), dRepActivity (13–37 epochs), committeeMinSize (3–10), committeeMaxTermLength (18–293 epochs)." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#parameters> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Parameter Group" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "param-group-governance" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#param-group> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-economic> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-economic/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-economic/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Protocol Parameters" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-economic> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Protocol parameters related to transaction fees, deposits, and monetary policy. DRep voting threshold: 67% (P5b). Includes: txFeePerByte (30–1,000 lovelace), txFeeFixed (100,000–10,000,000 lovelace), stakeAddressDeposit, stakePoolDeposit, monetaryExpansion (0.001–0.005), treasuryCut (10%–30%), minPoolCost, utxoCostPerByte (3,000–6,500), executionUnitPrices (priceMemory and priceSteps), minFeeRefScriptCostPerByte." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-economic> <http://xmlns.com/foaf/0.1/page> <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-economic> <http://purl.org/dc/terms/description> "Protocol parameters related to transaction fees, deposits, and monetary policy. DRep voting threshold: 67% (P5b). Includes: txFeePerByte (30–1,000 lovelace), txFeeFixed (100,000–10,000,000 lovelace), stakeAddressDeposit, stakePoolDeposit, monetaryExpansion (0.001–0.005), treasuryCut (10%–30%), minPoolCost, utxoCostPerByte (3,000–6,500), executionUnitPrices (priceMemory and priceSteps), minFeeRefScriptCostPerByte." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#parameters> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Economic Parameter Group" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "param-group-economic" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#param-group> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/cardano-foundation/cardano-org/tree/main/src/data"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CF Chart Data (source)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cardano.org/insights/governance-actions/?category=Critical+Parameter+Changes"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CF Critical Parameter Charts" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Some protocol parameters have voting thresholds that differ from their group defaults, as defined in the Cardano Constitution and implemented in the Guardrails Script. For example: committeeMaxTermLength requires only DRep 67% with no CC vote; deposit parameters (dRepDeposit, stakePoolDeposit, stakeAddressDeposit, minPoolCost, committeeMinSize) use the Governance group threshold (DRep 75% + CC 2/3) rather than their native Economic/Technical group thresholds. These exceptions reflect the constitutional significance of these specific parameters." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions> <http://xmlns.com/foaf/0.1/page> <https://github.com/cardano-foundation/cardano-org/tree/main/src/data> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://cardano.org/insights/governance-actions/?category=Critical+Parameter+Changes> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions> <http://purl.org/dc/terms/description> "Some protocol parameters have voting thresholds that differ from their group defaults, as defined in the Cardano Constitution and implemented in the Guardrails Script. For example: committeeMaxTermLength requires only DRep 67% with no CC vote; deposit parameters (dRepDeposit, stakePoolDeposit, stakeAddressDeposit, minPoolCost, committeeMinSize) use the Governance group threshold (DRep 75% + CC 2/3) rather than their native Economic/Technical group thresholds. These exceptions reflect the constitutional significance of these specific parameters." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#parameters> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Per-Parameter Threshold Exceptions" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "param-exceptions" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://orcfax.io/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Orcfax" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://charli3.io/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Charli3" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/Anastasia-Labs/design-patterns"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Design Patterns" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Leverages CIP-31 reference inputs: an oracle publishes price/data in a UTxO datum, and multiple contracts read it simultaneously without spending it. Eliminates contention. Charli3 and Orcfax are the main Cardano oracle providers." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern> <http://xmlns.com/foaf/0.1/page> <https://orcfax.io/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://charli3.io/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://github.com/Anastasia-Labs/design-patterns> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern> <http://purl.org/dc/terms/description> "Leverages CIP-31 reference inputs: an oracle publishes price/data in a UTxO datum, and multiple contracts read it simultaneously without spending it. Eliminates contention. Charli3 and Orcfax are the main Cardano oracle providers." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Oracle Pattern" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "oracle-pattern" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://pycardano.readthedocs.io/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "PyCardano" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/OpShin/opshin"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://opshin.dev/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "OpShin" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Write Cardano smart contracts in 100% valid Python syntax. Enforces a strict type system on top of Python. Integrates with PyCardano for off-chain code. Lowers the barrier for Python developers entering the Cardano ecosystem." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin> <http://xmlns.com/foaf/0.1/page> <https://pycardano.readthedocs.io/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://github.com/OpShin/opshin> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://opshin.dev/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin> <http://purl.org/dc/terms/description> "Write Cardano smart contracts in 100% valid Python syntax. Enforces a strict type system on top of Python. Integrates with PyCardano for off-chain code. Lowers the barrier for Python developers entering the Cardano ecosystem." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#languages> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "OpShin" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "opshin" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#language> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/no-confidence-option> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/no-confidence-option/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/no-confidence-option/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-1694#pre-defined-voting-options"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-1694 — Pre-Defined Voting Options" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/no-confidence-option> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "A pre-defined voting option for ada holders. When delegating to No Confidence, the holder's stake automatically votes 'Yes' on every Motion of No-Confidence and 'No' on every other governance action. Unlike Abstain, this stake IS counted in the active voting stake — it actively opposes all governance actions except no-confidence motions. This is a signal of dissatisfaction with the current governance state." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/no-confidence-option> <http://xmlns.com/foaf/0.1/page> <https://cips.cardano.org/cip/CIP-1694#pre-defined-voting-options> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/no-confidence-option> <http://purl.org/dc/terms/description> "A pre-defined voting option for ada holders. When delegating to No Confidence, the holder's stake automatically votes 'Yes' on every Motion of No-Confidence and 'No' on every other governance action. Unlike Abstain, this stake IS counted in the active voting stake — it actively opposes all governance actions except no-confidence motions. This is a signal of dissatisfaction with the current governance state." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actors> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "No Confidence (Pre-defined DRep)" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "no-confidence-option" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-25"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-25: NFT Metadata" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://aiken-lang.org/fundamentals/getting-started"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Aiken: Minting Policy" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/native-tokens/minting/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Minting Native Tokens" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "A Plutus script that controls the creation and destruction of native tokens. The policy receives the script context and decides whether to allow minting or burning. The policy hash becomes the first part of the token's asset ID, cryptographically binding tokens to their minting rules." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> <http://xmlns.com/foaf/0.1/page> <https://cips.cardano.org/cip/CIP-25> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://aiken-lang.org/fundamentals/getting-started> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://developers.cardano.org/docs/native-tokens/minting/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> <http://purl.org/dc/terms/description> "A Plutus script that controls the creation and destruction of native tokens. The policy receives the script context and decides whether to allow minting or burning. The policy hash becomes the first part of the token's asset ID, cryptographically binding tokens to their minting rules." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Minting Policy" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "minting-policy" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/minswap"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.minswap.org/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Docs" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://minswap.org/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Minswap" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Largest Cardano DEX by TVL and weekly volume. Multi-pool AMM using the constant-product formula. Written in Aiken. Demonstrates production-scale smart contract usage on Cardano with batched order settlement." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap> <http://xmlns.com/foaf/0.1/page> <https://github.com/minswap> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://docs.minswap.org/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://minswap.org/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap> <http://purl.org/dc/terms/description> "Largest Cardano DEX by TVL and weekly volume. Multi-pool AMM using the constant-product formula. Written in Aiken. Demonstrates production-scale smart contract usage on Cardano with batched order settlement." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#protocols> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Minswap" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "minswap" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#protocol> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/MeshJS/mesh"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://meshjs.dev/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Mesh" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "TypeScript SDK with transaction builder, React components, wallet connectors, and smart contract integration. Higher-level alternative to Lucid with more out-of-the-box UI components." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk> <http://xmlns.com/foaf/0.1/page> <https://github.com/MeshJS/mesh> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://meshjs.dev/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk> <http://purl.org/dc/terms/description> "TypeScript SDK with transaction builder, React components, wallet connectors, and smart contract integration. Higher-level alternative to Lucid with more out-of-the-box UI components." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#tooling> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Mesh SDK" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "mesh-sdk" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#tool> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/smart-contracts/smart-contract-languages/marlowe/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Developer Portal" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/marlowe-lang"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://marlowe.iohk.io/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Marlowe" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Domain-specific language for financial contracts. High-level, non-Turing-complete by design — contracts can be exhaustively analyzed and formally verified via Isabelle. Transitioned to community ownership (Marlowe Language CIC) in 2024." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe> <http://xmlns.com/foaf/0.1/page> <https://developers.cardano.org/docs/smart-contracts/smart-contract-languages/marlowe/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://github.com/marlowe-lang> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://marlowe.iohk.io/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe> <http://purl.org/dc/terms/description> "Domain-specific language for financial contracts. High-level, non-Turing-complete by design — contracts can be exhaustively analyzed and formally verified via Isabelle. Transitioned to community ownership (Marlowe Language CIC) in 2024." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#languages> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Marlowe" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "marlowe" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#language> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://anastasia-labs.com/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Anastasia Labs" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/Anastasia-Labs/lucid-evolution"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://anastasia-labs.github.io/lucid-evolution/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Docs" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Production-ready TypeScript off-chain transaction builder. Successor to the original Lucid, maintained by Anastasia Labs. Supports Plutus V1/V2/V3, Conway hard fork ready. The standard choice for building Cardano dApp frontends." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> <http://xmlns.com/foaf/0.1/page> <https://anastasia-labs.com/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://github.com/Anastasia-Labs/lucid-evolution> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://anastasia-labs.github.io/lucid-evolution/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> <http://purl.org/dc/terms/description> "Production-ready TypeScript off-chain transaction builder. Successor to the original Lucid, maintained by Anastasia Labs. Supports Plutus V1/V2/V3, Conway hard fork ready. The standard choice for building Cardano dApp frontends." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#tooling> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Lucid Evolution" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "lucid-evolution" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#tool> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liqwid> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liqwid/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liqwid/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.liqwid.finance/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Docs" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liqwid> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liqwid/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liqwid/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://liqwid.finance/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Liqwid" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liqwid> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Leading lending/borrowing protocol on Cardano. Non-custodial, supports liquid staking. DAO-governed via LQ token. Uses Plutarch for performance-critical validators. Demonstrates complex multi-contract DeFi on EUTxO." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liqwid> <http://xmlns.com/foaf/0.1/page> <https://docs.liqwid.finance/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liqwid> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://liqwid.finance/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liqwid> <http://purl.org/dc/terms/description> "Leading lending/borrowing protocol on Cardano. Non-custodial, supports liquid staking. DAO-governed via LQ token. Uses Plutarch for performance-critical validators. Demonstrates complex multi-contract DeFi on EUTxO." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#protocols> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Liqwid Finance" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "liqwid" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#protocol> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liquid-democracy> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liquid-democracy/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liquid-democracy/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.cardano.org/about-cardano/governance-overview"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Overview" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liquid-democracy> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The democratic model used by Cardano governance. Ada holders can vote directly on every governance matter (by registering as their own DRep) OR delegate their voting power to any registered DRep. Delegation can be changed at any time and takes effect immediately. This combines the benefits of direct democracy (anyone can participate) with representative democracy (expertise can be delegated to). DRep delegation is SEPARATE from stake pool delegation — you choose who produces blocks and who votes on your behalf independently." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liquid-democracy> <http://xmlns.com/foaf/0.1/page> <https://docs.cardano.org/about-cardano/governance-overview> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liquid-democracy> <http://purl.org/dc/terms/description> "The democratic model used by Cardano governance. Ada holders can vote directly on every governance matter (by registering as their own DRep) OR delegate their voting power to any registered DRep. Delegation can be changed at any time and takes effect immediately. This combines the benefits of direct democracy (anyone can participate) with representative democracy (expertise can be delegated to). DRep delegation is SEPARATE from stake pool delegation — you choose who produces blocks and who votes on your behalf independently." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#core> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Liquid Democracy" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "liquid-democracy" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/intersect> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/intersect/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/intersect/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://www.intersectmbo.org"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Intersect" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/intersect> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "A not-for-profit organization (registered in Wyoming, USA) that facilitates off-chain governance processes. Intersect manages the Parameter Committee, organizes elections, runs working groups, and coordinates the governance tooling ecosystem. It is NOT a governance body — it does not vote or ratify. Its role is facilitation and coordination: hosting discussions, managing the CIP process, coordinating hard fork readiness, and providing infrastructure like GovTool." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/intersect> <http://xmlns.com/foaf/0.1/page> <https://www.intersectmbo.org> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/intersect> <http://purl.org/dc/terms/description> "A not-for-profit organization (registered in Wyoming, USA) that facilitates off-chain governance processes. Intersect manages the Parameter Committee, organizes elections, runs working groups, and coordinates the governance tooling ecosystem. It is NOT a governance body — it does not vote or ratify. Its role is facilitation and coordination: hosting discussions, managing the CIP process, coordinating hard fork readiness, and providing infrastructure like GovTool." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#ecosystem> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Intersect" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "intersect" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#actor> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/inline-datums> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/inline-datums/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/inline-datums/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.cardano.org/about-cardano/evolution/upgrades/vasil/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Vasil Upgrade" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/inline-datums> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/inline-datums/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/inline-datums/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0032"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-32" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/inline-datums> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-32 feature that stores the full datum directly in the UTxO instead of just a hash. Eliminates the need for off-chain datum management — anyone can see the contract state by reading the UTxO. Essential for composability between protocols." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/inline-datums> <http://xmlns.com/foaf/0.1/page> <https://docs.cardano.org/about-cardano/evolution/upgrades/vasil/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/inline-datums> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://cips.cardano.org/cip/CIP-0032> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/inline-datums> <http://purl.org/dc/terms/description> "CIP-32 feature that stores the full datum directly in the UTxO instead of just a hash. Eliminates the need for off-chain datum management — anyone can see the contract state by reading the UTxO. Essential for composability between protocols." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Inline Datums" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "inline-datums" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/cardano-scaling/hydra"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.cardano.org/developer-resources/scalability-solutions/hydra"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Cardano Docs" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://hydra.family/head-protocol/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Hydra" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Layer 2 isomorphic state channels. Each \"head\" is a mini-ledger replicating Cardano's full functionality off-chain with sub-second latency and 1,000 TPS per head. Multiple heads scale linearly. Uses the same smart contract model as L1." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra> <http://xmlns.com/foaf/0.1/page> <https://github.com/cardano-scaling/hydra> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://docs.cardano.org/developer-resources/scalability-solutions/hydra> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://hydra.family/head-protocol/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra> <http://purl.org/dc/terms/description> "Layer 2 isomorphic state channels. Each \"head\" is a mini-ledger replicating Cardano's full functionality off-chain with sub-second latency and 1,000 TPS per head. Multiple heads scale linearly. Uses the same smart contract model as L1." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#protocols> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Hydra" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "hydra" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#protocol> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hot-cold-keys> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hot-cold-keys/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hot-cold-keys/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/constitutional-committee-guide/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Constitutional Committee Guide" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hot-cold-keys> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The credential system used by Constitutional Committee members. Similar to genesis delegation certificates. The cold key is the CC member's identity — kept offline for security. The hot key is authorized by the cold key for day-to-day voting. If a hot key is compromised, it can be rotated without changing the CC member's identity. This separation protects against key compromise while allowing active participation. CC members can also use native or Plutus script credentials instead of key pairs." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hot-cold-keys> <http://xmlns.com/foaf/0.1/page> <https://developers.cardano.org/docs/governance/cardano-governance/constitutional-committee-guide/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hot-cold-keys> <http://purl.org/dc/terms/description> "The credential system used by Constitutional Committee members. Similar to genesis delegation certificates. The cold key is the CC member's identity — kept offline for security. The hot key is authorized by the cold key for day-to-day voting. If a hot key is compromised, it can be rotated without changing the CC member's identity. This separation protects against key compromise while allowing active participation. CC members can also use native or Plutus script credentials instead of key pairs." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#framework> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Hot/Cold Key System" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "hot-cold-keys" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/helios> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/helios/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/helios/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/HeliosLang/compiler"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/helios> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/helios/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/helios/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://helios-lang.io/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Helios" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/helios> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "JavaScript/TypeScript SDK with its own on-chain DSL — functional, strongly typed, curly-brace syntax. Compiles to Plutus Core. Also handles off-chain transaction building, making it an all-in-one toolkit for JS developers." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/helios> <http://xmlns.com/foaf/0.1/page> <https://github.com/HeliosLang/compiler> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/helios> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://helios-lang.io/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/helios> <http://purl.org/dc/terms/description> "JavaScript/TypeScript SDK with its own on-chain DSL — functional, strongly typed, curly-brace syntax. Compiles to Plutus Core. Also handles off-chain transaction building, making it an all-in-one toolkit for JS developers." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#languages> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Helios" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "helios" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#language> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/submitting-governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Submitting Governance Actions" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-1694"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-1694 — Guardrails Script" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "An on-chain Plutus script that enforces specific constitutional rules programmatically. It applies ONLY to protocol parameter changes and treasury withdrawals — these are the two governance action types where automated enforcement is feasible. The script checks parameter bounds (e.g., maxBlockBodySize must be between 24,576 and 122,880 bytes) and treasury withdrawal limits. Named guardrails include PARAM-01 through PARAM-06a (parameter rules), TREASURY-01a through TREASURY-04a (withdrawal limits), HARDFORK-01 through HARDFORK-08, and committee/constitution update rules. The guardrails script can be updated via a New Constitution governance action." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> <http://xmlns.com/foaf/0.1/page> <https://developers.cardano.org/docs/governance/cardano-governance/submitting-governance-actions/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://cips.cardano.org/cip/CIP-1694> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> <http://purl.org/dc/terms/description> "An on-chain Plutus script that enforces specific constitutional rules programmatically. It applies ONLY to protocol parameter changes and treasury withdrawals — these are the two governance action types where automated enforcement is feasible. The script checks parameter bounds (e.g., maxBlockBodySize must be between 24,576 and 122,880 bytes) and treasury withdrawal limits. Named guardrails include PARAM-01 through PARAM-06a (parameter rules), TREASURY-01a through TREASURY-04a (withdrawal limits), HARDFORK-01 through HARDFORK-08, and committee/constitution update rules. The guardrails script can be updated via a New Constitution governance action." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#framework> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Guardrails Script" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "guardrails-script" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#artifact> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.gov.tools/overview/what-is-cardano-govtool"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GovTool Documentation" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://gov.tools"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GovTool" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "A web application for participating in Cardano governance. GovTool's four architectural pillars: Proposal Discussion, Delegation, Outcomes, and Voting. Users can delegate to DReps, register as DReps, view and vote on governance actions, and track outcomes. It connects to the user's wallet via CIP-95 (the Conway-era web-wallet bridge)." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> <http://xmlns.com/foaf/0.1/page> <https://docs.gov.tools/overview/what-is-cardano-govtool> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://gov.tools> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> <http://purl.org/dc/terms/description> "A web application for participating in Cardano governance. GovTool's four architectural pillars: Proposal Discussion, Delegation, Outcomes, and Voting. Users can delegate to DReps, register as DReps, view and vote on governance actions, and track outcomes. It connects to the user's wallet via CIP-95 (the Conway-era web-wallet bridge)." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#ecosystem> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "GovTool" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "govtool" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#tool> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cardanofoundation.org/governance"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CF Governance Page" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.cardano.org/about-cardano/governance-overview"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Overview (docs.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-1694"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-1694 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Cardano uses a tricameral (three-body) governance model implementing liquid democracy, introduced by CIP-1694 as part of the Voltaire phase. Ada holders can vote directly on every governance matter or delegate their voting power to Delegated Representatives (DReps). Three governance bodies — DReps, Stake Pool Operators (SPOs), and the Constitutional Committee (CC) — each play distinct roles in reviewing and ratifying governance actions. Every governance action requires approval from at least two of the three bodies." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> <http://xmlns.com/foaf/0.1/page> <https://cardanofoundation.org/governance> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://docs.cardano.org/about-cardano/governance-overview> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://cips.cardano.org/cip/CIP-1694> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> <http://purl.org/dc/terms/description> "Cardano uses a tricameral (three-body) governance model implementing liquid democracy, introduced by CIP-1694 as part of the Voltaire phase. Ada holders can vote directly on every governance matter or delegate their voting power to Delegated Representatives (DReps). Three governance bodies — DReps, Stake Pool Operators (SPOs), and the Constitutional Committee (CC) — each play distinct roles in reviewing and ratifying governance actions. Every governance action requires approval from at least two of the three bodies." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#core> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Cardano Governance" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "governance-model" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cardano.org/insights/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Action Flowcharts" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cardanofoundation.org/blog/understanding-cardano-governance-actions"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CF — Understanding Governance Actions" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Actions (developers.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "An on-chain event triggered by a transaction. Any ada holder can submit a governance action by paying the govActionDeposit (currently 100,000 ada, refundable). Every action includes: the deposit amount, a reward address for deposit return, a metadata anchor (URL + hash, following CIP-100/CIP-108 standards), and — for most types — a hash reference to the most recently enacted action of the same type (to prevent collisions). Actions have a lifespan of govActionLifetime epochs (currently 6 epochs / ~30 days). There are 7 types of governance actions." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> <http://xmlns.com/foaf/0.1/page> <https://cardano.org/insights/governance-actions/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://cardanofoundation.org/blog/understanding-cardano-governance-actions> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> <http://purl.org/dc/terms/description> "An on-chain event triggered by a transaction. Any ada holder can submit a governance action by paying the govActionDeposit (currently 100,000 ada, refundable). Every action includes: the deposit amount, a reward address for deposit return, a metadata anchor (URL + hash, following CIP-100/CIP-108 standards), and — for most types — a hash reference to the most recently enacted action of the same type (to prevent collisions). Actions have a lifespan of govActionLifetime epochs (currently 6 epochs / ~30 days). There are 7 types of governance actions." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actions> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Action" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "governance-action" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://plutus.cardano.intersectmbo.org/docs/reference/cardano/plutus-core-builtins-ref/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Script Cost Calculator" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.cardano.org/about-cardano/explore-more/fee-structure/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Fee Structure" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/smart-contracts/plutus/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Understanding ExUnits" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Execution units — the two-dimensional resource budget for Plutus scripts. CPU steps measure computation time, memory units measure peak memory usage. Every transaction specifies ExUnits for each script it runs. Fees are computed from ExUnits using protocol parameters (prices per step/unit)." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> <http://xmlns.com/foaf/0.1/page> <https://plutus.cardano.intersectmbo.org/docs/reference/cardano/plutus-core-builtins-ref/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://docs.cardano.org/about-cardano/explore-more/fee-structure/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://developers.cardano.org/docs/smart-contracts/plutus/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> <http://purl.org/dc/terms/description> "Execution units — the two-dimensional resource budget for Plutus scripts. CPU steps measure computation time, memory units measure peak memory usage. Every transaction specifies ExUnits for each script it runs. Fees are computed from ExUnits using protocol parameters (prices per step/unit)." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "ExUnits" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "exunits" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo/link/3> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo/link/3> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://ucarecdn.com/3da33f2f-73ac-4c9b-844b-f215dcce0628/EUTXOhandbook_for_ec.pdf"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "EUTxO Handbook" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/smart-contracts/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Developer Portal" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.cardano.org/about-cardano/learn/eutxo-explainer/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Understanding EUTxO" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://iohk.io/en/research/library/papers/the-extended-utxo-model/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "EUTxO Paper" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Extended UTxO — Cardano's transaction model that extends Bitcoin's UTxO with datum, redeemer, and script validation. Each UTxO can be locked by a validator script. Spending requires providing a redeemer that satisfies the validator. The model enables deterministic transaction validation — fees and outcomes are known before submission." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> <http://xmlns.com/foaf/0.1/page> <https://ucarecdn.com/3da33f2f-73ac-4c9b-844b-f215dcce0628/EUTXOhandbook_for_ec.pdf> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://developers.cardano.org/docs/smart-contracts/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://docs.cardano.org/about-cardano/learn/eutxo-explainer/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://iohk.io/en/research/library/papers/the-extended-utxo-model/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> <http://purl.org/dc/terms/description> "Extended UTxO — Cardano's transaction model that extends Bitcoin's UTxO with datum, redeemer, and script validation. Each UTxO can be locked by a validator script. Spending requires providing a redeemer that satisfies the validator. The model enables deterministic transaction validation — fees and outcomes are known before submission." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "EUTxO Model" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "eutxo" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/enactment> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/enactment/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/enactment/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-1694#enactment"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-1694 — Enactment" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/enactment> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Ratified governance actions are enacted on the epoch boundary FOLLOWING ratification. When multiple actions are ratified in the same epoch, they are enacted in a fixed priority order: (1) No-Confidence, (2) Committee Update, (3) New Constitution, (4) Hard Fork, (5) Parameter Changes, (6) Treasury Withdrawals, (7) Info. Within the same type, actions are enacted in the order they were accepted to the chain. After enactment, the governance action deposit is returned to the specified reward address." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/enactment> <http://xmlns.com/foaf/0.1/page> <https://cips.cardano.org/cip/CIP-1694#enactment> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/enactment> <http://purl.org/dc/terms/description> "Ratified governance actions are enacted on the epoch boundary FOLLOWING ratification. When multiple actions are ratified in the same epoch, they are enacted in a fixed priority order: (1) No-Confidence, (2) Committee Update, (3) New Constitution, (4) Hard Fork, (5) Parameter Changes, (6) Treasury Withdrawals, (7) Info. Within the same type, actions are enacted in the order they were accepted to the chain. After enactment, the governance action deposit is returned to the specified reward address." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#lifecycle> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Enactment" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "enactment" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#process> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep-thresholds> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep-thresholds/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep-thresholds/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-1694#ratification"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-1694 — Ratification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep-thresholds> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "DRep thresholds are expressed as a fraction of active DRep voting stake. Active voting stake = all stake delegated to registered, active DReps (excluding Abstain delegations). Current mainnet values: No-Confidence (P1) = 67%, Committee Update normal (P2a) = 67%, Committee Update no-confidence (P2b) = 60%, New Constitution (P3) = 75%, Hard Fork (P4) = 60%, Network params (P5a) = 67%, Economic params (P5b) = 67%, Technical params (P5c) = 67%, Governance params (P5d) = 75%, Treasury Withdrawal (P6) = 67%, Info = 100% (fixed)." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep-thresholds> <http://xmlns.com/foaf/0.1/page> <https://cips.cardano.org/cip/CIP-1694#ratification> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep-thresholds> <http://purl.org/dc/terms/description> "DRep thresholds are expressed as a fraction of active DRep voting stake. Active voting stake = all stake delegated to registered, active DReps (excluding Abstain delegations). Current mainnet values: No-Confidence (P1) = 67%, Committee Update normal (P2a) = 67%, Committee Update no-confidence (P2b) = 60%, New Constitution (P3) = 75%, Hard Fork (P4) = 60%, Network params (P5a) = 67%, Economic params (P5b) = 67%, Technical params (P5c) = 67%, Governance params (P5d) = 75%, Treasury Withdrawal (P6) = 67%, Info = 100% (fixed)." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#thresholds> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "DRep Voting Thresholds" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "drep-thresholds" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cardanofoundation.org/blog/strengthens-commitment-governance-drep"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CF as DRep" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-model/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Register as DRep (CLI)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.cardano.org/about-cardano/governance-overview"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "DReps (docs.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Any ada holder can register as a DRep by paying a refundable deposit (currently 500 ada). DReps accumulate voting power from ada holders who delegate to them. Their vote weight equals the total lovelace delegated to them — one lovelace = one vote. DReps must vote regularly or they become inactive after the dRepActivity period (currently 20 epochs / 100 days). Inactive DReps do not count toward the active voting stake. DRep delegation is separate from stake pool delegation and takes effect immediately (no two-epoch lag). DReps are identified by a credential: an Ed25519 verification key or a native/Plutus script." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> <http://xmlns.com/foaf/0.1/page> <https://cardanofoundation.org/blog/strengthens-commitment-governance-drep> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://developers.cardano.org/docs/governance/cardano-governance/governance-model/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://docs.cardano.org/about-cardano/governance-overview> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> <http://purl.org/dc/terms/description> "Any ada holder can register as a DRep by paying a refundable deposit (currently 500 ada). DReps accumulate voting power from ada holders who delegate to them. Their vote weight equals the total lovelace delegated to them — one lovelace = one vote. DReps must vote regularly or they become inactive after the dRepActivity period (currently 20 epochs / 100 days). Inactive DReps do not count toward the active voting stake. DRep delegation is separate from stake pool delegation and takes effect immediately (no two-epoch lag). DReps are identified by a credential: an Ed25519 verification key or a native/Plutus script." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actors> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Delegated Representative (DRep)" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "drep" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#actor> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/djed> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/djed/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/djed/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://eprint.iacr.org/2021/1069"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Djed Paper" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/djed> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/djed/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/djed/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://djed.xyz/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Djed" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/djed> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Overcollateralized algorithmic stablecoin. Maintained peg since January 2023 launch. Demonstrates formal verification applied to DeFi — the Djed paper provides mathematical proofs of peg stability under defined conditions." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/djed> <http://xmlns.com/foaf/0.1/page> <https://eprint.iacr.org/2021/1069> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/djed> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://djed.xyz/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/djed> <http://purl.org/dc/terms/description> "Overcollateralized algorithmic stablecoin. Maintained peg since January 2023 launch. Demonstrates formal verification applied to DeFi — the Djed paper provides mathematical proofs of peg stability under defined conditions." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#protocols> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Djed" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "djed" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#protocol> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/deposit-mechanism> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/deposit-mechanism/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/deposit-mechanism/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-model/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Model" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/deposit-mechanism> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Several governance actions require refundable deposits to prevent spam. govActionDeposit (currently 100,000 ada) is required to submit any governance action — returned when the action is ratified or expires. dRepDeposit (currently 500 ada) is required to register as a DRep — returned on retirement. These deposits are protocol parameters in the Governance group, changeable via governance actions with a 75% DRep threshold." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/deposit-mechanism> <http://xmlns.com/foaf/0.1/page> <https://developers.cardano.org/docs/governance/cardano-governance/governance-model/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/deposit-mechanism> <http://purl.org/dc/terms/description> "Several governance actions require refundable deposits to prevent spam. govActionDeposit (currently 100,000 ada) is required to submit any governance action — returned when the action is ratified or expires. dRepDeposit (currently 500 ada) is required to register as a DRep — returned on retirement. These deposits are protocol parameters in the Governance group, changeable via governance actions with a 75% DRep threshold." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#lifecycle> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Deposit Mechanism" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "deposit-mechanism" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/demeter> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/demeter/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/demeter/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.demeter.run/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Docs" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/demeter> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/demeter/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/demeter/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://demeter.run/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Demeter" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/demeter> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Cloud development platform for Cardano. Provides managed nodes, indexers, and Hydra infrastructure across mainnet/preprod/preview. No local infrastructure needed — develop and test in the cloud." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/demeter> <http://xmlns.com/foaf/0.1/page> <https://docs.demeter.run/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/demeter> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://demeter.run/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/demeter> <http://purl.org/dc/terms/description> "Cloud development platform for Cardano. Provides managed nodes, indexers, and Hydra infrastructure across mainnet/preprod/preview. No local infrastructure needed — develop and test in the cloud." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#tooling> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Demeter.run" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "demeter" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#tool> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://aiken-lang.org/fundamentals/getting-started"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Aiken Tutorial: Datums" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-32"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-32: Inline Datums" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/smart-contracts/plutus/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Datums and Redeemers" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Data attached to a UTxO that is locked by a Plutus script. The datum represents the state of the contract. When spending the UTxO, the datum is passed to the validator script along with a redeemer and the transaction context. Can be stored inline (CIP-32) or as a hash with the full datum provided in the transaction." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> <http://xmlns.com/foaf/0.1/page> <https://aiken-lang.org/fundamentals/getting-started> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://cips.cardano.org/cip/CIP-32> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://developers.cardano.org/docs/smart-contracts/plutus/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> <http://purl.org/dc/terms/description> "Data attached to a UTxO that is locked by a Plutus script. The datum represents the state of the contract. When spending the UTxO, the datum is passed to the validator script along with a redeemer and the transaction context. Can be stored inline (CIP-32) or as a hash with the full datum provided in the transaction." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Datum" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "datum" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/models.R"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "R Models" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Benchmark Data (benching-conway.csv)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/CostModelGeneration.md"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Cost Model Generation Process" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Protocol parameters that assign abstract CPU and memory costs (ExUnits) to each Plutus builtin function. These are part of the Technical parameter group. Cost models are calibrated by benchmarking each builtin on a reference machine through the Haskell CEK machine, then fitting cost functions via R scripts. Coefficients are stored as 64-bit integers (picoseconds) for cross-platform reproducibility. The cost model ensures that maxBlockExUnits worth of abstract work fits within the real block validation time budget. Every node implementation (Haskell, Rust, etc.) must compute identical ExUnits — the abstract costs are consensus-critical. Updates go through the governance process as Protocol Parameter Changes." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> <http://xmlns.com/foaf/0.1/page> <https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/models.R> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/CostModelGeneration.md> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> <http://purl.org/dc/terms/description> "Protocol parameters that assign abstract CPU and memory costs (ExUnits) to each Plutus builtin function. These are part of the Technical parameter group. Cost models are calibrated by benchmarking each builtin on a reference machine through the Haskell CEK machine, then fitting cost functions via R scripts. Coefficients are stored as 64-bit integers (picoseconds) for cross-platform reproducibility. The cost model ensures that maxBlockExUnits worth of abstract work fits within the real block validation time budget. Every node implementation (Haskell, Rust, etc.) must compute identical ExUnits — the abstract costs are consensus-critical. Updates go through the governance process as Protocol Parameter Changes." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#parameters> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Plutus Cost Models" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cost-models" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#parameter> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/conway-era> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/conway-era/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/conway-era/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.cardano.org/about-cardano/evolution/upgrades/chang"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Chang Upgrade" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/conway-era> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The current Cardano ledger era that implements CIP-1694 governance. Named after mathematician John Horton Conway. Introduced via two hard forks: Chang #1 (August 2024) — bootstrap phase with limited governance (DRep registration, interim CC, parameter changes and hard forks only); and Plomin hard fork / Chang #2 (December 2024) — full governance activation with all 7 action types and treasury withdrawals. The bootstrap phase ended when the CC and SPOs ratified the Plomin hard fork." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/conway-era> <http://xmlns.com/foaf/0.1/page> <https://docs.cardano.org/about-cardano/evolution/upgrades/chang> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/conway-era> <http://purl.org/dc/terms/description> "The current Cardano ledger era that implements CIP-1694 governance. Named after mathematician John Horton Conway. Introduced via two hard forks: Chang #1 (August 2024) — bootstrap phase with limited governance (DRep registration, interim CC, parameter changes and hard forks only); and Plomin hard fork / Chang #2 (December 2024) — full governance activation with all 7 action types and treasury withdrawals. The bootstrap phase ended when the CC and SPOs ratified the Plomin hard fork." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#framework> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Conway Ledger Era" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "conway-era" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cardanofoundation.org/blog/proposal-for-cardano-constitution"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CF Constitution Proposal" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://gov.tools"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Full Constitution Text" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "An off-chain text document whose hash is recorded on-chain. It defines shared values and guiding principles for Cardano governance. The current Constitution was ratified at the Buenos Aires Constitutional Convention (December 4-6, 2024) with 95% delegate approval after 63 workshops across 51 countries, and became effective on-chain on January 24, 2026. It contains: a Preamble (not used for constitutionality assessments), 10 Tenets (core principles including transaction freedom, predictable costs, ada supply cap at 45 billion), Articles covering community participation, decentralized governance, CC responsibilities, and treasury provisions, plus Appendix I with permitted parameter ranges. The on-chain version (hash) prevails over the documented version in case of conflict." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution> <http://xmlns.com/foaf/0.1/page> <https://cardanofoundation.org/blog/proposal-for-cardano-constitution> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://gov.tools> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution> <http://purl.org/dc/terms/description> "An off-chain text document whose hash is recorded on-chain. It defines shared values and guiding principles for Cardano governance. The current Constitution was ratified at the Buenos Aires Constitutional Convention (December 4-6, 2024) with 95% delegate approval after 63 workshops across 51 countries, and became effective on-chain on January 24, 2026. It contains: a Preamble (not used for constitutionality assessments), 10 Tenets (core principles including transaction freedom, predictable costs, ada supply cap at 45 billion), Articles covering community participation, decentralized governance, CC responsibilities, and treasury provisions, plus Appendix I with permitted parameter ranges. The on-chain version (hash) prevails over the documented version in case of conflict." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#framework> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Cardano Constitution" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "constitution" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#artifact> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-95> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-95/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-95/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0095"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-95 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-95> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-95 defines the web-wallet bridge for the Conway era. It extends the CIP-30 wallet connector with governance-specific capabilities: DRep registration, vote delegation, and governance action submission from browser-based wallets. Without CIP-95, governance tools like GovTool couldn't interact with users' wallets. It enables the 'connect wallet' flow that makes on-chain governance accessible to non-technical participants." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-95> <http://xmlns.com/foaf/0.1/page> <https://cips.cardano.org/cip/CIP-0095> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-95> <http://purl.org/dc/terms/description> "CIP-95 defines the web-wallet bridge for the Conway era. It extends the CIP-30 wallet connector with governance-specific capabilities: DRep registration, vote delegation, and governance action submission from browser-based wallets. Without CIP-95, governance tools like GovTool couldn't interact with users' wallets. It enables the 'connect wallet' flow that makes on-chain governance accessible to non-technical participants." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#framework> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-95" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-95" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#artifact> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-88> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-88/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-88/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0088"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-88 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-88> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Token Policy Registration — a metadata standard for registering information about a token's minting policy on-chain. Enables policy authors to declare the token's name, description, logo, decimals, and project details in a verifiable way. Helps wallets, explorers, and marketplaces display accurate token information without relying on centralized registries." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-88> <http://xmlns.com/foaf/0.1/page> <https://cips.cardano.org/cip/CIP-0088> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-88> <http://purl.org/dc/terms/description> "Token Policy Registration — a metadata standard for registering information about a token's minting policy on-chain. Enables policy authors to declare the token's name, description, logo, decimals, and project details in a verifiable way. Helps wallets, explorers, and marketplaces display accurate token information without relying on centralized registries." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#standards> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-88" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-88" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#standard> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-85> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-85/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-85/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0085"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-85 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-85> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Sums-of-Products (SOPs) for Plutus Core — replaces the Scott-encoded data representation with native constructor/case expressions. This makes compiled Plutus scripts significantly smaller and faster by eliminating the overhead of encoding algebraic data types as lambda terms. SOPs shipped with Plutus V3 and are a key driver of the script size and execution cost reductions in the Conway era." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-85> <http://xmlns.com/foaf/0.1/page> <https://cips.cardano.org/cip/CIP-0085> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-85> <http://purl.org/dc/terms/description> "Sums-of-Products (SOPs) for Plutus Core — replaces the Scott-encoded data representation with native constructor/case expressions. This makes compiled Plutus scripts significantly smaller and faster by eliminating the overhead of encoding algebraic data types as lambda terms. SOPs shipped with Plutus V3 and are a key driver of the script size and execution cost reductions in the Conway era." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#standards> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-85" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-85" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#standard> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-69> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-69/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-69/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0069"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-69 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-69> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Plutus Script Type Uniformization — unifies the interface for all Plutus script purposes (spending, minting, certifying, rewarding) into a single uniform signature. Before CIP-69, minting policies received two arguments (redeemer, context) while spending validators received three (datum, redeemer, context). CIP-69 makes all script types take the same arguments, simplifying multi-purpose scripts and enabling a single validator to serve as both spending and minting script." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-69> <http://xmlns.com/foaf/0.1/page> <https://cips.cardano.org/cip/CIP-0069> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-69> <http://purl.org/dc/terms/description> "Plutus Script Type Uniformization — unifies the interface for all Plutus script purposes (spending, minting, certifying, rewarding) into a single uniform signature. Before CIP-69, minting policies received two arguments (redeemer, context) while spending validators received three (datum, redeemer, context). CIP-69 makes all script types take the same arguments, simplifying multi-purpose scripts and enabling a single validator to serve as both spending and minting script." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#standards> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-69" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-69" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#standard> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/native-tokens/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Rich Metadata Explainer" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-68"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-68" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Rich, mutable metadata standard. Uses a reference NFT (label 100) carrying metadata in its datum, paired with a user token (label 222 for NFTs, 333 for FTs). Metadata can be updated by spending the reference UTxO. Successor to CIP-25." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68> <http://xmlns.com/foaf/0.1/page> <https://developers.cardano.org/docs/native-tokens/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://cips.cardano.org/cip/CIP-68> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68> <http://purl.org/dc/terms/description> "Rich, mutable metadata standard. Uses a reference NFT (label 100) carrying metadata in its datum, paired with a user token (label 222 for NFTs, 333 for FTs). Metadata can be updated by spending the reference UTxO. Successor to CIP-25." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#standards> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-68" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-68" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#standard> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://aiken-lang.org/fundamentals/getting-started"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Aiken Blueprint Docs" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-57"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-57" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Plutus Contract Blueprint — machine-readable JSON schema (plutus.json) documenting a smart contract's interface: validators, parameters, datum/redeemer types. Enables tooling to auto-generate off-chain bindings. Aiken generates blueprints automatically." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57> <http://xmlns.com/foaf/0.1/page> <https://aiken-lang.org/fundamentals/getting-started> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://cips.cardano.org/cip/CIP-57> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57> <http://purl.org/dc/terms/description> "Plutus Contract Blueprint — machine-readable JSON schema (plutus.json) documenting a smart contract's interface: validators, parameters, datum/redeemer types. Enables tooling to auto-generate off-chain bindings. Aiken generates blueprints automatically." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#standards> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-57" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-57" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#standard> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-381> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-381/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-381/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0381"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-381 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-381> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Adds BLS12-381 elliptic curve primitives as Plutus built-in functions. Enables zero-knowledge proofs (Groth16, PLONK), BLS signature verification, and advanced cryptographic protocols directly on-chain. These primitives support sidechains, bridges, and privacy-preserving applications on Cardano. Shipped with Plutus V3 in the Conway era." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-381> <http://xmlns.com/foaf/0.1/page> <https://cips.cardano.org/cip/CIP-0381> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-381> <http://purl.org/dc/terms/description> "Adds BLS12-381 elliptic curve primitives as Plutus built-in functions. Enables zero-knowledge proofs (Groth16, PLONK), BLS signature verification, and advanced cryptographic protocols directly on-chain. These primitives support sidechains, bridges, and privacy-preserving applications on Cardano. Shipped with Plutus V3 in the Conway era." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#standards> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-381" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-381" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#standard> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-30> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-30/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-30/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0030"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-30 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-30> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Cardano dApp-Wallet Web Bridge — the original standard for connecting browser-based dApps to Cardano wallets. Defines a JavaScript API injected into window.cardano that lets dApps discover wallets, request access, query balances, submit transactions, and sign data. Nearly every Cardano dApp uses CIP-30 for wallet interaction. CIP-95 extends it with governance capabilities." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-30> <http://xmlns.com/foaf/0.1/page> <https://cips.cardano.org/cip/CIP-0030> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-30> <http://purl.org/dc/terms/description> "Cardano dApp-Wallet Web Bridge — the original standard for connecting browser-based dApps to Cardano wallets. Defines a JavaScript API injected into window.cardano that lets dApps discover wallets, request access, query balances, submit transactions, and sign data. Nearly every Cardano dApp uses CIP-30 for wallet interaction. CIP-95 extends it with governance capabilities." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#standards> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-30" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-30" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#standard> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/native-tokens/minting-nfts/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Minting NFTs Guide" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-25"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-25" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Original NFT metadata standard. Metadata attached to minting transactions via transaction metadata label 721. Simple and widely adopted but metadata is immutable after minting. The foundation for Cardano's NFT ecosystem." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25> <http://xmlns.com/foaf/0.1/page> <https://developers.cardano.org/docs/native-tokens/minting-nfts/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://cips.cardano.org/cip/CIP-25> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25> <http://purl.org/dc/terms/description> "Original NFT metadata standard. Metadata attached to minting transactions via transaction metadata label 721. Simple and widely adopted but metadata is immutable after minting. The foundation for Cardano's NFT ecosystem." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#standards> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-25" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-25" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#standard> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-1694> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-1694/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-1694/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-1694"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-1694 Full Text" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-1694> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The Cardano Improvement Proposal that specifies the on-chain governance mechanism. Authored by Jared Corduan and Andre Knispel, it defines the three governance bodies, seven action types, voting and ratification rules, the Constitutional Committee structure, DRep mechanics, and the full lifecycle of governance actions. CIP-1694 was implemented in the Conway ledger era (named after John Horton Conway)." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-1694> <http://xmlns.com/foaf/0.1/page> <https://cips.cardano.org/cip/CIP-1694> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-1694> <http://purl.org/dc/terms/description> "The Cardano Improvement Proposal that specifies the on-chain governance mechanism. Authored by Jared Corduan and Andre Knispel, it defines the three governance bodies, seven action types, voting and ratification rules, the Constitutional Committee structure, DRep mechanics, and the full lifecycle of governance actions. CIP-1694 was implemented in the Conway ledger era (named after John Horton Conway)." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#framework> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-1694" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-1694" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#artifact> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-136> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-136/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-136/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0136"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-136 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-136> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-136 defines the metadata standard for Constitutional Committee vote rationales. When CC members vote on governance actions, they are expected to explain their constitutional reasoning. CIP-136 provides a structured format for these rationales, including which constitutional articles were considered and why the action was deemed constitutional or not. This creates a public record of constitutional interpretation — effectively building governance case law over time." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-136> <http://xmlns.com/foaf/0.1/page> <https://cips.cardano.org/cip/CIP-0136> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-136> <http://purl.org/dc/terms/description> "CIP-136 defines the metadata standard for Constitutional Committee vote rationales. When CC members vote on governance actions, they are expected to explain their constitutional reasoning. CIP-136 provides a structured format for these rationales, including which constitutional articles were considered and why the action was deemed constitutional or not. This creates a public record of constitutional interpretation — effectively building governance case law over time." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#framework> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-136" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-136" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#artifact> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-129> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-129/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-129/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0129"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-129 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-129> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-129 standardizes governance identifiers across the ecosystem. It defines canonical string representations for governance credentials (DRep IDs, CC member IDs, governance action IDs) that work consistently across wallets, explorers, and governance tools. Without this standard, different tools might represent the same DRep or action differently, causing confusion when sharing links or referencing proposals." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-129> <http://xmlns.com/foaf/0.1/page> <https://cips.cardano.org/cip/CIP-0129> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-129> <http://purl.org/dc/terms/description> "CIP-129 standardizes governance identifiers across the ecosystem. It defines canonical string representations for governance credentials (DRep IDs, CC member IDs, governance action IDs) that work consistently across wallets, explorers, and governance tools. Without this standard, different tools might represent the same DRep or action differently, causing confusion when sharing links or referencing proposals." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#framework> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-129" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-129" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#artifact> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-119> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-119/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-119/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0119"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-119 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-119> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-119 defines the governance metadata standard for Delegated Representatives. It extends CIP-100 with DRep-specific fields: display name, bio, motivations, qualifications, payment address, and references. This structured profile metadata helps ada holders make informed delegation decisions. GovTool and other governance interfaces render CIP-119 metadata on DRep profile pages." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-119> <http://xmlns.com/foaf/0.1/page> <https://cips.cardano.org/cip/CIP-0119> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-119> <http://purl.org/dc/terms/description> "CIP-119 defines the governance metadata standard for Delegated Representatives. It extends CIP-100 with DRep-specific fields: display name, bio, motivations, qualifications, payment address, and references. This structured profile metadata helps ada holders make informed delegation decisions. GovTool and other governance interfaces render CIP-119 metadata on DRep profile pages." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#framework> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-119" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-119" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#artifact> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-108> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-108/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-108/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0108"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-108 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-108> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-108 extends CIP-100 with a specific metadata format for governance actions. It defines required fields: title, abstract, motivation, rationale, and supporting references. This structured format ensures that voters have consistent, comparable information when evaluating proposals. GovTool and other governance interfaces render CIP-108 metadata to present proposals in a human-readable format." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-108> <http://xmlns.com/foaf/0.1/page> <https://cips.cardano.org/cip/CIP-0108> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-108> <http://purl.org/dc/terms/description> "CIP-108 extends CIP-100 with a specific metadata format for governance actions. It defines required fields: title, abstract, motivation, rationale, and supporting references. This structured format ensures that voters have consistent, comparable information when evaluating proposals. GovTool and other governance interfaces render CIP-108 metadata to present proposals in a human-readable format." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#framework> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-108" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-108" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#artifact> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-105> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-105/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-105/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0105"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-105 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-105> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-105 defines the Conway-era HD wallet key derivation paths for governance credentials. It specifies how wallets derive the key pairs used for DRep registration, vote delegation, and CC member credentials from a single master seed. This ensures that governance keys are deterministically recoverable from a wallet's mnemonic phrase, following the same BIP-32/BIP-44 patterns used for payment and staking keys." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-105> <http://xmlns.com/foaf/0.1/page> <https://cips.cardano.org/cip/CIP-0105> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-105> <http://purl.org/dc/terms/description> "CIP-105 defines the Conway-era HD wallet key derivation paths for governance credentials. It specifies how wallets derive the key pairs used for DRep registration, vote delegation, and CC member credentials from a single master seed. This ensures that governance keys are deterministically recoverable from a wallet's mnemonic phrase, following the same BIP-32/BIP-44 patterns used for payment and staking keys." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#framework> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-105" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-105" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#artifact> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-100> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-100/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-100/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0100"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-100 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-100> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-100 defines the general governance metadata standard. Every governance action includes a metadata anchor — a URL pointing to a JSON document plus its hash for integrity. CIP-100 specifies the base format for this metadata, ensuring all governance tools can parse and display proposal information consistently. The metadata is stored off-chain (to avoid blockchain bloat) but its hash is recorded on-chain, making it tamper-proof." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-100> <http://xmlns.com/foaf/0.1/page> <https://cips.cardano.org/cip/CIP-0100> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-100> <http://purl.org/dc/terms/description> "CIP-100 defines the general governance metadata standard. Every governance action includes a metadata anchor — a URL pointing to a JSON document plus its hash for integrity. CIP-100 specifies the base format for this metadata, ensuring all governance tools can parse and display proposal information consistently. The metadata is stored off-chain (to avoid blockchain bloat) but its hash is recorded on-chain, making it tamper-proof." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#framework> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-100" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-100" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#artifact> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/smart-contracts/plutus/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "How Plutus Scripts Are Evaluated" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://plutus.cardano.intersectmbo.org/resources/plutus-core-spec.pdf"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CEK Machine Spec" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The abstract machine that evaluates Plutus Core on-chain. Tracks CPU and memory consumption using ExUnits budgets. If a script exceeds its budget, the transaction fails. The CEK machine is deterministic — same inputs always produce same outputs and same costs." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine> <http://xmlns.com/foaf/0.1/page> <https://developers.cardano.org/docs/smart-contracts/plutus/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://plutus.cardano.intersectmbo.org/resources/plutus-core-spec.pdf> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine> <http://purl.org/dc/terms/description> "The abstract machine that evaluates Plutus Core on-chain. Tracks CPU and memory consumption using ExUnits budgets. If a script exceeds its budget, the transaction fails. The CEK machine is deterministic — same inputs always produce same outputs and same costs." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "CEK Machine" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cek-machine" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#runtime> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc-threshold> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc-threshold/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc-threshold/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/constitutional-committee-guide/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Constitutional Committee Guide" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc-threshold> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The CC uses one-member-one-vote (not stake-weighted). The required fraction of CC members who must approve is a configurable threshold (currently 2/3 on mainnet). The CC votes on: New Constitution, Hard Fork, all Protocol Parameter Changes, Treasury Withdrawals, and Info actions. The CC does NOT vote on: No-Confidence motions or Committee Updates (since those are about the CC itself). Expired members cannot vote. The committee has a minimum size (committeeMinSize = 7 on mainnet)." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc-threshold> <http://xmlns.com/foaf/0.1/page> <https://developers.cardano.org/docs/governance/cardano-governance/constitutional-committee-guide/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc-threshold> <http://purl.org/dc/terms/description> "The CC uses one-member-one-vote (not stake-weighted). The required fraction of CC members who must approve is a configurable threshold (currently 2/3 on mainnet). The CC votes on: New Constitution, Hard Fork, all Protocol Parameter Changes, Treasury Withdrawals, and Info actions. The CC does NOT vote on: No-Confidence motions or Committee Updates (since those are about the CC itself). Expired members cannot vote. The committee has a minimum size (committeeMinSize = 7 on mainnet)." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#thresholds> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "CC Voting Threshold" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cc-threshold" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://gov.tools"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CC Portal" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/constitutional-committee-guide/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Constitutional Committee Guide" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "A community-elected oversight body responsible for ensuring that governance actions respect the Cardano Constitution. Each CC member holds exactly one vote (not stake-weighted). The CC does NOT create proposals and does NOT evaluate merit — it reviews constitutionality only. Members use a hot/cold key credential system (like genesis delegation). Each member has an individual term expiration epoch; expired members cannot vote. Members can resign early. The CC can enter a 'no-confidence' state via a Motion of No-Confidence, which blocks it from participating in ratification until a new committee is elected. The CC does not vote on No-Confidence motions or Committee updates (since those are about the CC itself)." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <http://xmlns.com/foaf/0.1/page> <https://gov.tools> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://developers.cardano.org/docs/governance/cardano-governance/constitutional-committee-guide/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <http://purl.org/dc/terms/description> "A community-elected oversight body responsible for ensuring that governance actions respect the Cardano Constitution. Each CC member holds exactly one vote (not stake-weighted). The CC does NOT create proposals and does NOT evaluate merit — it reviews constitutionality only. Members use a hot/cold key credential system (like genesis delegation). Each member has an individual term expiration epoch; expired members cannot vote. Members can resign early. The CC can enter a 'no-confidence' state via a Motion of No-Confidence, which blocks it from participating in ratification until a new committee is elected. The CC does not vote on No-Confidence motions or Committee updates (since those are about the CC itself)." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actors> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Constitutional Committee (CC)" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cc" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#actor> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cardanofoundation.org/blog/strengthens-commitment-governance-drep"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CF as DRep" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://proposalexaminer.cardanofoundation.org/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Cardano Proposal Examiner" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cardanofoundation.org/governance"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CF Governance" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "One of the three founding entities of Cardano (alongside IOG and EMURGO). The CF is registered as a DRep on-chain and operates a Governance Advisory Team of subject-matter experts. It evaluates proposals on constitutional alignment and governance merit, publishing vote rationales with each governance action vote. The CF served on the interim Constitutional Committee during the bootstrap phase and created the Cardano Proposal Examiner tool. The founding entities relinquished their genesis keys, transitioning control to the community." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation> <http://xmlns.com/foaf/0.1/page> <https://cardanofoundation.org/blog/strengthens-commitment-governance-drep> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://proposalexaminer.cardanofoundation.org/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://cardanofoundation.org/governance> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation> <http://purl.org/dc/terms/description> "One of the three founding entities of Cardano (alongside IOG and EMURGO). The CF is registered as a DRep on-chain and operates a Governance Advisory Team of subject-matter experts. It evaluates proposals on constitutional alignment and governance merit, publishing vote rationales with each governance action vote. The CF served on the interim Constitutional Committee during the bootstrap phase and created the Cardano Proposal Examiner tool. The founding entities relinquished their genesis keys, transitioning control to the community." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#ecosystem> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Cardano Foundation" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cardano-foundation" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#actor> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/bootstrap-phase> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/bootstrap-phase/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/bootstrap-phase/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.cardano.org/about-cardano/evolution/upgrades/chang"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Chang Upgrade" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/bootstrap-phase> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The initial governance phase after Chang #1 (August 2024) and before the Plomin hard fork (December 2024). During bootstrap: CC vote alone was sufficient for protocol parameter changes; CC + SPO vote was sufficient for hard fork initiation; Info actions were available; no other governance actions were possible; DRep participation was not required. The bootstrap phase ended when CC and SPOs ratified the Plomin hard fork, transitioning to full governance." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/bootstrap-phase> <http://xmlns.com/foaf/0.1/page> <https://docs.cardano.org/about-cardano/evolution/upgrades/chang> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/bootstrap-phase> <http://purl.org/dc/terms/description> "The initial governance phase after Chang #1 (August 2024) and before the Plomin hard fork (December 2024). During bootstrap: CC vote alone was sufficient for protocol parameter changes; CC + SPO vote was sufficient for hard fork initiation; Info actions were available; no other governance actions were possible; DRep participation was not required. The bootstrap phase ended when CC and SPOs ratified the Plomin hard fork, transitioning to full governance." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#lifecycle> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Bootstrap Phase" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "bootstrap-phase" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#process> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/blockfrost"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.blockfrost.io/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "API Docs" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://blockfrost.io/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Blockfrost" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Hosted REST API for Cardano blockchain data. Free tier available. SDKs in 15+ languages. The most common way dApps query chain state without running a full node. Also offers self-hosted option." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost> <http://xmlns.com/foaf/0.1/page> <https://github.com/blockfrost> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://docs.blockfrost.io/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://blockfrost.io/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost> <http://purl.org/dc/terms/description> "Hosted REST API for Cardano blockchain data. Free tier available. SDKs in 15+ languages. The most common way dApps query chain state without running a full node. Also offers self-hosted option." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#tooling> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Blockfrost" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "blockfrost" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#tool> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken/link/3> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken/link/3> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://aiken-lang.org/stdlib"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Standard Library" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://aiken-lang.org/fundamentals/getting-started"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Getting Started" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/aiken-lang/aiken"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://aiken-lang.org/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Aiken" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Rust-inspired, purpose-built language for Cardano smart contracts. Most popular on-chain language — 75%+ of developers use it. Compiles directly to UPLC with excellent optimization. First-class Plutus blueprint (CIP-57) generation." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> <http://xmlns.com/foaf/0.1/page> <https://aiken-lang.org/stdlib> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://aiken-lang.org/fundamentals/getting-started> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://github.com/aiken-lang/aiken> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://aiken-lang.org/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> <http://purl.org/dc/terms/description> "Rust-inspired, purpose-built language for Cardano smart contracts. Most popular on-chain language — 75%+ of developers use it. Compiles directly to UPLC with excellent optimization. First-class Plutus blueprint (CIP-57) generation." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#languages> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Aiken" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "aiken" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#language> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-model/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Model (developers.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://gov.tools"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GovTool — Participate in Governance" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Any holder of ada. Ada holders are the foundation of Cardano governance — they have 'skin in the game' and can participate in governance in multiple ways: vote directly by registering as a DRep, delegate their voting power to a DRep (or to the pre-defined Abstain/No Confidence options), submit governance actions (with a deposit), and delegate stake to SPOs for block production. Voting power is proportional: one lovelace = one vote." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> <http://xmlns.com/foaf/0.1/page> <https://developers.cardano.org/docs/governance/cardano-governance/governance-model/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://gov.tools> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> <http://purl.org/dc/terms/description> "Any holder of ada. Ada holders are the foundation of Cardano governance — they have 'skin in the game' and can participate in governance in multiple ways: vote directly by registering as a DRep, delegate their voting power to a DRep (or to the pre-defined Abstain/No Confidence options), submit governance actions (with a deposit), and delegate stake to SPOs for block production. Voting power is proportional: one lovelace = one vote." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actors> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Ada Holder" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "ada-holder" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#actor> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-update-committee> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-update-committee/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-update-committee/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Actions (developers.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-update-committee> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Changes the Constitutional Committee membership, its signature threshold, and/or member term limits. Can add new members (with term expiration epochs), remove existing members, and adjust the fraction of CC members required to approve actions. Thresholds differ depending on CC state: in normal state, requires DRep 67% + SPO 51%; in no-confidence state, DRep 60% + SPO 51% (lower DRep threshold to make it easier to replace a failed CC). The CC does not vote on this." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-update-committee> <http://xmlns.com/foaf/0.1/page> <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-update-committee> <http://purl.org/dc/terms/description> "Changes the Constitutional Committee membership, its signature threshold, and/or member term limits. Can add new members (with term expiration epochs), remove existing members, and adjust the fraction of CC members required to approve actions. Thresholds differ depending on CC state: in normal state, requires DRep 67% + SPO 51%; in no-confidence state, DRep 60% + SPO 51% (lower DRep threshold to make it easier to replace a failed CC). The CC does not vote on this." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actions> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "2. Update Committee / Threshold" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "action-update-committee" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#action-type> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Actions (developers.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Withdraws ada from the Cardano treasury. The action specifies a map from stake credentials to positive lovelace amounts. Requires: CC approval (2/3 majority) + DRep approval at 67%. SPOs do not vote on this. The Guardrails Script enforces withdrawal limits (TREASURY-01a through TREASURY-04a). Treasury withdrawals must specify purpose, expected costs, and provide for auditable accounts. This action type does NOT require chaining to previous actions of the same type (unlike most other types)." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> <http://xmlns.com/foaf/0.1/page> <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> <http://purl.org/dc/terms/description> "Withdraws ada from the Cardano treasury. The action specifies a map from stake credentials to positive lovelace amounts. Requires: CC approval (2/3 majority) + DRep approval at 67%. SPOs do not vote on this. The Guardrails Script enforces withdrawal limits (TREASURY-01a through TREASURY-04a). Treasury withdrawals must specify purpose, expected costs, and provide for auditable accounts. This action type does NOT require chaining to previous actions of the same type (unlike most other types)." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actions> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "6. Treasury Withdrawal" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "action-treasury" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#action-type> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Actions (developers.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Protocol Parameters" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Changes one or more updatable protocol parameters. Parameters are grouped into four categories (Network, Economic, Technical, Governance), each with its own DRep voting threshold. Requires CC approval (2/3 majority) for all groups. If the change touches security-relevant parameters, SPOs must also approve at 51%. The Guardrails Script enforces permitted ranges for each parameter. This is the mechanism used for Plutus cost model updates — cost model parameters are part of the Technical group." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> <http://xmlns.com/foaf/0.1/page> <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> <http://purl.org/dc/terms/description> "Changes one or more updatable protocol parameters. Parameters are grouped into four categories (Network, Economic, Technical, Governance), each with its own DRep voting threshold. Requires CC approval (2/3 majority) for all groups. If the change touches security-relevant parameters, SPOs must also approve at 51%. The Guardrails Script enforces permitted ranges for each parameter. This is the mechanism used for Plutus cost model updates — cost model parameters are part of the Technical group." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actions> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "5. Protocol Parameter Changes" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "action-param-change" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#action-type> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-no-confidence> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-no-confidence/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-no-confidence/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Actions (developers.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-no-confidence> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Creates a state of no-confidence in the current Constitutional Committee. When ratified, the CC enters a no-confidence state and cannot participate in governance until a new committee is elected via an Update Committee action. This is the highest-priority governance action — if ratified in the same epoch as other actions, it is enacted first. Requires: DRep approval at 67% of active voting stake + SPO approval at 51% of active pool stake. The CC does not vote on this (since it's about them)." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-no-confidence> <http://xmlns.com/foaf/0.1/page> <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-no-confidence> <http://purl.org/dc/terms/description> "Creates a state of no-confidence in the current Constitutional Committee. When ratified, the CC enters a no-confidence state and cannot participate in governance until a new committee is elected via an Update Committee action. This is the highest-priority governance action — if ratified in the same epoch as other actions, it is enacted first. Requires: DRep approval at 67% of active voting stake + SPO approval at 51% of active pool stake. The CC does not vote on this (since it's about them)." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actions> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "1. Motion of No-Confidence" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "action-no-confidence" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#action-type> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Actions (developers.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Modifies the Cardano Constitution and/or the on-chain Guardrails Script. The action includes an anchor to the new Constitution text and optionally a new script hash for the Guardrails Script. Requires: CC approval (2/3 majority) + DRep approval at 75% of active voting stake. SPOs do not vote on this. This is the action with the highest DRep threshold (alongside Governance group parameter changes), reflecting the significance of constitutional amendments." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> <http://xmlns.com/foaf/0.1/page> <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> <http://purl.org/dc/terms/description> "Modifies the Cardano Constitution and/or the on-chain Guardrails Script. The action includes an anchor to the new Constitution text and optionally a new script hash for the Guardrails Script. Requires: CC approval (2/3 majority) + DRep approval at 75% of active voting stake. SPOs do not vote on this. This is the action with the highest DRep threshold (alongside Governance group parameter changes), reflecting the significance of constitutional amendments." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actions> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "3. New Constitution / Guardrails Script" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "action-new-constitution" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#action-type> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Actions (developers.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Has no on-chain effect — it's a mechanism for recording community sentiment on-chain. Requires 100% threshold from all three bodies (meaning it can never technically be 'ratified' in the normal sense, but serves as a signal). Info actions are useful for polling the community on proposals before committing to a binding governance action. They do not require chaining to previous actions." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> <http://xmlns.com/foaf/0.1/page> <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> <http://purl.org/dc/terms/description> "Has no on-chain effect — it's a mechanism for recording community sentiment on-chain. Requires 100% threshold from all three bodies (meaning it can never technically be 'ratified' in the normal sense, but serves as a signal). Info actions are useful for polling the community on proposals before committing to a binding governance action. They do not require chaining to previous actions." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actions> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "7. Info Action" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "action-info" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#action-type> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.cardano.org/about-cardano/evolution/upgrades/chang"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Chang Upgrade" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Actions (developers.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Triggers a non-backwards-compatible protocol upgrade. The action specifies a new major protocol version (must be exactly +1 from current). This is the only governance action that requires approval from ALL THREE bodies: CC (2/3 majority), DReps (60%), and SPOs (51%). Guardrail HARDFORK-04a requires at least 85% of stake pools by active stake to have upgraded their node software before enactment. A ratified hard fork delays ratification of all other pending actions until after enactment." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork> <http://xmlns.com/foaf/0.1/page> <https://docs.cardano.org/about-cardano/evolution/upgrades/chang> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork> <http://purl.org/dc/terms/description> "Triggers a non-backwards-compatible protocol upgrade. The action specifies a new major protocol version (must be exactly +1 from current). This is the only governance action that requires approval from ALL THREE bodies: CC (2/3 majority), DReps (60%), and SPOs (51%). Guardrail HARDFORK-04a requires at least 85% of stake pools by active stake to have upgraded their node software before enactment. A ratified hard fork delays ratification of all other pending actions until after enactment." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actions> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "4. Hard Fork Initiation" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "action-hard-fork" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#action-type> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-chaining> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-chaining/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-chaining/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-1694#governance-actions"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-1694 — Governance Actions" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-chaining> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "A collision-prevention mechanism. Each governance action (except Treasury Withdrawals and Info) must include the governance action ID of the most recently enacted action of its same type. This forms a chain that prevents two competing same-type actions from both being ratified when they assume incompatible starting states. For example, two parameter change proposals that both assume the current parameter values cannot both be valid after one of them changes those values." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-chaining> <http://xmlns.com/foaf/0.1/page> <https://cips.cardano.org/cip/CIP-1694#governance-actions> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-chaining> <http://purl.org/dc/terms/description> "A collision-prevention mechanism. Each governance action (except Treasury Withdrawals and Info) must include the governance action ID of the most recently enacted action of its same type. This forms a chain that prevents two competing same-type actions from both being ratified when they assume incompatible starting states. For example, two parameter change proposals that both assume the current parameter values cannot both be valid after one of them changes those values." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#lifecycle> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Action Chaining" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "action-chaining" ;
 	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
 	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/abstain-option> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/abstain-option/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/abstain-option/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-1694#pre-defined-voting-options"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-1694 — Pre-Defined Voting Options" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/abstain-option> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "A pre-defined voting option for ada holders. When delegating to Abstain, the holder's stake is marked as not participating — it is NOT counted in the active voting stake denominator. This means it neither helps nor hinders ratification of any action. The holder still counts as registered for staking reward incentives." ;
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/abstain-option> <http://xmlns.com/foaf/0.1/page> <https://cips.cardano.org/cip/CIP-1694#pre-defined-voting-options> .
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/abstain-option> <http://purl.org/dc/terms/description> "A pre-defined voting option for ada holders. When delegating to Abstain, the holder's stake is marked as not participating — it is NOT counted in the active voting stake denominator. This means it neither helps nor hinders ratification of any action. The holder still counts as registered for staking reward incentives." ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actors> ;
 	<http://www.w3.org/2000/01/rdf-schema#label> "Abstain (Pre-defined DRep)" ;
 	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "abstain-option" ;

--- a/flake.lock
+++ b/flake.lock
@@ -55,11 +55,11 @@
         "purescript-overlay": "purescript-overlay"
       },
       "locked": {
-        "lastModified": 1775739065,
-        "narHash": "sha256-gRddug5YmHmNIkUwlY+7fP3M7dJoc088qM5amrxfbY8=",
+        "lastModified": 1775752072,
+        "narHash": "sha256-AsJxfPcnM3QOewac6R5zqicK38l2OxBAPK5i/Ay5b7o=",
         "owner": "lambdasistemi",
         "repo": "graph-browser",
-        "rev": "7d33b9f583a160624d67e3983a33466d8e4df374",
+        "rev": "e3cf2643bced59368ff0e8a9becac01163806375",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -26,12 +26,9 @@
             cp ${browser}/index.html $out/
             cp ${browser}/index.js $out/
 
-            # Copy data as writable so we can merge ontology triples
+            # Copy data alongside the bundled viewer; the runtime merges RDF
+            # inputs declared in data/config.json.
             cp -r --no-preserve=mode ${./data} $out/data
-
-            # Merge ontology triples into graph.ttl so SPARQL queries
-            # using cardano: vocabulary work at runtime
-            cat ${./data/rdf/cardano.ttl} >> $out/data/rdf/graph.ttl
 
             # Publish namespace document so ontology IRI is dereferenceable
             mkdir -p $out/vocab

--- a/justfile
+++ b/justfile
@@ -2,9 +2,9 @@
 build:
     nix build
 
-# Validate RDF graph parses correctly
+# Validate the configured RDF sources parse correctly
 validate:
-    node -e "const fs=require('fs'); const ox=require('oxigraph'); const s=new ox.Store(); s.load(fs.readFileSync('data/rdf/graph.ttl','utf8'),{format:'text/turtle',base_iri:'https://graph-browser.invalid/'}); console.log('graph.ttl: '+s.size+' triples — OK')"
+    node -e "const fs=require('fs'); const ox=require('oxigraph'); const cfg=JSON.parse(fs.readFileSync('data/config.json','utf8')); const sources=cfg.graphSources ?? [cfg.graphSource]; for (const src of sources) { const s=new ox.Store(); s.load(fs.readFileSync(src.path,'utf8'),{format:src.format,base_iri:'https://graph-browser.invalid/'}); console.log(src.path+': '+s.size+' triples — OK'); }"
 
 ci: build validate
 


### PR DESCRIPTION
Closes #31

This downstream change adopts the new graph-browser runtime contract after the upstream RDF work was merged to `main`.

## What changed

The viewer configuration now uses `graphSources` instead of a single `graphSource`, so the runtime loads and merges four RDF inputs:
- `data/rdf/graph.ttl`
- `data/rdf/core-ontology.ttl`
- `data/rdf/application-ontology.ttl`
- `data/rdf/cardano.ttl`

The flake input was switched back to upstream `main`, and the lock file now pins the merged upstream revision on `main` rather than the temporary feature branch.

## Why this was needed

Before this change, downstream was relying on two incompatible assumptions:
- the build step concatenated `cardano.ttl` into `graph.ttl` to fake a merged graph
- the graph data still used legacy `gb:description`, `gb:externalLink`, `gb:url`, and `gb:EdgeAssertion` semantics that the new upstream importer intentionally ignores

That meant simply updating graph-browser upstream would have broken edge descriptions, external links, and any query that depended on `gb:EdgeAssertion`.

## Data model migration

`data/rdf/graph.ttl` was mechanically migrated to the new upstream contract:
- node descriptions now use `dcterms:description`
- node links now use standard RDF predicates (`foaf:page` and `rdfs:seeAlso`)
- edge descriptions now live on `rdf:Statement` reification resources with `rdf:subject`, `rdf:predicate`, `rdf:object`, and `dcterms:description`
- the direct subject-predicate-object graph edges were preserved as the primary relation graph

I also refreshed `data/rdf/core-ontology.ttl` and `data/rdf/core-ontology.mmd` from the current upstream `main` so the ontology view no longer advertises the removed legacy edge/link model as if it were current.

## Query and tutorial impact

The risky downstream surface here was not the raw data alone but the navigation layer built on top of it.

I updated the `Neighborhood` query to stop traversing `gb:EdgeAssertion` resources and instead use direct RDF relations between nodes. That keeps the same user-facing behavior under the new importer.

Tutorials were checked explicitly because they are easy to break accidentally during data migrations. They still key off stable node ids, so the migration preserved:
- node ids in `graph.ttl`
- query catalog loading
- tutorial index loading
- tutorial stop navigation

I also kept the ontology query naming aligned with the upstream viewer by renaming `Ontology Subtree` to `Ontology Subtrees`.

## Build and verification

What I verified locally:
- `nix build` succeeds against the updated upstream `main`
- the built standalone site loads from a local HTTP server
- the query catalog renders
- the `Neighborhood` query opens with a populated node selector
- the tours panel renders the tutorial list
- the `How Cardano Governance Works` tour starts and renders its first step

The only runtime issue seen in the local smoke test was the existing missing `favicon.ico` 404.

## Files to review

Start here:
- `flake.nix`
- `flake.lock`
- `data/config.json`
- `data/queries.json`
- `data/rdf/graph.ttl`
- `data/rdf/core-ontology.ttl`

## Reviewer guide

The important thing to evaluate is not the formatting of the Turtle diff but whether the downstream repo is now internally consistent with the merged upstream behavior:
- config declares multiple runtime RDF sources instead of relying on concatenation
- graph data no longer depends on removed legacy gb semantic predicates
- neighborhood navigation still works without `gb:EdgeAssertion`
- ontology and Cardano vocabulary are both present in the runtime dataset
- tours still resolve the same node ids

Once this lands, `cardano-knowledge-maps` will be using the merged upstream multi-source RDF input feature on `main` instead of carrying a temporary branch pin.
