### PR TITLE
fix: load all RDF sources via graphSources

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -2,10 +2,12 @@
   "title": "Cardano Knowledge Maps",
   "description": "Interactive knowledge maps of the Cardano ecosystem — governance, smart contracts, and more.",
   "sourceUrl": "https://github.com/lambdasistemi/cardano-knowledge-maps",
-  "graphSource": {
-    "format": "text/turtle",
-    "path": "data/rdf/graph.ttl"
-  },
+  "graphSources": [
+    { "format": "text/turtle", "path": "data/rdf/graph.ttl" },
+    { "format": "text/turtle", "path": "data/rdf/cardano.ttl" },
+    { "format": "text/turtle", "path": "data/rdf/core-ontology.ttl" },
+    { "format": "text/turtle", "path": "data/rdf/application-ontology.ttl" }
+  ],
   "kinds": {
     "actor": {
       "label": "Actor",


### PR DESCRIPTION
Closes #31

## Summary

Switch `config.json` from singular `graphSource` (only `graph.ttl`) to `graphSources` array that loads all four TTL files into the Oxigraph store:

1. `graph.ttl` — instance data (nodes, edges with `gb:` predicates)
2. `cardano.ttl` — domain ontology (`cardano:` OWL classes and properties)
3. `core-ontology.ttl` — graph-browser core vocabulary (`gb:` terms)
4. `application-ontology.ttl` — application vocabulary (`gbkind:`, `gbedge:`, etc.)

Without `cardano.ttl` in the store, every SPARQL query using `cardano:` types (all governance, smart contract, and domain queries) returned zero results.

## Preview

https://ckm-multi-source-pr34.surge.sh

## Test plan

- [ ] Verify queries return results on surge preview
- [ ] Check both governance and smart contract views populate
- [ ] Ontology views (class hierarchy, properties) also work