### PR TITLE
feat: publish cardano ontology namespace

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,6 +23,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: lambdasistemi/graph-browser/validate-action@main
       - uses: lambdasistemi/graph-browser/build-action@main
+      - uses: lambdasistemi/graph-browser/vocab-publish-action@main
+        with:
+          sources: data/rdf/cardano.ttl
+          output-dir: site
+          site-base-path: /cardano-knowledge-maps
       - uses: actions/upload-pages-artifact@v4
         with:
           path: site


### PR DESCRIPTION
Closes #33

## Summary

Adds `vocab-publish-action` step to the Pages workflow. Generates `/vocab/cardano` from `data/rdf/cardano.ttl` so term IRIs like `/vocab/cardano#GovernanceAction` resolve to a namespace document with anchored term definitions.

## Changes

- `.github/workflows/pages.yml`: add `vocab-publish-action@main` between `build-action` and `upload-pages-artifact`

## Test plan

- [ ] CI passes
- [ ] After merge, verify `https://lambdasistemi.github.io/cardano-knowledge-maps/vocab/cardano` resolves
- [ ] Fragment IRIs like `#GovernanceAction`, `#DRep` scroll to anchors