### PR TITLE
fix: drop ontology vocabulary files from graphSources

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -4,9 +4,7 @@
   "sourceUrl": "https://github.com/lambdasistemi/cardano-knowledge-maps",
   "graphSources": [
     { "format": "text/turtle", "path": "data/rdf/graph.ttl" },
-    { "format": "text/turtle", "path": "data/rdf/cardano.ttl" },
-    { "format": "text/turtle", "path": "data/rdf/core-ontology.ttl" },
-    { "format": "text/turtle", "path": "data/rdf/application-ontology.ttl" }
+    { "format": "text/turtle", "path": "data/rdf/cardano.ttl" }
   ],
   "kinds": {
     "actor": {


### PR DESCRIPTION
Hotfix for #31 — the `core-ontology.ttl` and `application-ontology.ttl` files define graph-browser's own OWL classes (`gb:Node`, `gb:EdgeAssertion`, kind classes, etc.). Loading them into graphSources causes the ontology extractor to create graph nodes for every OWL class, drowning the actual instance data.

The surge preview only had `graph.ttl` + `cardano.ttl` and worked correctly. I then added the two extra files before committing, which broke the deployed Pages version.

This reverts to the two-file configuration that was verified on surge.

## Preview

https://ckm-multi-source-pr34.surge.sh (this was the working surge with 2 sources)