### PR TITLE
refactor: migrate to standard RDF predicates

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -4,9 +4,7 @@
   "sourceUrl": "https://github.com/lambdasistemi/cardano-knowledge-maps",
   "graphSources": [
     { "format": "text/turtle", "path": "data/rdf/graph.ttl" },
-    { "format": "text/turtle", "path": "data/rdf/cardano.ttl" },
-    { "format": "text/turtle", "path": "data/rdf/core-ontology.ttl" },
-    { "format": "text/turtle", "path": "data/rdf/application-ontology.ttl" }
+    { "format": "text/turtle", "path": "data/rdf/cardano.ttl" }
   ],
   "kinds": {
     "actor": {

--- a/data/rdf/cardano.ttl
+++ b/data/rdf/cardano.ttl
@@ -504,59 +504,8 @@ gbkind:protocol      owl:equivalentClass  cardano:DApp .
 gbkind:runtime       owl:equivalentClass  cardano:SmartContractRuntime .
 gbkind:standard      owl:equivalentClass  cardano:CIP .
 
-# ==============================================================================
-# Alignment — bridge gbedge: properties to cardano: properties
-# ==============================================================================
-
-gbedge:votes%20on                       owl:equivalentProperty cardano:votesOn .
-gbedge:evaluates%20and%20votes%20on     owl:equivalentProperty cardano:evaluatesAndVotesOn .
-gbedge:delegates%20voting%20power%20to  owl:equivalentProperty cardano:delegatesVotingPowerTo .
-gbedge:delegates%20stake%20to           owl:equivalentProperty cardano:delegatesStakeTo .
-gbedge:submits                          owl:equivalentProperty cardano:submits .
-gbedge:constrains                       owl:equivalentProperty cardano:constrains .
-gbedge:evaluates%20actions%20against    owl:equivalentProperty cardano:evaluatesAgainst .
-gbedge:leads%20to                       owl:equivalentProperty cardano:leadsTo .
-gbedge:requires                         owl:equivalentProperty cardano:requires .
-gbedge:subject%20to                     owl:equivalentProperty cardano:subjectTo .
-gbedge:can%20delegate%20to             owl:equivalentProperty cardano:canDelegateTo .
-gbedge:can%20register%20as             owl:equivalentProperty cardano:canRegisterAs .
-gbedge:changes%20membership%20of       owl:equivalentProperty cardano:changesMembershipOf .
-gbedge:puts%20into%20no-confidence%20state  owl:equivalentProperty cardano:putsIntoNoConfidenceState .
-gbedge:codified%20in                   owl:equivalentProperty cardano:codifiedIn .
-gbedge:modifies%20voting%20for         owl:equivalentProperty cardano:modifiesVotingFor .
-gbedge:belongs%20to                    owl:equivalentProperty cardano:belongsToGroup .
-gbedge:can%20change                    owl:equivalentProperty cardano:canChange .
-gbedge:affects                         owl:equivalentProperty cardano:affects .
-gbedge:compiles%20to                   owl:equivalentProperty cardano:compilesTo .
-gbedge:evaluated%20by                  owl:equivalentProperty cardano:evaluatedBy .
-gbedge:priced%20by                     owl:equivalentProperty cardano:pricedBy .
-gbedge:built%20on                      owl:equivalentProperty cardano:builtOn .
-gbedge:written%20in                    owl:equivalentProperty cardano:writtenIn .
-gbedge:builds%20transactions%20for     owl:equivalentProperty cardano:buildsTransactionsFor .
-gbedge:indexes                         owl:equivalentProperty cardano:indexes .
-gbedge:specifies                       owl:equivalentProperty cardano:specifies .
-gbedge:implemented%20in                owl:equivalentProperty cardano:implementedIn .
-gbedge:enables                         owl:equivalentProperty cardano:enables .
-gbedge:facilitates                     owl:equivalentProperty cardano:facilitates .
-gbedge:documents                       owl:equivalentProperty cardano:documents .
-gbedge:succeeds                        owl:equivalentProperty cardano:succeeds .
-
-gbedge:profile%20follows               owl:equivalentProperty cardano:profileFollows .
-gbedge:renders%20profiles%20from       owl:equivalentProperty cardano:rendersProfilesFrom .
-gbedge:unifies%20script%20types%20in   owl:equivalentProperty cardano:unifiesScriptTypesIn .
-gbedge:adds%20built-ins%20to           owl:equivalentProperty cardano:addsBuiltInsTo .
-gbedge:optimizes                       owl:equivalentProperty cardano:optimizes .
-gbedge:registers%20metadata%20for      owl:equivalentProperty cardano:registersMetadataFor .
-
-# Edges that map directly to standard vocabulary properties
-gbedge:is%20a%20type%20of             owl:equivalentProperty rdfs:subClassOf .
-gbedge:contains                        owl:equivalentProperty skos:member .
-gbedge:some%20params%20are            owl:equivalentProperty skos:related .
-gbedge:extends                         owl:equivalentProperty dcterms:requires .
-gbedge:uses                            owl:equivalentProperty prov:used .
-gbedge:generates                       owl:equivalentProperty prov:generated .
-gbedge:improves                        owl:equivalentProperty dcterms:relation .
-gbedge:consumes                        owl:equivalentProperty prov:used .
+# Note: owl:equivalentProperty mappings removed — graph.ttl now uses
+# cardano: and standard predicates directly (see #35).
 
 # ==============================================================================
 # Instance typing — give existing nodes their cardano: types

--- a/data/rdf/graph.ttl
+++ b/data/rdf/graph.ttl
@@ -1,2685 +1,2545 @@
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/128> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-88 provides a standard for declaring token metadata linked to a minting policy, enabling verifiable token information." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "registers metadata for" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#registers%20metadata%20for> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-88> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 128 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-88> <https://lambdasistemi.github.io/graph-browser/vocab/edges#registers%20metadata%20for> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/127> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-85 replaces Scott-encoded data with native sums-of-products in Plutus Core, reducing script size and execution cost." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "optimizes" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#optimizes> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-85> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 127 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-85> <https://lambdasistemi.github.io/graph-browser/vocab/edges#optimizes> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/126> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-381 adds BLS12-381 curve operations as Plutus Core built-in functions for on-chain cryptographic verification." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "adds built-ins to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#adds%20built-ins%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-381> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 126 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-381> <https://lambdasistemi.github.io/graph-browser/vocab/edges#adds%20built-ins%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/125> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-69 unifies the argument interface across all Plutus script purposes, enabling multi-purpose validators." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "unifies script types in" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#unifies%20script%20types%20in> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-69> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 125 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-69> <https://lambdasistemi.github.io/graph-browser/vocab/edges#unifies%20script%20types%20in> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/124> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "GovTool reads and displays DRep profile metadata structured according to CIP-119." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "renders profiles from" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#renders%20profiles%20from> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-119> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 124 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> <https://lambdasistemi.github.io/graph-browser/vocab/edges#renders%20profiles%20from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-119> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/123> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "DReps publish their profile metadata following CIP-119, enabling voters to discover and evaluate representatives through governance tools." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "profile follows" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#profile%20follows> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-119> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 123 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> <https://lambdasistemi.github.io/graph-browser/vocab/edges#profile%20follows> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-119> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/122> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-119 builds on CIP-100's base governance metadata format, adding DRep-specific fields like display name, bio, motivations, and qualifications." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "extends" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-100> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-119> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 122 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-119> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-100> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/121> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Mesh SDK uses CIP-30 to interact with browser-based Cardano wallets." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "uses" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-30> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 121 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-30> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/120> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Lucid Evolution uses CIP-30 to connect to browser wallets for transaction signing and submission." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "uses" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-30> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 120 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-30> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/119> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-95 extends the CIP-30 wallet connector with Conway-era governance capabilities: DRep registration, vote delegation, and governance action submission." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "extends" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-30> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-95> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 119 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-95> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-30> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/118> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Lucid can auto-generate off-chain bindings from CIP-57 Plutus blueprints." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "consumes" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#consumes> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 118 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> <https://lambdasistemi.github.io/graph-browser/vocab/edges#consumes> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/117> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Demeter provides cloud infrastructure for developing, testing, and deploying Plutus-based dApps." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "hosts infrastructure for" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#hosts%20infrastructure%20for> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/demeter> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 117 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/demeter> <https://lambdasistemi.github.io/graph-browser/vocab/edges#hosts%20infrastructure%20for> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/116> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Blockfrost indexes the UTxO set and provides REST APIs for querying chain state, script datums, and transaction history." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "indexes" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#indexes> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 116 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost> <https://lambdasistemi.github.io/graph-browser/vocab/edges#indexes> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/115> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Mesh SDK provides high-level TypeScript APIs for building transactions that interact with smart contracts." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "builds transactions for" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#builds%20transactions%20for> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 115 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk> <https://lambdasistemi.github.io/graph-browser/vocab/edges#builds%20transactions%20for> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/114> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Lucid Evolution constructs off-chain transactions that interact with Plutus validators, handling datum/redeemer serialization." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "builds transactions for" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#builds%20transactions%20for> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 114 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> <https://lambdasistemi.github.io/graph-browser/vocab/edges#builds%20transactions%20for> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/113> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Djed stablecoin uses Plutus validators with formally verified peg stability properties." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "built on" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#built%20on> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/djed> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 113 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/djed> <https://lambdasistemi.github.io/graph-browser/vocab/edges#built%20on> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/112> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Hydra L2 heads replicate the full EUTxO model off-chain with the same smart contract semantics." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "replicates" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#replicates> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 112 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra> <https://lambdasistemi.github.io/graph-browser/vocab/edges#replicates> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/111> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Liqwid uses Plutarch for performance-critical lending/borrowing validators." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "written in" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#written%20in> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liqwid> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 111 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liqwid> <https://lambdasistemi.github.io/graph-browser/vocab/edges#written%20in> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/110> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Minswap V2 validators are written in Aiken for production-grade AMM DEX." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "written in" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#written%20in> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 110 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap> <https://lambdasistemi.github.io/graph-browser/vocab/edges#written%20in> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/109> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Aiken automatically generates CIP-57 Plutus blueprints from contract source code." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "generates" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#generates> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 109 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> <https://lambdasistemi.github.io/graph-browser/vocab/edges#generates> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/108> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-57 blueprints provide machine-readable interface documentation for Plutus contracts." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "documents" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#documents> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 108 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57> <https://lambdasistemi.github.io/graph-browser/vocab/edges#documents> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/107> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-68 is the successor to CIP-25, adding mutability and richer metadata capabilities." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "succeeds" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#succeeds> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 107 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68> <https://lambdasistemi.github.io/graph-browser/vocab/edges#succeeds> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/106> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-68 stores rich metadata in UTxO datums, enabling mutable token metadata." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "uses" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 106 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/105> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-25 defines how NFT metadata is attached to minting transactions via label 721." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "extends" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 105 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/104> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Oracles publish data in UTxO datums; consumers read via reference inputs without contention." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "uses" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 104 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/103> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "State machines store contract state in the datum, with validators enforcing valid transitions." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "uses" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 103 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/102> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The withdraw-zero pattern reduces validation cost from O(n²) to O(n) by consolidating logic in a staking validator." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "optimizes" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#optimizes> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/staking-validator> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 102 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/staking-validator> <https://lambdasistemi.github.io/graph-browser/vocab/edges#optimizes> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/101> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Marlowe financial contracts compile to Plutus Core validators with formal verification guarantees." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "compiles to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 101 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/100> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "plu-ts constructs UPLC AST directly in TypeScript." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "compiles to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plu-ts> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 100 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plu-ts> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/99> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Plutarch generates UPLC with fine-grained control, producing highly optimized validators." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "compiles to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 99 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/98> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Scalus compiles Scala 3 to UPLC with compile-time partial evaluation." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "compiles to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 98 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/97> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Helios compiles its TypeScript-embedded DSL to Plutus Core." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "compiles to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/helios> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 97 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/helios> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/96> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "OpShin compiles Python syntax to UPLC, enforcing a strict type system at compile time." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "compiles to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 96 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/95> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Plinth (formerly PlutusTx) compiles a Haskell subset to Plutus Core via GHC plugin." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "compiles to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 95 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/94> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Aiken compiles directly to UPLC (Untyped Plutus Core) with aggressive optimization passes." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "compiles to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 94 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/93> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Parameter changes can modify ExUnits prices, changing how much ada scripts cost to run." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "affects" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#affects> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 93 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> <https://lambdasistemi.github.io/graph-browser/vocab/edges#affects> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/92> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Parameter change governance actions can update cost model values, affecting smart contract execution costs." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "can modify" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20modify> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 92 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20modify> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/91> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The on-chain guardrails script is a Plutus validator that enforces constitutional rules on governance parameter changes." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "written in" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#written%20in> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 91 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> <https://lambdasistemi.github.io/graph-browser/vocab/edges#written%20in> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/90> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Minting policies are Plutus scripts that control native token creation and destruction." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "type of" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#type%20of> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 90 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> <https://lambdasistemi.github.io/graph-browser/vocab/edges#type%20of> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/89> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Inline datums store the full datum in the UTxO, eliminating off-chain datum management." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "improves" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#improves> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/inline-datums> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 89 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/inline-datums> <https://lambdasistemi.github.io/graph-browser/vocab/edges#improves> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/88> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Reference inputs add read-only UTxO access to the EUTxO model, enabling oracle and shared state patterns." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "extends" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 88 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/87> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Reference scripts reduce costs by allowing scripts to be stored on-chain once and reused across transactions." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "optimizes" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#optimizes> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 87 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts> <https://lambdasistemi.github.io/graph-browser/vocab/edges#optimizes> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/86> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The EUTxO model is what makes Plutus smart contracts possible — validators receive datum, redeemer, and context." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "enables" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#enables> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 86 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> <https://lambdasistemi.github.io/graph-browser/vocab/edges#enables> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/85> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The script context gives validators full visibility into the transaction being validated." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "provides" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#provides> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 85 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context> <https://lambdasistemi.github.io/graph-browser/vocab/edges#provides> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/84> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Redeemers provide the action/input mechanism for EUTxO script validation." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "extends" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/redeemer> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 84 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/redeemer> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/83> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Datums are the key extension that transforms the UTxO model into EUTxO, enabling stateful contracts." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "extends" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 83 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/82> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Cost model parameters are part of the technical parameter group." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "belongs to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#belongs%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 82 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> <https://lambdasistemi.github.io/graph-browser/vocab/edges#belongs%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/81> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "ExUnits are converted to ada fees using price parameters from the cost model." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "priced by" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#priced%20by> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 81 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> <https://lambdasistemi.github.io/graph-browser/vocab/edges#priced%20by> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/80> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The CEK machine tracks CPU steps and memory units during script evaluation, enforcing ExUnits budgets." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "consumes" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#consumes> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 80 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine> <https://lambdasistemi.github.io/graph-browser/vocab/edges#consumes> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/79> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Plutus Core programs are evaluated by the CEK machine, which tracks resource consumption." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "evaluated by" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluated%20by> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 79 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> <https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluated%20by> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/78> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Plutus Tx (Haskell) compiles to Plutus Core, the on-chain language executed by the CEK machine." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "compiles to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 78 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/77> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The Guardrails Script implements the per-parameter threshold exceptions on-chain. When a Protocol Parameter Change governance action is submitted, the script checks not just the permitted value ranges but also whether the correct voting bodies and thresholds apply for each specific parameter being changed." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "enforces" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#enforces> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 77 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> <https://lambdasistemi.github.io/graph-browser/vocab/edges#enforces> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/76> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Per-parameter threshold exceptions change which bodies vote and at what thresholds for specific parameter changes. For example, committeeMaxTermLength only requires DRep 67% with no CC or SPO vote — a unique exception where the CC is excluded because the parameter directly governs CC member terms, and self-governance would be a conflict of interest." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "modifies voting for" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#modifies%20voting%20for> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 76 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions> <https://lambdasistemi.github.io/graph-browser/vocab/edges#modifies%20voting%20for> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/75> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Some parameters that belong to the Economic or Technical groups are constitutionally elevated to Governance group thresholds (DRep 75% + CC 2/3). This includes dRepDeposit, stakePoolDeposit, stakeAddressDeposit, minPoolCost, and committeeMinSize. The Constitution treats these as governance-critical despite their technical classification." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "overrides thresholds from" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#overrides%20thresholds%20from> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-governance> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 75 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions> <https://lambdasistemi.github.io/graph-browser/vocab/edges#overrides%20thresholds%20from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-governance> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/74> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Info Actions, despite having no direct on-chain effect, are the mechanism for the treasury budgeting process. Net Change Limits and Budget approvals are submitted as Info Actions with effective voting thresholds of DRep 50% + CC 2/3. This repurposes the Info Action type for binding community decisions that gate subsequent Treasury Withdrawals." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "used for" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#used%20for> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 74 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> <https://lambdasistemi.github.io/graph-browser/vocab/edges#used%20for> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/73> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Treasury Withdrawals can only be submitted after a Net Change Limit and Budget have been approved. The Net Change Limit (Info Action, DRep 50% + CC 2/3) sets the maximum withdrawal amount per period. Budget proposals (also Info Actions, DRep 50% + CC 2/3) allocate portions of that limit. Only then can Treasury Withdrawal governance actions be submitted against the approved budget." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "gates" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#gates> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 73 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting> <https://lambdasistemi.github.io/graph-browser/vocab/edges#gates> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/72> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Cost model updates go through Protocol Parameter Change governance: the Plutus team benchmarks builtins, fits cost functions via R scripts, and the new coefficients are submitted as a governance action requiring CC 2/3 and DRep 67% (Technical group threshold)." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "updated via" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#updated%20via> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 72 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> <https://lambdasistemi.github.io/graph-browser/vocab/edges#updated%20via> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/71> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "SanchoNet was a dedicated governance testnet (launched 2023) where the community tested CIP-1694 features before mainnet. It validated the Conway implementation and allowed governance tooling development against a live environment." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "tested" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#tested> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/conway-era> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/sanchonet> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 71 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/sanchonet> <https://lambdasistemi.github.io/graph-browser/vocab/edges#tested> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/conway-era> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/70> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "GovTool provides a web interface for DRep registration and delegation, handling certificate submission and deposit payment without CLI tools." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "enables registration as" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#enables%20registration%20as> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 70 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> <https://lambdasistemi.github.io/graph-browser/vocab/edges#enables%20registration%20as> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/69> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "GovTool connects to wallets via CIP-95 and enables viewing governance actions, reading metadata, and casting votes on-chain. It makes governance accessible to non-technical participants." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "enables" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#enables> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 69 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> <https://lambdasistemi.github.io/graph-browser/vocab/edges#enables> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/68> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The CF evaluates governance actions for constitutional compliance and governance merit through its Governance Advisory Team. It publishes vote rationales and created the Proposal Examiner tool for structured evaluation." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "evaluates and votes on" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluates%20and%20votes%20on> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 68 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation> <https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluates%20and%20votes%20on> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/67> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The CF registered as a DRep to actively participate in governance, bringing institutional expertise and a Governance Advisory Team. It publishes detailed vote rationales, setting a standard for transparent governance engagement." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "registered as" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#registered%20as> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 67 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation> <https://lambdasistemi.github.io/graph-browser/vocab/edges#registered%20as> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/66> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Intersect provides off-chain governance infrastructure: Parameter Committee, CC elections, working groups, hard fork coordination, CIP process, and GovTool. It fills the coordination gap between decentralized on-chain governance and the practical need for organized deliberation." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "facilitates" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#facilitates> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/intersect> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 66 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/intersect> <https://lambdasistemi.github.io/graph-browser/vocab/edges#facilitates> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/65> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-105 specifies how wallets derive governance key pairs (for DRep registration and voting) from a master seed, ensuring keys are recoverable from a mnemonic phrase." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "derives keys for" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#derives%20keys%20for> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-105> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 65 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-105> <https://lambdasistemi.github.io/graph-browser/vocab/edges#derives%20keys%20for> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/64> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-129 defines canonical governance action IDs used across wallets, explorers, and governance tools for consistent cross-tool reference." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "standardizes IDs for" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#standardizes%20IDs%20for> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-129> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 64 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-129> <https://lambdasistemi.github.io/graph-browser/vocab/edges#standardizes%20IDs%20for> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/63> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-129 defines canonical string representations for DRep IDs, ensuring all tools display the same identifier for the same representative." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "standardizes IDs for" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#standardizes%20IDs%20for> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-129> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 63 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-129> <https://lambdasistemi.github.io/graph-browser/vocab/edges#standardizes%20IDs%20for> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/62> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CC members publish structured vote rationales using CIP-136 metadata. This format requires citing specific constitutional articles, creating a public record of constitutional interpretation that builds governance case law." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "publishes rationales via" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#publishes%20rationales%20via> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-136> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 62 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <https://lambdasistemi.github.io/graph-browser/vocab/edges#publishes%20rationales%20via> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-136> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/61> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "GovTool uses CIP-95 to connect to users' browser wallets. CIP-95 extends the CIP-30 wallet connector with governance capabilities: DRep registration, delegation, and voting transactions." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "connects wallets via" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#connects%20wallets%20via> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-95> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 61 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> <https://lambdasistemi.github.io/graph-browser/vocab/edges#connects%20wallets%20via> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-95> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/60> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-108 builds on CIP-100's base metadata format, adding governance-action-specific fields (title, abstract, motivation, rationale). CIP-100 defines the general anchor structure; CIP-108 defines what goes inside it for governance actions." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "extends" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-100> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-108> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 60 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-108> <https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-100> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/59> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Governance action metadata is structured according to CIP-108, which defines required fields: title, abstract, motivation, rationale, and references. This ensures voters have consistent information when evaluating proposals." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "structured as" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#structured%20as> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-108> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 59 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> <https://lambdasistemi.github.io/graph-browser/vocab/edges#structured%20as> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-108> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/58> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Every governance action includes a metadata anchor (URL + hash) following CIP-100's general governance metadata format. The metadata is stored off-chain but its hash is recorded on-chain for integrity verification." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "metadata follows" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#metadata%20follows> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-100> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 58 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> <https://lambdasistemi.github.io/graph-browser/vocab/edges#metadata%20follows> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-100> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/57> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "DRep registration requires 500 ada (refundable on retirement). This prevents spam registrations while keeping registration accessible. The amount is a Governance group protocol parameter changeable with 75% DRep threshold." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "requires" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#requires> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/deposit-mechanism> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 57 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> <https://lambdasistemi.github.io/graph-browser/vocab/edges#requires> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/deposit-mechanism> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/56> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Submitting a governance action requires 100,000 ada (refundable). This anti-spam mechanism prevents frivolous proposals from flooding the chain. The amount is a Governance group parameter, also classified as security-relevant (requires SPO approval to change)." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "requires" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#requires> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/deposit-mechanism> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 56 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> <https://lambdasistemi.github.io/graph-browser/vocab/edges#requires> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/deposit-mechanism> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/55> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CC uses one-member-one-vote with a configurable threshold (currently 2/3). Expired members cannot vote. Minimum committee size is 7 on mainnet. The threshold is changeable via the Update Committee governance action." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "subject to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#subject%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc-threshold> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 55 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <https://lambdasistemi.github.io/graph-browser/vocab/edges#subject%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc-threshold> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/54> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "SPO votes are tallied at 51% of active pool stake for all applicable actions: No-Confidence (Q1), Committee Update (Q2a/Q2b), Hard Fork (Q4), security parameters (Q5), and Info (100% fixed)." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "subject to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#subject%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo-thresholds> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 54 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> <https://lambdasistemi.github.io/graph-browser/vocab/edges#subject%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo-thresholds> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/53> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "DRep votes are tallied against action-type-specific thresholds of active voting stake: No-Confidence 67%, Committee Update 67%/60%, New Constitution 75%, Hard Fork 60%, Network/Economic/Technical params 67%, Governance params 75%, Treasury 67%, Info 100%." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "subject to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#subject%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep-thresholds> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 53 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> <https://lambdasistemi.github.io/graph-browser/vocab/edges#subject%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep-thresholds> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/52> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Conway began with a bootstrap phase where only CC could approve parameter changes and CC + SPOs could approve hard forks. DRep participation was not required. This phased rollout prevented governance deadlocks while DRep registration ramped up. Ended with the Plomin hard fork in December 2024." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "started with" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#started%20with> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/bootstrap-phase> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/conway-era> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 52 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/conway-era> <https://lambdasistemi.github.io/graph-browser/vocab/edges#started%20with> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/bootstrap-phase> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/51> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-1694 was implemented in the Conway ledger era via two phases: Chang #1 (August 2024, bootstrap) and Plomin hard fork (December 2024, full activation). Conway is the current ledger era, representing the Voltaire phase of Cardano's roadmap." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "implemented in" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#implemented%20in> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/conway-era> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-1694> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 51 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-1694> <https://lambdasistemi.github.io/graph-browser/vocab/edges#implemented%20in> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/conway-era> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/50> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-1694 formally specifies the entire on-chain governance mechanism: three bodies, seven action types, voting/ratification rules, CC structure, DRep mechanics, deposits, action chaining, and the full governance lifecycle. It is the authoritative technical specification." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "specifies" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#specifies> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-1694> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 50 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-1694> <https://lambdasistemi.github.io/graph-browser/vocab/edges#specifies> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/49> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The CC forms the third governance body with one-member-one-vote (not stake-weighted). Its role is purely constitutional review. It votes on actions that change protocol rules but not on actions about its own composition, preventing self-dealing." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "governance body" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 49 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/48> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "SPOs form the second governance body, representing the infrastructure layer. They vote on a limited subset: Hard Forks, No-Confidence, Committee Updates, security parameters, and Info. This focused scope ensures operators have voice on matters affecting their operations." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "governance body" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 48 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/47> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "DReps form the first of three governance bodies, representing all ada holders who delegate to them. They vote on all seven action types with stake-weighted voting, providing the democratic legitimacy layer of governance." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "governance body" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 47 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/46> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Cardano's governance combines direct and representative democracy. Ada holders can vote directly (as DReps) or delegate. Delegation is fluid — changeable at any time with immediate effect. This ensures all stake can participate without requiring every holder to be actively engaged." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "implements" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#implements> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liquid-democracy> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 46 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> <https://lambdasistemi.github.io/graph-browser/vocab/edges#implements> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liquid-democracy> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/45> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The sole mechanism for modifying CC membership, terms, and approval threshold. Can add new members with term expirations, remove members, and adjust the approval fraction. Used both for routine updates and to replace a committee in no-confidence state." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "changes membership of" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#changes%20membership%20of> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-update-committee> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 45 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-update-committee> <https://lambdasistemi.github.io/graph-browser/vocab/edges#changes%20membership%20of> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/44> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "When ratified, the CC enters no-confidence state and cannot approve any governance actions. This blocks all action types requiring CC approval. Recovery requires electing a new committee via Update Committee, which has a lower DRep threshold (60% vs 67%) in no-confidence state." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "puts into no-confidence state" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#puts%20into%20no-confidence%20state> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-no-confidence> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 44 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-no-confidence> <https://lambdasistemi.github.io/graph-browser/vocab/edges#puts%20into%20no-confidence%20state> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/43> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Can optionally include a new Guardrails Script hash. This is the only mechanism for updating the enforcement script, ensuring it stays synchronized with constitutional amendments." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "can update" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20update> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 43 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20update> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/42> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The only mechanism for amending the Cardano Constitution. The action includes an anchor to the new text. Requires DRep 75% and CC 2/3 majority. The current Constitution was ratified at the Buenos Aires Constitutional Convention in December 2024." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "modifies" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#modifies> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 42 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> <https://lambdasistemi.github.io/graph-browser/vocab/edges#modifies> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/41> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The Constitution's enforceable rules — particularly Appendix I's parameter ranges and treasury limits — are codified in the on-chain Guardrails Script. The Constitution provides the authoritative rules; the script automates enforcement of the programmatically expressible subset." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "codified in" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#codified%20in> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 41 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution> <https://lambdasistemi.github.io/graph-browser/vocab/edges#codified%20in> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/40> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The Guardrails Script enforces treasury withdrawal limits (TREASURY-01a through TREASURY-04a). This automated enforcement ensures treasury funds cannot be drained beyond constitutional bounds even if sufficient votes are gathered." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "constrains" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#constrains> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 40 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> <https://lambdasistemi.github.io/graph-browser/vocab/edges#constrains> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/39> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The Guardrails Script checks that proposed parameter values fall within permitted ranges from the Constitution's Appendix I. Named guardrails PARAM-01 through PARAM-06a define rules. The script rejects non-compliant transactions before they reach voting." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "constrains" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#constrains> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 39 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> <https://lambdasistemi.github.io/graph-browser/vocab/edges#constrains> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/38> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "govActionDeposit is the only Governance group security-relevant parameter. Currently 100,000 ada, it prevents spam governance actions. SPO approval at Q5 = 51% is required to change it." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "some params are" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#some%20params%20are> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-governance> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 38 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-governance> <https://lambdasistemi.github.io/graph-browser/vocab/edges#some%20params%20are> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/37> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Economic security-relevant parameters: txFeePerByte, txFeeFixed, utxoCostPerByte, minFeeRefScriptCostPerByte. Setting these too low enables denial-of-service via cheap spam transactions. SPO approval at Q5 = 51% is required." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "some params are" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#some%20params%20are> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-economic> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 37 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-economic> <https://lambdasistemi.github.io/graph-browser/vocab/edges#some%20params%20are> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/36> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Network security-relevant parameters: maxBlockBodySize, maxTxSize, maxBlockHeaderSize, maxValueSize, maxBlockExecutionUnits. Changes to these additionally require SPO approval at Q5 = 51%, giving infrastructure operators a veto." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "some params are" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#some%20params%20are> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-network> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 36 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-network> <https://lambdasistemi.github.io/graph-browser/vocab/edges#some%20params%20are> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/35> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Plutus cost models assign abstract CPU and memory costs to each builtin function, calibrated by benchmarking on a reference machine. These are consensus-critical — every node must compute identical ExUnits. Updates go through the Technical group governance threshold." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "contains" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#contains> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 35 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical> <https://lambdasistemi.github.io/graph-browser/vocab/edges#contains> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/34> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Governance group includes all 15 voting thresholds, govActionLifetime, govActionDeposit, dRepDeposit, dRepActivity, committeeMinSize, and committeeMaxTermLength. Changes require the highest DRep threshold at 75% plus CC 2/3, reflecting the self-referential nature of changing governance rules." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "can change" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-governance> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 34 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-governance> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/33> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Technical group includes poolPledgeInfluence, poolRetireMaxEpoch, stakePoolTargetNum, costModels, and collateralPercentage. The costModels parameter determines Plutus builtin pricing. Changes require CC 2/3 and DRep 67%." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "can change" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 33 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/32> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Economic group includes txFeePerByte, txFeeFixed, stakeAddressDeposit, stakePoolDeposit, monetaryExpansion, treasuryCut, minPoolCost, utxoCostPerByte, executionUnitPrices, and minFeeRefScriptCostPerByte. Changes require CC 2/3 and DRep 67%." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "can change" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-economic> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 32 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-economic> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/31> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Network group includes maxBlockBodySize, maxTxSize, maxBlockHeaderSize, maxValueSize, maxTxExecutionUnits, maxBlockExecutionUnits, and maxCollateralInputs. Changes require CC 2/3 and DRep 67%. Several are security-relevant, additionally requiring SPO 51%." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "can change" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-network> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 31 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-network> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/30> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Info Action has no on-chain effect and uses a fixed 100% threshold. It records community sentiment and polls stakeholders before committing to binding actions. Does not require action chaining." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "is a type of" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 30 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/29> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Treasury Withdrawal disburses ada from the treasury. Requires CC 2/3 and DRep 67%. Does not require action chaining, allowing multiple independent withdrawals to proceed concurrently." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "is a type of" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 29 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/28> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Protocol Parameter Changes modify one or more of ~30 updatable parameters in four groups (Network, Economic, Technical, Governance). Each group has its own DRep threshold. Security-relevant parameters additionally require SPO approval." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "is a type of" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 28 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/27> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Hard Fork Initiation is the only action requiring all three bodies: CC 2/3, DReps 60%, SPOs 51%. It specifies a new major protocol version. A ratified hard fork delays all other pending ratifications." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "is a type of" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 27 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/26> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "New Constitution / Guardrails Script requires the highest DRep threshold at 75% plus CC 2/3 majority. SPOs do not vote. It can update both the Constitution text and the automated enforcement script." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "is a type of" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 26 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/25> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Update Committee can add/remove CC members, set term expirations, and adjust the CC threshold. The CC does not vote. Thresholds differ by CC state: normal DRep 67% + SPO 51%; no-confidence DRep 60% + SPO 51%." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "is a type of" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-update-committee> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 25 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-update-committee> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/24> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Motion of No-Confidence is the highest-priority action type. It requires DRep 67% and SPO 51%. The CC does not vote. When ratified, it blocks the CC from participating until a new committee is elected." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "is a type of" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-no-confidence> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 24 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-no-confidence> <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/23> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Most action types (except Treasury and Info) must reference the most recently enacted action of the same type. This prevents conflicting same-type actions from both ratifying when they assume incompatible starting states." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "uses" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-chaining> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 23 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-chaining> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/22> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Accumulated votes determine whether an action meets its thresholds. At each epoch boundary, a fresh tally is calculated using the current stake snapshot. An action is ratified when all required thresholds are simultaneously met." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "determines" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#determines> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ratification> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 22 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting> <https://lambdasistemi.github.io/graph-browser/vocab/edges#determines> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ratification> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/21> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Once submitted, a governance action is immediately available for voting. DRep and SPO votes are stake-weighted; CC votes are one-member-one-vote. Votes can be changed at any time before ratification. Registered stake that did not vote counts as 'No'." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "open for" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#open%20for> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 21 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> <https://lambdasistemi.github.io/graph-browser/vocab/edges#open%20for> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/20> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Ratified actions are enacted at the next epoch boundary. There is always at least a one-epoch gap. If a high-priority action (No-Confidence, Committee Update, New Constitution, or Hard Fork) is ratified, it delays ratification of all other pending actions until after its enactment." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "leads to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#leads%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/enactment> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ratification> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 20 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ratification> <https://lambdasistemi.github.io/graph-browser/vocab/edges#leads%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/enactment> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/19> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Every governance action enters ratification for up to govActionLifetime epochs (currently 6 / ~30 days). Ratification is checked only at epoch boundaries. An action can become ratified without new votes if delegation changes shift the stake distribution." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "undergoes" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#undergoes> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ratification> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 19 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> <https://lambdasistemi.github.io/graph-browser/vocab/edges#undergoes> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ratification> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/18> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CC members use a hot/cold key credential system. The cold key is the member's identity, kept offline. The hot key is used for day-to-day voting. If compromised, the hot key can be rotated without changing the member's identity or requiring a Committee Update governance action." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "uses" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hot-cold-keys> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 18 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hot-cold-keys> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/17> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The CC's sole mandate is constitutional review — it evaluates whether governance actions comply with the Cardano Constitution. The CC does NOT assess merit or desirability; it only checks constitutionality. CC members cite specific articles when publishing vote rationales via CIP-136." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "evaluates actions against" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluates%20actions%20against> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 17 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluates%20actions%20against> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/16> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The CC can vote on Info actions to signal its position. CC members may use CIP-136 metadata to cite specific constitutional articles in their vote rationale, providing constitutional analysis even on non-binding proposals." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "votes on" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 16 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/15> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The CC reviews treasury withdrawals for constitutional compliance, including requirements that withdrawals specify purpose, expected costs, and provide for auditable accounts. CC approval at 2/3 is required alongside DRep approval at 67%." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "votes on" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 15 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/14> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The CC reviews parameter changes for constitutional compliance, particularly against Appendix I which defines permitted parameter ranges. CC approval at 2/3 majority is required for all parameter groups." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "votes on" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 14 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/13> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The CC reviews hard fork proposals for constitutional compliance — whether the upgrade respects tenets on transaction freedom, predictable costs, and backward compatibility. CC approval at 2/3 is required alongside DRep and SPO approval." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "votes on" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 13 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/12> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The CC must approve constitutional amendments because its mandate is ensuring governance actions comply with the Constitution. CC approval at 2/3 majority is required alongside the highest DRep threshold (75%)." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "votes on" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 12 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/11> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "SPOs can vote on Info actions to signal their position on community proposals. Since Info actions have no on-chain effect and use a fixed 100% threshold, SPO votes serve purely as a gauge of infrastructure operator sentiment." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "votes on" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 11 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/10> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Security-relevant parameters (maxBlockBodySize, maxTxSize, txFeePerByte, etc.) directly affect node resource requirements. SPO approval at Q5 = 51% gives infrastructure operators a veto over modifications that could make block production uneconomical or destabilize the network." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "votes on changes to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on%20changes%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 10 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on%20changes%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/9> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Hard Fork Initiation requires approval from all three bodies. SPOs must approve at Q4 = 51% because they must actually upgrade their node software. Guardrail HARDFORK-04a requires at least 85% of stake pools to have upgraded before enactment." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "votes on" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 9 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/8> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "SPOs vote on Committee Updates because the CC's role in ratifying hard forks and security parameter changes directly affects node operators. SPO approval at Q2a/Q2b = 51% is required." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "votes on" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-update-committee> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 8 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-update-committee> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/7> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "SPOs vote on Motions of No-Confidence because a dysfunctional CC could block critical protocol upgrades. SPO approval at Q1 = 51% is required alongside DRep approval at 67%." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "votes on" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-no-confidence> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 7 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-no-confidence> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/6> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "DReps vote Yes, No, or Abstain on all seven types of governance actions. Their vote weight equals the total lovelace delegated to them. DReps must vote regularly or become inactive after the dRepActivity period (currently 20 epochs / 100 days)." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "votes on" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 6 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/5> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Any ada holder can register as a DRep by paying a refundable dRepDeposit (currently 500 ada). Self-delegation means the holder votes with their own stake weight. This is the 'direct democracy' path in Cardano's liquid democracy model." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "can register as" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20register%20as> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 5 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20register%20as> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/4> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Any ada holder can submit a governance action on-chain by paying the govActionDeposit (currently 100,000 ada, refundable). The submitter must include a metadata anchor following CIP-100/CIP-108 standards and, for most action types, a reference to the most recently enacted action of the same type." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "submits" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#submits> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 4 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> <https://lambdasistemi.github.io/graph-browser/vocab/edges#submits> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/3> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Ada holders delegate stake to stake pools for block production via Ouroboros Praos. This is separate from DRep delegation — ada holders independently choose who produces blocks and who votes on governance. The pool's total stake also determines the SPO's governance voting weight." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "delegates stake to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#delegates%20stake%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 3 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> <https://lambdasistemi.github.io/graph-browser/vocab/edges#delegates%20stake%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Ada holders who distrust the current governance state can delegate to No Confidence. This stake IS counted in the active voting stake and automatically votes 'Yes' on every Motion of No-Confidence and 'No' on all other governance actions." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "can delegate to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20delegate%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/no-confidence-option> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 2 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20delegate%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/no-confidence-option> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Ada holders who do not wish to participate in governance can delegate to the pre-defined Abstain option. Stake delegated to Abstain is excluded from the active voting stake denominator, meaning it neither helps nor blocks ratification of any governance action." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "can delegate to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20delegate%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/abstain-option> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 1 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20delegate%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/abstain-option> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/edge/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Under CIP-1694's liquid democracy model, ada holders delegate their voting power to any registered DRep. The delegated stake counts toward the DRep's vote weight on governance actions. Unlike stake pool delegation, DRep delegation takes effect immediately with no two-epoch lag and can be changed at any time." ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "delegates voting power to" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#predicate> <https://lambdasistemi.github.io/graph-browser/vocab/edges#delegates%20voting%20power%20to> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#from> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeIndex> 0 ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#EdgeAssertion> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> <https://lambdasistemi.github.io/graph-browser/vocab/edges#delegates%20voting%20power%20to> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://gov.tools"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GovTool" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.cardano.org/about-cardano/governance-overview"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Voting (docs.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/voting> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Each governance body votes Yes, No, or Abstain on applicable governance actions. Votes are recorded on-chain via transactions. DRep and SPO votes are weighted by delegated stake; CC votes are one-member-one-vote. Votes can be changed at any time before the action is ratified. The voting period lasts up to govActionLifetime epochs (currently 6 epochs / ~30 days). Abstain votes are NOT counted in the active voting stake denominator. Post-bootstrap: ada holders must delegate to a DRep (or Abstain/No Confidence) to withdraw staking rewards." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#lifecycle> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Voting" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "voting" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#process> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/cardano-foundation/cardano-org/tree/main/src/data"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CF Chart Data (source)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cardano.org/insights/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Action Charts" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/treasury-budgeting> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Treasury withdrawals follow a multi-step budgeting process defined by the Cardano Constitution. First, a Net Change Limit must be approved via an Info Action (DRep 50% + CC 2/3) to set the maximum amount that can be withdrawn in a period. Then, individual Budget proposals are approved (also Info Actions with DRep 50% + CC 2/3). Only after both are in place can Treasury Withdrawal governance actions be submitted against the approved budget. This layered process prevents unchecked treasury spending." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#lifecycle> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Treasury Budgeting Process" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "treasury-budgeting" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#process> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/input-output-hk/plutus-pioneer-program"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Plutus Pioneer: State Machines" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://scalus.org/docs/design-patterns"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Scalus: State Machines" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/Anastasia-Labs/design-patterns"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Design Patterns" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/state-machine> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Model contract state as a datum on a UTxO. The validator checks that input datum + redeemer produces a valid output datum, enforcing legal state transitions. Used for multi-step protocols: escrow, auctions, governance, DEX order matching." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "State Machine Pattern" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "state-machine" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/staking-validator> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/staking-validator/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/staking-validator/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://anastasia-labs.com/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Anastasia Labs" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/staking-validator> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/staking-validator/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/staking-validator/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/Anastasia-Labs/design-patterns"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Withdraw Zero Pattern" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/staking-validator> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Validators attached to staking credentials. The \"withdraw zero\" pattern delegates expensive validation logic to a staking validator (called once per transaction) instead of a spending validator (called per input), reducing cost from O(n²) to O(n). Key optimization pattern." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Staking Validators" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "staking-validator" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo-thresholds> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo-thresholds/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo-thresholds/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-1694#ratification"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-1694 — Ratification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo-thresholds> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "SPO thresholds are expressed as a fraction of active pool stake. SPOs only vote on specific action types. Current mainnet values: No-Confidence (Q1) = 51%, Committee Update normal (Q2a) = 51%, Committee Update no-confidence (Q2b) = 51%, Hard Fork (Q4) = 51%, Security-relevant params (Q5) = 51%, Info = 100% (fixed). SPOs do NOT vote on: New Constitution, non-security parameter changes, or Treasury Withdrawals." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#thresholds> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "SPO Voting Thresholds" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "spo-thresholds" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-model/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Model (developers.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/spo> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Block producers who also participate in governance voting. SPOs vote on a specific subset of governance action types: No Confidence motions, Committee updates, Hard Fork Initiation, security-relevant protocol parameter changes, and Info actions. Their voting power is proportional to the total stake delegated to their pool. SPOs implement approved protocol upgrades (hard forks) on their infrastructure." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actors> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Stake Pool Operator (SPO)" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "spo" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#actor> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-1694"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-1694 — Security-relevant parameters" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/security-params> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "A subset of protocol parameters that additionally require SPO approval (at Q5 = 51% threshold) when changed. These parameters directly affect network security and node operator costs. The list: maxBlockBodySize, maxTxSize, maxBlockHeaderSize, maxValueSize, maxBlockExecutionUnits, txFeePerByte, txFeeFixed, utxoCostPerByte, govActionDeposit, minFeeRefScriptCostPerByte. This gives SPOs a veto over changes that could destabilize the network or make block production uneconomical." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#parameters> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Security-Relevant Parameters" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "security-params" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://plutus.cardano.intersectmbo.org/docs/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Plutus Ledger API" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://aiken-lang.org/fundamentals/getting-started"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Aiken ScriptContext" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/smart-contracts/plutus/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Script Context Reference" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/script-context> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The full transaction context passed to a Plutus validator. Includes all inputs, outputs, minting, certificates, withdrawals, validity range, signatories, and datum map. Scripts can inspect any part of the transaction to enforce arbitrary conditions." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Script Context" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "script-context" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://scalus.org/docs/design-patterns"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Design Patterns" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/scalus3/scalus"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://scalus.org/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Scalus" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/scalus> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Write smart contracts in Scala 3, compiled to UPLC. Runs on JVM, JS, and Native. UPLC optimizer with compile-time partial evaluation produces competitive script sizes. Full ScalaTest/ScalaCheck support for property-based testing." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#languages> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Scalus" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "scalus" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#language> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/sanchonet> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/sanchonet/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/sanchonet/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://sancho.network"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "SanchoNet" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/sanchonet> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "A dedicated governance testnet for experimenting with CIP-1694 features. Launched in 2023, it allowed the community to test DRep registration, voting, governance action submission, and the full lifecycle before Conway went live on mainnet. Named after Sancho Panza (Don Quixote's practical companion)." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#ecosystem> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "SanchoNet" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "sanchonet" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#tool> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.cardano.org/about-cardano/evolution/upgrades/vasil/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Vasil Upgrade" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/smart-contracts/plutus/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Developer Guide" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0033"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-33" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-scripts> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-33 feature allowing scripts to be stored on-chain in a UTxO and referenced by transactions without including the script in the transaction body. Dramatically reduces transaction size and fees for popular contracts. The reference script UTxO is not spent." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Reference Scripts" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "reference-scripts" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/Anastasia-Labs/design-patterns"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Oracle Pattern with Ref Inputs" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/smart-contracts/plutus/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Developer Guide" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0031"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-31" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/reference-inputs> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-31 feature allowing transactions to read UTxOs without spending them. Enables oracle patterns, shared state, and read-only access to on-chain data. Referenced UTxOs appear in the script context but remain unspent." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Reference Inputs" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "reference-inputs" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/redeemer> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/redeemer/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/redeemer/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://aiken-lang.org/fundamentals/getting-started"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Aiken Tutorial" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/redeemer> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/redeemer/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/redeemer/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/smart-contracts/plutus/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Datums and Redeemers" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/redeemer> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "User-provided data included in a transaction to unlock a script-locked UTxO. The redeemer represents the action the user wants to perform. The validator script receives the datum, redeemer, and script context and decides whether to allow the spending." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Redeemer" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "redeemer" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ratification> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ratification/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ratification/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-1694#ratification"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-1694 — Ratification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ratification> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The process by which a governance action accumulates enough votes to be approved. Ratification is checked ONLY at epoch boundaries — a new tally is calculated each epoch using the current stake snapshot. An action can become ratified even without new votes if delegation changes shift the stake distribution. Votes can be changed at any time before ratification. Registered stake that did not vote counts as 'No'. Unregistered stake counts as 'Abstain'. Each action type has specific thresholds for each governance body. A successful No-Confidence, Committee Update, New Constitution, or Hard Fork delays ratification of ALL other pending actions until after enactment." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#lifecycle> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Ratification" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "ratification" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#process> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://plutus.cardano.intersectmbo.org/docs/reference/cardano/plutus-core-builtins-ref/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Built-in Functions Reference" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/IntersectMBO/plutus"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://plutus.cardano.intersectmbo.org/resources/plutus-core-spec.pdf"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Plutus Core Spec" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus-core> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The low-level language that Plutus scripts compile to. An untyped lambda calculus with built-in functions for cryptography, arithmetic, and data manipulation. Executed by the CEK machine on-chain. Each built-in function has an associated cost in CPU and memory units defined by the cost model." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Plutus Core" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "plutus-core" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#runtime> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus/link/3> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus/link/3> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://plutus.cardano.intersectmbo.org/resources/plutus-core-spec.pdf"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Plutus Core Spec" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/smart-contracts/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Developer Portal" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/input-output-hk/plutus-pioneer-program"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Plutus Pioneer Program" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://plutus.cardano.intersectmbo.org/docs/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Plutus Documentation" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutus> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The native smart contract platform for Cardano. Plutus scripts are written in PureScript-like Haskell, compiled to Plutus Core (an untyped lambda calculus), and executed on-chain by the Plutus evaluator. Scripts validate transactions — they receive a datum, redeemer, and script context, returning true or false." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Plutus" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "plutus" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/Plutonomicon/plutonomicon"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Plutonomicon" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/Plutonomicon/plutarch-plutus"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plutarch> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Haskell eDSL giving fine-grained control over generated UPLC. Produces significantly more efficient validators than PlutusTx. Created by Liqwid Labs / MLabs. Used by several high-TVL protocols for performance-critical validators." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#languages> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Plutarch" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "plutarch" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#language> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plu-ts> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plu-ts/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plu-ts/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/HarmonicLabs/plu-ts"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plu-ts> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plu-ts/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plu-ts/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://pluts.harmoniclabs.tech/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Docs" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plu-ts> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "TypeScript-embedded DSL for on-chain smart contracts plus off-chain transaction building. Constructs UPLC AST directly in TypeScript. Single-language stack for JS/TS developers. Maintained by Harmonic Labs." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#languages> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "plu-ts" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "plu-ts" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#language> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/input-output-hk/plutus-pioneer-program"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Pioneer Program" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/IntersectMBO/plutus"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://plutus.cardano.intersectmbo.org/docs/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Plutus Docs" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/plinth> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Write smart contracts in a subset of Haskell, compiled to UPLC. Formerly PlutusTx, rebranded in February 2025. The original on-chain language maintained by IntersectMBO. Tight integration with the Haskell ecosystem and GHC type system." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#languages> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Plinth" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "plinth" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#language> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/CostModelGeneration.md"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Plutus Cost Model Generation" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Protocol Parameters" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-technical> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Protocol parameters related to stake pool mechanics, Plutus execution, and script validation. DRep voting threshold: 67% (P5c). Includes: poolPledgeInfluence (0.1–1.0), poolRetireMaxEpoch, stakePoolTargetNum (250–2,000), costModels (the Plutus cost model parameters — benchmarked values for each builtin function), collateralPercentage (100–200). The costModels parameter is what gets updated when the Plutus team reprices builtins based on new benchmarks." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#parameters> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Technical Parameter Group" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "param-group-technical" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#param-group> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-network> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-network/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-network/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Protocol Parameters" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-network> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Protocol parameters related to network capacity and transaction limits. DRep voting threshold: 67% (P5a). Includes: maxBlockBodySize (24,576–122,880 bytes), maxTxSize (up to 32,768 bytes), maxBlockHeaderSize (up to 5,000 bytes), maxValueSize (up to 12,288 bytes), maxTxExecutionUnits (memory and steps), maxBlockExecutionUnits (memory and steps), maxCollateralInputs (minimum 1). Guardrail NETWORK-01: should not change more than once per 2 epochs. NETWORK-02: only one parameter should change per epoch unless correlated." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#parameters> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Network Parameter Group" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "param-group-network" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#param-group> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-governance> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-governance/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-governance/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Protocol Parameters" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-governance> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Protocol parameters that govern governance itself. DRep voting threshold: 75% (P5d) — the highest threshold for parameter changes, reflecting the self-referential nature of changing governance rules. Includes: all 15 voting thresholds (P1–P6 for DReps, Q1–Q5 for SPOs), govActionLifetime (1–15 epochs), govActionDeposit (1M–10T lovelace), dRepDeposit (1M–100B lovelace), dRepActivity (13–37 epochs), committeeMinSize (3–10), committeeMaxTermLength (18–293 epochs)." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#parameters> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Parameter Group" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "param-group-governance" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#param-group> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-economic> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-economic/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-economic/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Protocol Parameters" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-group-economic> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Protocol parameters related to transaction fees, deposits, and monetary policy. DRep voting threshold: 67% (P5b). Includes: txFeePerByte (30–1,000 lovelace), txFeeFixed (100,000–10,000,000 lovelace), stakeAddressDeposit, stakePoolDeposit, monetaryExpansion (0.001–0.005), treasuryCut (10%–30%), minPoolCost, utxoCostPerByte (3,000–6,500), executionUnitPrices (priceMemory and priceSteps), minFeeRefScriptCostPerByte." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#parameters> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Economic Parameter Group" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "param-group-economic" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#param-group> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/cardano-foundation/cardano-org/tree/main/src/data"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CF Chart Data (source)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cardano.org/insights/governance-actions/?category=Critical+Parameter+Changes"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CF Critical Parameter Charts" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/param-exceptions> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Some protocol parameters have voting thresholds that differ from their group defaults, as defined in the Cardano Constitution and implemented in the Guardrails Script. For example: committeeMaxTermLength requires only DRep 67% with no CC vote; deposit parameters (dRepDeposit, stakePoolDeposit, stakeAddressDeposit, minPoolCost, committeeMinSize) use the Governance group threshold (DRep 75% + CC 2/3) rather than their native Economic/Technical group thresholds. These exceptions reflect the constitutional significance of these specific parameters." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#parameters> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Per-Parameter Threshold Exceptions" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "param-exceptions" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://orcfax.io/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Orcfax" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://charli3.io/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Charli3" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/Anastasia-Labs/design-patterns"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Design Patterns" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/oracle-pattern> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Leverages CIP-31 reference inputs: an oracle publishes price/data in a UTxO datum, and multiple contracts read it simultaneously without spending it. Eliminates contention. Charli3 and Orcfax are the main Cardano oracle providers." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Oracle Pattern" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "oracle-pattern" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://pycardano.readthedocs.io/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "PyCardano" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/OpShin/opshin"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://opshin.dev/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "OpShin" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/opshin> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Write Cardano smart contracts in 100% valid Python syntax. Enforces a strict type system on top of Python. Integrates with PyCardano for off-chain code. Lowers the barrier for Python developers entering the Cardano ecosystem." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#languages> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "OpShin" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "opshin" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#language> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/no-confidence-option> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/no-confidence-option/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/no-confidence-option/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-1694#pre-defined-voting-options"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-1694 — Pre-Defined Voting Options" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/no-confidence-option> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "A pre-defined voting option for ada holders. When delegating to No Confidence, the holder's stake automatically votes 'Yes' on every Motion of No-Confidence and 'No' on every other governance action. Unlike Abstain, this stake IS counted in the active voting stake — it actively opposes all governance actions except no-confidence motions. This is a signal of dissatisfaction with the current governance state." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actors> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "No Confidence (Pre-defined DRep)" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "no-confidence-option" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-25"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-25: NFT Metadata" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://aiken-lang.org/fundamentals/getting-started"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Aiken: Minting Policy" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/native-tokens/minting/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Minting Native Tokens" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minting-policy> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "A Plutus script that controls the creation and destruction of native tokens. The policy receives the script context and decides whether to allow minting or burning. The policy hash becomes the first part of the token's asset ID, cryptographically binding tokens to their minting rules." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Minting Policy" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "minting-policy" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/minswap"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.minswap.org/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Docs" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://minswap.org/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Minswap" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/minswap> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Largest Cardano DEX by TVL and weekly volume. Multi-pool AMM using the constant-product formula. Written in Aiken. Demonstrates production-scale smart contract usage on Cardano with batched order settlement." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#protocols> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Minswap" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "minswap" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#protocol> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/MeshJS/mesh"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://meshjs.dev/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Mesh" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/mesh-sdk> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "TypeScript SDK with transaction builder, React components, wallet connectors, and smart contract integration. Higher-level alternative to Lucid with more out-of-the-box UI components." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#tooling> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Mesh SDK" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "mesh-sdk" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#tool> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/smart-contracts/smart-contract-languages/marlowe/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Developer Portal" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/marlowe-lang"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://marlowe.iohk.io/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Marlowe" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/marlowe> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Domain-specific language for financial contracts. High-level, non-Turing-complete by design — contracts can be exhaustively analyzed and formally verified via Isabelle. Transitioned to community ownership (Marlowe Language CIC) in 2024." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#languages> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Marlowe" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "marlowe" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#language> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://anastasia-labs.com/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Anastasia Labs" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/Anastasia-Labs/lucid-evolution"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://anastasia-labs.github.io/lucid-evolution/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Docs" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/lucid-evolution> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Production-ready TypeScript off-chain transaction builder. Successor to the original Lucid, maintained by Anastasia Labs. Supports Plutus V1/V2/V3, Conway hard fork ready. The standard choice for building Cardano dApp frontends." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#tooling> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Lucid Evolution" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "lucid-evolution" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#tool> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liqwid> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liqwid/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liqwid/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.liqwid.finance/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Docs" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liqwid> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liqwid/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liqwid/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://liqwid.finance/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Liqwid" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liqwid> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Leading lending/borrowing protocol on Cardano. Non-custodial, supports liquid staking. DAO-governed via LQ token. Uses Plutarch for performance-critical validators. Demonstrates complex multi-contract DeFi on EUTxO." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#protocols> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Liqwid Finance" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "liqwid" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#protocol> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liquid-democracy> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liquid-democracy/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liquid-democracy/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.cardano.org/about-cardano/governance-overview"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Overview" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/liquid-democracy> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The democratic model used by Cardano governance. Ada holders can vote directly on every governance matter (by registering as their own DRep) OR delegate their voting power to any registered DRep. Delegation can be changed at any time and takes effect immediately. This combines the benefits of direct democracy (anyone can participate) with representative democracy (expertise can be delegated to). DRep delegation is SEPARATE from stake pool delegation — you choose who produces blocks and who votes on your behalf independently." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#core> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Liquid Democracy" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "liquid-democracy" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/intersect> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/intersect/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/intersect/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://www.intersectmbo.org"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Intersect" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/intersect> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "A not-for-profit organization (registered in Wyoming, USA) that facilitates off-chain governance processes. Intersect manages the Parameter Committee, organizes elections, runs working groups, and coordinates the governance tooling ecosystem. It is NOT a governance body — it does not vote or ratify. Its role is facilitation and coordination: hosting discussions, managing the CIP process, coordinating hard fork readiness, and providing infrastructure like GovTool." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#ecosystem> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Intersect" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "intersect" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#actor> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/inline-datums> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/inline-datums/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/inline-datums/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.cardano.org/about-cardano/evolution/upgrades/vasil/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Vasil Upgrade" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/inline-datums> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/inline-datums/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/inline-datums/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0032"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-32" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/inline-datums> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-32 feature that stores the full datum directly in the UTxO instead of just a hash. Eliminates the need for off-chain datum management — anyone can see the contract state by reading the UTxO. Essential for composability between protocols." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Inline Datums" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "inline-datums" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/cardano-scaling/hydra"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.cardano.org/developer-resources/scalability-solutions/hydra"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Cardano Docs" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://hydra.family/head-protocol/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Hydra" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hydra> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Layer 2 isomorphic state channels. Each \"head\" is a mini-ledger replicating Cardano's full functionality off-chain with sub-second latency and 1,000 TPS per head. Multiple heads scale linearly. Uses the same smart contract model as L1." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#protocols> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Hydra" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "hydra" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#protocol> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hot-cold-keys> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hot-cold-keys/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hot-cold-keys/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/constitutional-committee-guide/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Constitutional Committee Guide" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/hot-cold-keys> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The credential system used by Constitutional Committee members. Similar to genesis delegation certificates. The cold key is the CC member's identity — kept offline for security. The hot key is authorized by the cold key for day-to-day voting. If a hot key is compromised, it can be rotated without changing the CC member's identity. This separation protects against key compromise while allowing active participation. CC members can also use native or Plutus script credentials instead of key pairs." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#framework> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Hot/Cold Key System" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "hot-cold-keys" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/helios> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/helios/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/helios/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/HeliosLang/compiler"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/helios> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/helios/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/helios/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://helios-lang.io/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Helios" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/helios> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "JavaScript/TypeScript SDK with its own on-chain DSL — functional, strongly typed, curly-brace syntax. Compiles to Plutus Core. Also handles off-chain transaction building, making it an all-in-one toolkit for JS developers." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#languages> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Helios" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "helios" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#language> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/submitting-governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Submitting Governance Actions" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-1694"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-1694 — Guardrails Script" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/guardrails-script> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "An on-chain Plutus script that enforces specific constitutional rules programmatically. It applies ONLY to protocol parameter changes and treasury withdrawals — these are the two governance action types where automated enforcement is feasible. The script checks parameter bounds (e.g., maxBlockBodySize must be between 24,576 and 122,880 bytes) and treasury withdrawal limits. Named guardrails include PARAM-01 through PARAM-06a (parameter rules), TREASURY-01a through TREASURY-04a (withdrawal limits), HARDFORK-01 through HARDFORK-08, and committee/constitution update rules. The guardrails script can be updated via a New Constitution governance action." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#framework> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Guardrails Script" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "guardrails-script" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#artifact> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.gov.tools/overview/what-is-cardano-govtool"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GovTool Documentation" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://gov.tools"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GovTool" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/govtool> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "A web application for participating in Cardano governance. GovTool's four architectural pillars: Proposal Discussion, Delegation, Outcomes, and Voting. Users can delegate to DReps, register as DReps, view and vote on governance actions, and track outcomes. It connects to the user's wallet via CIP-95 (the Conway-era web-wallet bridge)." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#ecosystem> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GovTool" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "govtool" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#tool> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cardanofoundation.org/governance"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CF Governance Page" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.cardano.org/about-cardano/governance-overview"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Overview (docs.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-1694"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-1694 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-model> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Cardano uses a tricameral (three-body) governance model implementing liquid democracy, introduced by CIP-1694 as part of the Voltaire phase. Ada holders can vote directly on every governance matter or delegate their voting power to Delegated Representatives (DReps). Three governance bodies — DReps, Stake Pool Operators (SPOs), and the Constitutional Committee (CC) — each play distinct roles in reviewing and ratifying governance actions. Every governance action requires approval from at least two of the three bodies." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#core> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Cardano Governance" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "governance-model" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cardano.org/insights/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Action Flowcharts" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cardanofoundation.org/blog/understanding-cardano-governance-actions"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CF — Understanding Governance Actions" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Actions (developers.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/governance-action> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "An on-chain event triggered by a transaction. Any ada holder can submit a governance action by paying the govActionDeposit (currently 100,000 ada, refundable). Every action includes: the deposit amount, a reward address for deposit return, a metadata anchor (URL + hash, following CIP-100/CIP-108 standards), and — for most types — a hash reference to the most recently enacted action of the same type (to prevent collisions). Actions have a lifespan of govActionLifetime epochs (currently 6 epochs / ~30 days). There are 7 types of governance actions." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actions> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Action" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "governance-action" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://plutus.cardano.intersectmbo.org/docs/reference/cardano/plutus-core-builtins-ref/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Script Cost Calculator" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.cardano.org/about-cardano/explore-more/fee-structure/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Fee Structure" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/smart-contracts/plutus/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Understanding ExUnits" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/exunits> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Execution units — the two-dimensional resource budget for Plutus scripts. CPU steps measure computation time, memory units measure peak memory usage. Every transaction specifies ExUnits for each script it runs. Fees are computed from ExUnits using protocol parameters (prices per step/unit)." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "ExUnits" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "exunits" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo/link/3> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo/link/3> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://ucarecdn.com/3da33f2f-73ac-4c9b-844b-f215dcce0628/EUTXOhandbook_for_ec.pdf"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "EUTxO Handbook" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/smart-contracts/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Developer Portal" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.cardano.org/about-cardano/learn/eutxo-explainer/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Understanding EUTxO" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://iohk.io/en/research/library/papers/the-extended-utxo-model/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "EUTxO Paper" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/eutxo> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Extended UTxO — Cardano's transaction model that extends Bitcoin's UTxO with datum, redeemer, and script validation. Each UTxO can be locked by a validator script. Spending requires providing a redeemer that satisfies the validator. The model enables deterministic transaction validation — fees and outcomes are known before submission." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "EUTxO Model" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "eutxo" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/enactment> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/enactment/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/enactment/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-1694#enactment"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-1694 — Enactment" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/enactment> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Ratified governance actions are enacted on the epoch boundary FOLLOWING ratification. When multiple actions are ratified in the same epoch, they are enacted in a fixed priority order: (1) No-Confidence, (2) Committee Update, (3) New Constitution, (4) Hard Fork, (5) Parameter Changes, (6) Treasury Withdrawals, (7) Info. Within the same type, actions are enacted in the order they were accepted to the chain. After enactment, the governance action deposit is returned to the specified reward address." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#lifecycle> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Enactment" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "enactment" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#process> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep-thresholds> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep-thresholds/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep-thresholds/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-1694#ratification"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-1694 — Ratification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep-thresholds> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "DRep thresholds are expressed as a fraction of active DRep voting stake. Active voting stake = all stake delegated to registered, active DReps (excluding Abstain delegations). Current mainnet values: No-Confidence (P1) = 67%, Committee Update normal (P2a) = 67%, Committee Update no-confidence (P2b) = 60%, New Constitution (P3) = 75%, Hard Fork (P4) = 60%, Network params (P5a) = 67%, Economic params (P5b) = 67%, Technical params (P5c) = 67%, Governance params (P5d) = 75%, Treasury Withdrawal (P6) = 67%, Info = 100% (fixed)." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#thresholds> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "DRep Voting Thresholds" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "drep-thresholds" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cardanofoundation.org/blog/strengthens-commitment-governance-drep"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CF as DRep" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-model/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Register as DRep (CLI)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.cardano.org/about-cardano/governance-overview"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "DReps (docs.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/drep> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Any ada holder can register as a DRep by paying a refundable deposit (currently 500 ada). DReps accumulate voting power from ada holders who delegate to them. Their vote weight equals the total lovelace delegated to them — one lovelace = one vote. DReps must vote regularly or they become inactive after the dRepActivity period (currently 20 epochs / 100 days). Inactive DReps do not count toward the active voting stake. DRep delegation is separate from stake pool delegation and takes effect immediately (no two-epoch lag). DReps are identified by a credential: an Ed25519 verification key or a native/Plutus script." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actors> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Delegated Representative (DRep)" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "drep" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#actor> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/djed> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/djed/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/djed/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://eprint.iacr.org/2021/1069"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Djed Paper" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/djed> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/djed/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/djed/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://djed.xyz/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Djed" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/djed> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Overcollateralized algorithmic stablecoin. Maintained peg since January 2023 launch. Demonstrates formal verification applied to DeFi — the Djed paper provides mathematical proofs of peg stability under defined conditions." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#protocols> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Djed" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "djed" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#protocol> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/deposit-mechanism> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/deposit-mechanism/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/deposit-mechanism/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-model/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Model" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/deposit-mechanism> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Several governance actions require refundable deposits to prevent spam. govActionDeposit (currently 100,000 ada) is required to submit any governance action — returned when the action is ratified or expires. dRepDeposit (currently 500 ada) is required to register as a DRep — returned on retirement. These deposits are protocol parameters in the Governance group, changeable via governance actions with a 75% DRep threshold." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#lifecycle> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Deposit Mechanism" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "deposit-mechanism" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/demeter> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/demeter/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/demeter/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.demeter.run/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Docs" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/demeter> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/demeter/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/demeter/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://demeter.run/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Demeter" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/demeter> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Cloud development platform for Cardano. Provides managed nodes, indexers, and Hydra infrastructure across mainnet/preprod/preview. No local infrastructure needed — develop and test in the cloud." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#tooling> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Demeter.run" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "demeter" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#tool> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://aiken-lang.org/fundamentals/getting-started"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Aiken Tutorial: Datums" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-32"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-32: Inline Datums" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/smart-contracts/plutus/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Datums and Redeemers" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/datum> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Data attached to a UTxO that is locked by a Plutus script. The datum represents the state of the contract. When spending the UTxO, the datum is passed to the validator script along with a redeemer and the transaction context. Can be stored inline (CIP-32) or as a hash with the full datum provided in the transaction." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Datum" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "datum" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/models.R"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "R Models" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Benchmark Data (benching-conway.csv)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/CostModelGeneration.md"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Cost Model Generation Process" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cost-models> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Protocol parameters that assign abstract CPU and memory costs (ExUnits) to each Plutus builtin function. These are part of the Technical parameter group. Cost models are calibrated by benchmarking each builtin on a reference machine through the Haskell CEK machine, then fitting cost functions via R scripts. Coefficients are stored as 64-bit integers (picoseconds) for cross-platform reproducibility. The cost model ensures that maxBlockExUnits worth of abstract work fits within the real block validation time budget. Every node implementation (Haskell, Rust, etc.) must compute identical ExUnits — the abstract costs are consensus-critical. Updates go through the governance process as Protocol Parameter Changes." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#parameters> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Plutus Cost Models" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cost-models" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#parameter> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/conway-era> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/conway-era/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/conway-era/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.cardano.org/about-cardano/evolution/upgrades/chang"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Chang Upgrade" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/conway-era> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The current Cardano ledger era that implements CIP-1694 governance. Named after mathematician John Horton Conway. Introduced via two hard forks: Chang #1 (August 2024) — bootstrap phase with limited governance (DRep registration, interim CC, parameter changes and hard forks only); and Plomin hard fork / Chang #2 (December 2024) — full governance activation with all 7 action types and treasury withdrawals. The bootstrap phase ended when the CC and SPOs ratified the Plomin hard fork." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#framework> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Conway Ledger Era" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "conway-era" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cardanofoundation.org/blog/proposal-for-cardano-constitution"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CF Constitution Proposal" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://gov.tools"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Full Constitution Text" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/constitution> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "An off-chain text document whose hash is recorded on-chain. It defines shared values and guiding principles for Cardano governance. The current Constitution was ratified at the Buenos Aires Constitutional Convention (December 4-6, 2024) with 95% delegate approval after 63 workshops across 51 countries, and became effective on-chain on January 24, 2026. It contains: a Preamble (not used for constitutionality assessments), 10 Tenets (core principles including transaction freedom, predictable costs, ada supply cap at 45 billion), Articles covering community participation, decentralized governance, CC responsibilities, and treasury provisions, plus Appendix I with permitted parameter ranges. The on-chain version (hash) prevails over the documented version in case of conflict." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#framework> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Cardano Constitution" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "constitution" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#artifact> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-95> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-95/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-95/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0095"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-95 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-95> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-95 defines the web-wallet bridge for the Conway era. It extends the CIP-30 wallet connector with governance-specific capabilities: DRep registration, vote delegation, and governance action submission from browser-based wallets. Without CIP-95, governance tools like GovTool couldn't interact with users' wallets. It enables the 'connect wallet' flow that makes on-chain governance accessible to non-technical participants." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#framework> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-95" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-95" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#artifact> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-88> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-88/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-88/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0088"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-88 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-88> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Token Policy Registration — a metadata standard for registering information about a token's minting policy on-chain. Enables policy authors to declare the token's name, description, logo, decimals, and project details in a verifiable way. Helps wallets, explorers, and marketplaces display accurate token information without relying on centralized registries." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#standards> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-88" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-88" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#standard> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-85> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-85/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-85/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0085"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-85 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-85> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Sums-of-Products (SOPs) for Plutus Core — replaces the Scott-encoded data representation with native constructor/case expressions. This makes compiled Plutus scripts significantly smaller and faster by eliminating the overhead of encoding algebraic data types as lambda terms. SOPs shipped with Plutus V3 and are a key driver of the script size and execution cost reductions in the Conway era." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#standards> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-85" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-85" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#standard> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-69> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-69/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-69/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0069"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-69 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-69> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Plutus Script Type Uniformization — unifies the interface for all Plutus script purposes (spending, minting, certifying, rewarding) into a single uniform signature. Before CIP-69, minting policies received two arguments (redeemer, context) while spending validators received three (datum, redeemer, context). CIP-69 makes all script types take the same arguments, simplifying multi-purpose scripts and enabling a single validator to serve as both spending and minting script." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#standards> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-69" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-69" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#standard> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/native-tokens/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Rich Metadata Explainer" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-68"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-68" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-68> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Rich, mutable metadata standard. Uses a reference NFT (label 100) carrying metadata in its datum, paired with a user token (label 222 for NFTs, 333 for FTs). Metadata can be updated by spending the reference UTxO. Successor to CIP-25." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#standards> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-68" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-68" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#standard> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://aiken-lang.org/fundamentals/getting-started"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Aiken Blueprint Docs" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-57"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-57" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-57> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Plutus Contract Blueprint — machine-readable JSON schema (plutus.json) documenting a smart contract's interface: validators, parameters, datum/redeemer types. Enables tooling to auto-generate off-chain bindings. Aiken generates blueprints automatically." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#standards> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-57" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-57" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#standard> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-381> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-381/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-381/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0381"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-381 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-381> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Adds BLS12-381 elliptic curve primitives as Plutus built-in functions. Enables zero-knowledge proofs (Groth16, PLONK), BLS signature verification, and advanced cryptographic protocols directly on-chain. These primitives support sidechains, bridges, and privacy-preserving applications on Cardano. Shipped with Plutus V3 in the Conway era." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#standards> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-381" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-381" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#standard> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-30> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-30/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-30/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0030"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-30 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-30> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Cardano dApp-Wallet Web Bridge — the original standard for connecting browser-based dApps to Cardano wallets. Defines a JavaScript API injected into window.cardano that lets dApps discover wallets, request access, query balances, submit transactions, and sign data. Nearly every Cardano dApp uses CIP-30 for wallet interaction. CIP-95 extends it with governance capabilities." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#standards> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-30" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-30" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#standard> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/native-tokens/minting-nfts/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Minting NFTs Guide" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-25"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-25" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-25> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Original NFT metadata standard. Metadata attached to minting transactions via transaction metadata label 721. Simple and widely adopted but metadata is immutable after minting. The foundation for Cardano's NFT ecosystem." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#standards> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-25" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-25" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#standard> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-1694> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-1694/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-1694/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-1694"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-1694 Full Text" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-1694> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The Cardano Improvement Proposal that specifies the on-chain governance mechanism. Authored by Jared Corduan and Andre Knispel, it defines the three governance bodies, seven action types, voting and ratification rules, the Constitutional Committee structure, DRep mechanics, and the full lifecycle of governance actions. CIP-1694 was implemented in the Conway ledger era (named after John Horton Conway)." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#framework> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-1694" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-1694" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#artifact> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-136> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-136/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-136/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0136"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-136 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-136> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-136 defines the metadata standard for Constitutional Committee vote rationales. When CC members vote on governance actions, they are expected to explain their constitutional reasoning. CIP-136 provides a structured format for these rationales, including which constitutional articles were considered and why the action was deemed constitutional or not. This creates a public record of constitutional interpretation — effectively building governance case law over time." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#framework> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-136" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-136" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#artifact> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-129> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-129/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-129/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0129"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-129 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-129> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-129 standardizes governance identifiers across the ecosystem. It defines canonical string representations for governance credentials (DRep IDs, CC member IDs, governance action IDs) that work consistently across wallets, explorers, and governance tools. Without this standard, different tools might represent the same DRep or action differently, causing confusion when sharing links or referencing proposals." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#framework> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-129" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-129" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#artifact> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-119> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-119/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-119/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0119"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-119 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-119> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-119 defines the governance metadata standard for Delegated Representatives. It extends CIP-100 with DRep-specific fields: display name, bio, motivations, qualifications, payment address, and references. This structured profile metadata helps ada holders make informed delegation decisions. GovTool and other governance interfaces render CIP-119 metadata on DRep profile pages." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#framework> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-119" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-119" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#artifact> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-108> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-108/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-108/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0108"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-108 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-108> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-108 extends CIP-100 with a specific metadata format for governance actions. It defines required fields: title, abstract, motivation, rationale, and supporting references. This structured format ensures that voters have consistent, comparable information when evaluating proposals. GovTool and other governance interfaces render CIP-108 metadata to present proposals in a human-readable format." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#framework> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-108" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-108" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#artifact> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-105> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-105/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-105/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0105"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-105 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-105> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-105 defines the Conway-era HD wallet key derivation paths for governance credentials. It specifies how wallets derive the key pairs used for DRep registration, vote delegation, and CC member credentials from a single master seed. This ensures that governance keys are deterministically recoverable from a wallet's mnemonic phrase, following the same BIP-32/BIP-44 patterns used for payment and staking keys." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#framework> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-105" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-105" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#artifact> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-100> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-100/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-100/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-0100"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-100 Specification" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cip-100> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "CIP-100 defines the general governance metadata standard. Every governance action includes a metadata anchor — a URL pointing to a JSON document plus its hash for integrity. CIP-100 specifies the base format for this metadata, ensuring all governance tools can parse and display proposal information consistently. The metadata is stored off-chain (to avoid blockchain bloat) but its hash is recorded on-chain, making it tamper-proof." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#framework> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-100" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cip-100" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#artifact> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/smart-contracts/plutus/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "How Plutus Scripts Are Evaluated" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://plutus.cardano.intersectmbo.org/resources/plutus-core-spec.pdf"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CEK Machine Spec" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cek-machine> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The abstract machine that evaluates Plutus Core on-chain. Tracks CPU and memory consumption using ExUnits budgets. If a script exceeds its budget, the transaction fails. The CEK machine is deterministic — same inputs always produce same outputs and same costs." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CEK Machine" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cek-machine" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#runtime> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc-threshold> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc-threshold/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc-threshold/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/constitutional-committee-guide/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Constitutional Committee Guide" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc-threshold> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The CC uses one-member-one-vote (not stake-weighted). The required fraction of CC members who must approve is a configurable threshold (currently 2/3 on mainnet). The CC votes on: New Constitution, Hard Fork, all Protocol Parameter Changes, Treasury Withdrawals, and Info actions. The CC does NOT vote on: No-Confidence motions or Committee Updates (since those are about the CC itself). Expired members cannot vote. The committee has a minimum size (committeeMinSize = 7 on mainnet)." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#thresholds> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CC Voting Threshold" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cc-threshold" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://gov.tools"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CC Portal" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/constitutional-committee-guide/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Constitutional Committee Guide" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cc> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "A community-elected oversight body responsible for ensuring that governance actions respect the Cardano Constitution. Each CC member holds exactly one vote (not stake-weighted). The CC does NOT create proposals and does NOT evaluate merit — it reviews constitutionality only. Members use a hot/cold key credential system (like genesis delegation). Each member has an individual term expiration epoch; expired members cannot vote. Members can resign early. The CC can enter a 'no-confidence' state via a Motion of No-Confidence, which blocks it from participating in ratification until a new committee is elected. The CC does not vote on No-Confidence motions or Committee updates (since those are about the CC itself)." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actors> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Constitutional Committee (CC)" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cc" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#actor> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cardanofoundation.org/blog/strengthens-commitment-governance-drep"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CF as DRep" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://proposalexaminer.cardanofoundation.org/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Cardano Proposal Examiner" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cardanofoundation.org/governance"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CF Governance" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/cardano-foundation> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "One of the three founding entities of Cardano (alongside IOG and EMURGO). The CF is registered as a DRep on-chain and operates a Governance Advisory Team of subject-matter experts. It evaluates proposals on constitutional alignment and governance merit, publishing vote rationales with each governance action vote. The CF served on the interim Constitutional Committee during the bootstrap phase and created the Cardano Proposal Examiner tool. The founding entities relinquished their genesis keys, transitioning control to the community." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#ecosystem> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Cardano Foundation" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "cardano-foundation" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#actor> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/bootstrap-phase> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/bootstrap-phase/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/bootstrap-phase/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.cardano.org/about-cardano/evolution/upgrades/chang"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Chang Upgrade" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/bootstrap-phase> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "The initial governance phase after Chang #1 (August 2024) and before the Plomin hard fork (December 2024). During bootstrap: CC vote alone was sufficient for protocol parameter changes; CC + SPO vote was sufficient for hard fork initiation; Info actions were available; no other governance actions were possible; DRep participation was not required. The bootstrap phase ended when CC and SPOs ratified the Plomin hard fork, transitioning to full governance." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#lifecycle> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Bootstrap Phase" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "bootstrap-phase" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#process> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/blockfrost"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.blockfrost.io/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "API Docs" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://blockfrost.io/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Blockfrost" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/blockfrost> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Hosted REST API for Cardano blockchain data. Free tier available. SDKs in 15+ languages. The most common way dApps query chain state without running a full node. Also offers self-hosted option." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#tooling> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Blockfrost" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "blockfrost" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#tool> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken/link/3> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken/link/3> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://aiken-lang.org/stdlib"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Standard Library" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken/link/2> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken/link/2> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://aiken-lang.org/fundamentals/getting-started"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Getting Started" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://github.com/aiken-lang/aiken"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GitHub" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://aiken-lang.org/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Aiken" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/aiken> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Rust-inspired, purpose-built language for Cardano smart contracts. Most popular on-chain language — 75%+ of developers use it. Compiles directly to UPLC with excellent optimization. First-class Plutus blueprint (CIP-57) generation." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#languages> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Aiken" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "aiken" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#language> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-model/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Model (developers.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://gov.tools"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "GovTool — Participate in Governance" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/ada-holder> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Any holder of ada. Ada holders are the foundation of Cardano governance — they have 'skin in the game' and can participate in governance in multiple ways: vote directly by registering as a DRep, delegate their voting power to a DRep (or to the pre-defined Abstain/No Confidence options), submit governance actions (with a deposit), and delegate stake to SPOs for block production. Voting power is proportional: one lovelace = one vote." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actors> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Ada Holder" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "ada-holder" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#actor> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-update-committee> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-update-committee/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-update-committee/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Actions (developers.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-update-committee> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Changes the Constitutional Committee membership, its signature threshold, and/or member term limits. Can add new members (with term expiration epochs), remove existing members, and adjust the fraction of CC members required to approve actions. Thresholds differ depending on CC state: in normal state, requires DRep 67% + SPO 51%; in no-confidence state, DRep 60% + SPO 51% (lower DRep threshold to make it easier to replace a failed CC). The CC does not vote on this." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actions> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "2. Update Committee / Threshold" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "action-update-committee" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#action-type> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Actions (developers.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-treasury> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Withdraws ada from the Cardano treasury. The action specifies a map from stake credentials to positive lovelace amounts. Requires: CC approval (2/3 majority) + DRep approval at 67%. SPOs do not vote on this. The Guardrails Script enforces withdrawal limits (TREASURY-01a through TREASURY-04a). Treasury withdrawals must specify purpose, expected costs, and provide for auditable accounts. This action type does NOT require chaining to previous actions of the same type (unlike most other types)." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actions> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "6. Treasury Withdrawal" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "action-treasury" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#action-type> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Actions (developers.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Protocol Parameters" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-param-change> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Changes one or more updatable protocol parameters. Parameters are grouped into four categories (Network, Economic, Technical, Governance), each with its own DRep voting threshold. Requires CC approval (2/3 majority) for all groups. If the change touches security-relevant parameters, SPOs must also approve at 51%. The Guardrails Script enforces permitted ranges for each parameter. This is the mechanism used for Plutus cost model updates — cost model parameters are part of the Technical group." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actions> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "5. Protocol Parameter Changes" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "action-param-change" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#action-type> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-no-confidence> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-no-confidence/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-no-confidence/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Actions (developers.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-no-confidence> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Creates a state of no-confidence in the current Constitutional Committee. When ratified, the CC enters a no-confidence state and cannot participate in governance until a new committee is elected via an Update Committee action. This is the highest-priority governance action — if ratified in the same epoch as other actions, it is enacted first. Requires: DRep approval at 67% of active voting stake + SPO approval at 51% of active pool stake. The CC does not vote on this (since it's about them)." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actions> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "1. Motion of No-Confidence" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "action-no-confidence" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#action-type> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Actions (developers.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-new-constitution> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Modifies the Cardano Constitution and/or the on-chain Guardrails Script. The action includes an anchor to the new Constitution text and optionally a new script hash for the Guardrails Script. Requires: CC approval (2/3 majority) + DRep approval at 75% of active voting stake. SPOs do not vote on this. This is the action with the highest DRep threshold (alongside Governance group parameter changes), reflecting the significance of constitutional amendments." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actions> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "3. New Constitution / Guardrails Script" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "action-new-constitution" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#action-type> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Actions (developers.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-info> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Has no on-chain effect — it's a mechanism for recording community sentiment on-chain. Requires 100% threshold from all three bodies (meaning it can never technically be 'ratified' in the normal sense, but serves as a signal). Info actions are useful for polling the community on proposals before committing to a binding governance action. They do not require chaining to previous actions." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actions> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "7. Info Action" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "action-info" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#action-type> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork/link/1> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork/link/1> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://docs.cardano.org/about-cardano/evolution/upgrades/chang"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Chang Upgrade" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Governance Actions (developers.cardano.org)" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-hard-fork> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "Triggers a non-backwards-compatible protocol upgrade. The action specifies a new major protocol version (must be exactly +1 from current). This is the only governance action that requires approval from ALL THREE bodies: CC (2/3 majority), DReps (60%), and SPOs (51%). Guardrail HARDFORK-04a requires at least 85% of stake pools by active stake to have upgraded their node software before enactment. A ratified hard fork delays ratification of all other pending actions until after enactment." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actions> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "4. Hard Fork Initiation" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "action-hard-fork" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#action-type> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-chaining> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-chaining/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-chaining/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-1694#governance-actions"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-1694 — Governance Actions" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/action-chaining> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "A collision-prevention mechanism. Each governance action (except Treasury Withdrawals and Info) must include the governance action ID of the most recently enacted action of its same type. This forms a chain that prevents two competing same-type actions from both being ratified when they assume incompatible starting states. For example, two parameter change proposals that both assume the current parameter values cannot both be valid after one of them changes those values." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#lifecycle> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Action Chaining" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "action-chaining" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/abstain-option> <https://lambdasistemi.github.io/graph-browser/vocab/terms#externalLink> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/abstain-option/link/0> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/abstain-option/link/0> <https://lambdasistemi.github.io/graph-browser/vocab/terms#url> "https://cips.cardano.org/cip/CIP-1694#pre-defined-voting-options"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "CIP-1694 — Pre-Defined Voting Options" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#ExternalLink> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/abstain-option> <https://lambdasistemi.github.io/graph-browser/vocab/terms#description> "A pre-defined voting option for ada holders. When delegating to Abstain, the holder's stake is marked as not participating — it is NOT counted in the active voting stake denominator. This means it neither helps nor hinders ratification of any action. The holder still counts as registered for staking reward incentives." ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#group> <https://lambdasistemi.github.io/graph-browser/vocab/groups#actors> ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Abstain (Pre-defined DRep)" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeId> "abstain-option" ;
-	<http://purl.org/dc/terms/isPartOf> <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> , <https://lambdasistemi.github.io/graph-browser/vocab/terms#Node> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#written%20in> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "written in" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "written in" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on%20changes%20to> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "votes on changes to" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "votes on changes to" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "votes on" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "votes on" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#uses> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "uses" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "uses" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#used%20for> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "used for" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "used for" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#updated%20via> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "updated via" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "updated via" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#unifies%20script%20types%20in> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "unifies script types in" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "unifies script types in" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#undergoes> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "undergoes" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "undergoes" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#type%20of> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "type of" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "type of" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#tested> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "tested" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "tested" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#succeeds> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "succeeds" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "succeeds" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#submits> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "submits" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "submits" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#subject%20to> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "subject to" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "subject to" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#structured%20as> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "structured as" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "structured as" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#started%20with> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "started with" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "started with" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#standardizes%20IDs%20for> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "standardizes IDs for" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "standardizes IDs for" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#specifies> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "specifies" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "specifies" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#some%20params%20are> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "some params are" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "some params are" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#requires> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "requires" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "requires" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#replicates> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "replicates" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "replicates" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#renders%20profiles%20from> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "renders profiles from" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "renders profiles from" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#registers%20metadata%20for> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "registers metadata for" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "registers metadata for" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#registered%20as> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "registered as" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "registered as" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#puts%20into%20no-confidence%20state> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "puts into no-confidence state" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "puts into no-confidence state" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#publishes%20rationales%20via> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "publishes rationales via" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "publishes rationales via" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#provides> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "provides" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "provides" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#profile%20follows> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "profile follows" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "profile follows" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#priced%20by> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "priced by" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "priced by" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#overrides%20thresholds%20from> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "overrides thresholds from" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "overrides thresholds from" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#optimizes> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "optimizes" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "optimizes" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#open%20for> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "open for" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "open for" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#modifies%20voting%20for> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "modifies voting for" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "modifies voting for" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#modifies> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "modifies" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "modifies" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#metadata%20follows> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "metadata follows" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "metadata follows" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#leads%20to> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "leads to" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "leads to" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "is a type of" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "is a type of" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#indexes> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "indexes" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "indexes" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#improves> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "improves" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "improves" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#implements> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "implements" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "implements" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#implemented%20in> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "implemented in" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "implemented in" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#hosts%20infrastructure%20for> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "hosts infrastructure for" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "hosts infrastructure for" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "governance body" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "governance body" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#generates> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "generates" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "generates" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#gates> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "gates" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "gates" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#facilitates> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "facilitates" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "facilitates" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#extends> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "extends" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "extends" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluates%20and%20votes%20on> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "evaluates and votes on" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "evaluates and votes on" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluates%20actions%20against> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "evaluates actions against" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "evaluates actions against" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluated%20by> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "evaluated by" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "evaluated by" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#enforces> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "enforces" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "enforces" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#enables%20registration%20as> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "enables registration as" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "enables registration as" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#enables> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "enables" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "enables" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#documents> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "documents" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "documents" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#determines> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "determines" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "determines" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#derives%20keys%20for> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "derives keys for" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "derives keys for" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#delegates%20voting%20power%20to> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "delegates voting power to" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "delegates voting power to" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#delegates%20stake%20to> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "delegates stake to" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "delegates stake to" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#contains> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "contains" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "contains" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#consumes> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "consumes" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "consumes" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#constrains> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "constrains" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "constrains" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#connects%20wallets%20via> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "connects wallets via" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "connects wallets via" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "compiles to" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "compiles to" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#codified%20in> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "codified in" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "codified in" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#changes%20membership%20of> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "changes membership of" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "changes membership of" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20update> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "can update" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "can update" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20register%20as> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "can register as" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "can register as" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20modify> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "can modify" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "can modify" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20delegate%20to> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "can delegate to" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "can delegate to" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "can change" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "can change" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#built%20on> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "built on" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "built on" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#builds%20transactions%20for> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "builds transactions for" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "builds transactions for" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#belongs%20to> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "belongs to" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "belongs to" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#affects> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "affects" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "affects" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/edges#adds%20built-ins%20to> <https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeLabel> "adds built-ins to" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "adds built-ins to" ;
-	a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-<https://lambdasistemi.github.io/graph-browser/vocab/groups#tooling> <https://lambdasistemi.github.io/graph-browser/vocab/terms#groupId> "tooling" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "tooling" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#Group> .
-<https://lambdasistemi.github.io/graph-browser/vocab/groups#thresholds> <https://lambdasistemi.github.io/graph-browser/vocab/terms#groupId> "thresholds" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "thresholds" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#Group> .
-<https://lambdasistemi.github.io/graph-browser/vocab/groups#standards> <https://lambdasistemi.github.io/graph-browser/vocab/terms#groupId> "standards" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "standards" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#Group> .
-<https://lambdasistemi.github.io/graph-browser/vocab/groups#smart-contracts> <https://lambdasistemi.github.io/graph-browser/vocab/terms#groupId> "smart-contracts" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "smart-contracts" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#Group> .
-<https://lambdasistemi.github.io/graph-browser/vocab/groups#protocols> <https://lambdasistemi.github.io/graph-browser/vocab/terms#groupId> "protocols" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "protocols" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#Group> .
-<https://lambdasistemi.github.io/graph-browser/vocab/groups#parameters> <https://lambdasistemi.github.io/graph-browser/vocab/terms#groupId> "parameters" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "parameters" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#Group> .
-<https://lambdasistemi.github.io/graph-browser/vocab/groups#lifecycle> <https://lambdasistemi.github.io/graph-browser/vocab/terms#groupId> "lifecycle" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "lifecycle" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#Group> .
-<https://lambdasistemi.github.io/graph-browser/vocab/groups#languages> <https://lambdasistemi.github.io/graph-browser/vocab/terms#groupId> "languages" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "languages" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#Group> .
-<https://lambdasistemi.github.io/graph-browser/vocab/groups#framework> <https://lambdasistemi.github.io/graph-browser/vocab/terms#groupId> "framework" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "framework" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#Group> .
-<https://lambdasistemi.github.io/graph-browser/vocab/groups#ecosystem> <https://lambdasistemi.github.io/graph-browser/vocab/terms#groupId> "ecosystem" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "ecosystem" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#Group> .
-<https://lambdasistemi.github.io/graph-browser/vocab/groups#core> <https://lambdasistemi.github.io/graph-browser/vocab/terms#groupId> "core" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "core" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#Group> .
-<https://lambdasistemi.github.io/graph-browser/vocab/groups#actors> <https://lambdasistemi.github.io/graph-browser/vocab/terms#groupId> "actors" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "actors" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#Group> .
-<https://lambdasistemi.github.io/graph-browser/vocab/groups#actions> <https://lambdasistemi.github.io/graph-browser/vocab/terms#groupId> "actions" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "actions" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#Group> .
-<https://lambdasistemi.github.io/graph-browser/vocab/kinds#tool> <https://lambdasistemi.github.io/graph-browser/vocab/terms#shape> "round-pentagon" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#color> "#56d4dd" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#kindId> "tool" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Tool" ;
-	a <http://www.w3.org/2000/01/rdf-schema#Class> .
-<https://lambdasistemi.github.io/graph-browser/vocab/kinds#standard> <https://lambdasistemi.github.io/graph-browser/vocab/terms#shape> "round-pentagon" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#color> "#e3b341" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#kindId> "standard" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Standard" ;
-	a <http://www.w3.org/2000/01/rdf-schema#Class> .
-<https://lambdasistemi.github.io/graph-browser/vocab/kinds#runtime> <https://lambdasistemi.github.io/graph-browser/vocab/terms#shape> "round-hexagon" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#color> "#ff7b72" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#kindId> "runtime" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Runtime" ;
-	a <http://www.w3.org/2000/01/rdf-schema#Class> .
-<https://lambdasistemi.github.io/graph-browser/vocab/kinds#protocol> <https://lambdasistemi.github.io/graph-browser/vocab/terms#shape> "barrel" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#color> "#f0883e" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#kindId> "protocol" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Protocol" ;
-	a <http://www.w3.org/2000/01/rdf-schema#Class> .
-<https://lambdasistemi.github.io/graph-browser/vocab/kinds#process> <https://lambdasistemi.github.io/graph-browser/vocab/terms#shape> "diamond" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#color> "#3fb950" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#kindId> "process" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Process" ;
-	a <http://www.w3.org/2000/01/rdf-schema#Class> .
-<https://lambdasistemi.github.io/graph-browser/vocab/kinds#parameter> <https://lambdasistemi.github.io/graph-browser/vocab/terms#shape> "round-rectangle" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#color> "#a5d6a7" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#kindId> "parameter" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Parameter" ;
-	a <http://www.w3.org/2000/01/rdf-schema#Class> .
-<https://lambdasistemi.github.io/graph-browser/vocab/kinds#param-group> <https://lambdasistemi.github.io/graph-browser/vocab/terms#shape> "barrel" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#color> "#e3b341" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#kindId> "param-group" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Param Group" ;
-	a <http://www.w3.org/2000/01/rdf-schema#Class> .
-<https://lambdasistemi.github.io/graph-browser/vocab/kinds#mechanism> <https://lambdasistemi.github.io/graph-browser/vocab/terms#shape> "round-hexagon" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#color> "#bc8cff" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#kindId> "mechanism" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Mechanism" ;
-	a <http://www.w3.org/2000/01/rdf-schema#Class> .
-<https://lambdasistemi.github.io/graph-browser/vocab/kinds#language> <https://lambdasistemi.github.io/graph-browser/vocab/terms#shape> "diamond" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#color> "#d2a8ff" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#kindId> "language" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Language" ;
-	a <http://www.w3.org/2000/01/rdf-schema#Class> .
-<https://lambdasistemi.github.io/graph-browser/vocab/kinds#concept> <https://lambdasistemi.github.io/graph-browser/vocab/terms#shape> "round-octagon" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#color> "#79c0ff" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#kindId> "concept" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Concept" ;
-	a <http://www.w3.org/2000/01/rdf-schema#Class> .
-<https://lambdasistemi.github.io/graph-browser/vocab/kinds#artifact> <https://lambdasistemi.github.io/graph-browser/vocab/terms#shape> "rectangle" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#color> "#f778ba" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#kindId> "artifact" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Artifact" ;
-	a <http://www.w3.org/2000/01/rdf-schema#Class> .
-<https://lambdasistemi.github.io/graph-browser/vocab/kinds#actor> <https://lambdasistemi.github.io/graph-browser/vocab/terms#shape> "ellipse" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#color> "#58a6ff" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#kindId> "actor" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Actor" ;
-	a <http://www.w3.org/2000/01/rdf-schema#Class> .
-<https://lambdasistemi.github.io/graph-browser/vocab/kinds#action-type> <https://lambdasistemi.github.io/graph-browser/vocab/terms#shape> "round-rectangle" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#color> "#d29922" ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#kindId> "action-type" ;
-	<http://www.w3.org/2000/01/rdf-schema#label> "Action Type" ;
-	a <http://www.w3.org/2000/01/rdf-schema#Class> .
-<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> <https://lambdasistemi.github.io/graph-browser/vocab/terms#sourceRepository> "https://github.com/lambdasistemi/cardano-knowledge-maps"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#edgeCount> 129 ;
-	<https://lambdasistemi.github.io/graph-browser/vocab/terms#nodeCount> 88 ;
-	<http://purl.org/dc/terms/description> "Interactive knowledge maps of the Cardano ecosystem — governance, smart contracts, and more." ;
-	<http://purl.org/dc/terms/title> "Cardano Knowledge Maps" ;
-	a <https://lambdasistemi.github.io/graph-browser/vocab/terms#Dataset> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+@prefix prov:    <http://www.w3.org/ns/prov#> .
+@prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
+@prefix gb:      <https://lambdasistemi.github.io/graph-browser/vocab/terms#> .
+@prefix gbkind:  <https://lambdasistemi.github.io/graph-browser/vocab/kinds#> .
+@prefix gbgroup: <https://lambdasistemi.github.io/graph-browser/vocab/groups#> .
+@prefix gbedge:  <https://lambdasistemi.github.io/graph-browser/vocab/edges#> .
+@prefix cardano: <https://lambdasistemi.github.io/cardano-knowledge-maps/vocab/cardano#> .
+@prefix n:       <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/> .
+
+# -- Edges ----------------------------------------------------------------
+
+n:cip-88 cardano:registersMetadataFor n:minting-policy .
+[] a rdf:Statement ;
+  rdf:subject n:cip-88 ;
+  rdf:predicate cardano:registersMetadataFor ;
+  rdf:object n:minting-policy ;
+  dcterms:description "CIP-88 provides a standard for declaring token metadata linked to a minting policy, enabling verifiable token information." .
+
+n:cip-85 cardano:optimizes n:plutus-core .
+[] a rdf:Statement ;
+  rdf:subject n:cip-85 ;
+  rdf:predicate cardano:optimizes ;
+  rdf:object n:plutus-core ;
+  dcterms:description "CIP-85 replaces Scott-encoded data with native sums-of-products in Plutus Core, reducing script size and execution cost." .
+
+n:cip-381 cardano:addsBuiltInsTo n:plutus-core .
+[] a rdf:Statement ;
+  rdf:subject n:cip-381 ;
+  rdf:predicate cardano:addsBuiltInsTo ;
+  rdf:object n:plutus-core ;
+  dcterms:description "CIP-381 adds BLS12-381 curve operations as Plutus Core built-in functions for on-chain cryptographic verification." .
+
+n:cip-69 cardano:unifiesScriptTypesIn n:plutus .
+[] a rdf:Statement ;
+  rdf:subject n:cip-69 ;
+  rdf:predicate cardano:unifiesScriptTypesIn ;
+  rdf:object n:plutus ;
+  dcterms:description "CIP-69 unifies the argument interface across all Plutus script purposes, enabling multi-purpose validators." .
+
+n:govtool cardano:rendersProfilesFrom n:cip-119 .
+[] a rdf:Statement ;
+  rdf:subject n:govtool ;
+  rdf:predicate cardano:rendersProfilesFrom ;
+  rdf:object n:cip-119 ;
+  dcterms:description "GovTool reads and displays DRep profile metadata structured according to CIP-119." .
+
+n:drep cardano:profileFollows n:cip-119 .
+[] a rdf:Statement ;
+  rdf:subject n:drep ;
+  rdf:predicate cardano:profileFollows ;
+  rdf:object n:cip-119 ;
+  dcterms:description "DReps publish their profile metadata following CIP-119, enabling voters to discover and evaluate representatives through governance tools." .
+
+n:cip-119 dcterms:requires n:cip-100 .
+[] a rdf:Statement ;
+  rdf:subject n:cip-119 ;
+  rdf:predicate dcterms:requires ;
+  rdf:object n:cip-100 ;
+  dcterms:description "CIP-119 builds on CIP-100's base governance metadata format, adding DRep-specific fields like display name, bio, motivations, and qualifications." .
+
+n:mesh-sdk prov:used n:cip-30 .
+[] a rdf:Statement ;
+  rdf:subject n:mesh-sdk ;
+  rdf:predicate prov:used ;
+  rdf:object n:cip-30 ;
+  dcterms:description "Mesh SDK uses CIP-30 to interact with browser-based Cardano wallets." .
+
+n:lucid-evolution prov:used n:cip-30 .
+[] a rdf:Statement ;
+  rdf:subject n:lucid-evolution ;
+  rdf:predicate prov:used ;
+  rdf:object n:cip-30 ;
+  dcterms:description "Lucid Evolution uses CIP-30 to connect to browser wallets for transaction signing and submission." .
+
+n:cip-95 dcterms:requires n:cip-30 .
+[] a rdf:Statement ;
+  rdf:subject n:cip-95 ;
+  rdf:predicate dcterms:requires ;
+  rdf:object n:cip-30 ;
+  dcterms:description "CIP-95 extends the CIP-30 wallet connector with Conway-era governance capabilities: DRep registration, vote delegation, and governance action submission." .
+
+n:lucid-evolution prov:used n:cip-57 .
+[] a rdf:Statement ;
+  rdf:subject n:lucid-evolution ;
+  rdf:predicate prov:used ;
+  rdf:object n:cip-57 ;
+  dcterms:description "Lucid can auto-generate off-chain bindings from CIP-57 Plutus blueprints." .
+
+n:demeter <https://lambdasistemi.github.io/graph-browser/vocab/edges#hosts%20infrastructure%20for> n:plutus .
+[] a rdf:Statement ;
+  rdf:subject n:demeter ;
+  rdf:predicate <https://lambdasistemi.github.io/graph-browser/vocab/edges#hosts%20infrastructure%20for> ;
+  rdf:object n:plutus ;
+  dcterms:description "Demeter provides cloud infrastructure for developing, testing, and deploying Plutus-based dApps." .
+
+n:blockfrost cardano:indexes n:eutxo .
+[] a rdf:Statement ;
+  rdf:subject n:blockfrost ;
+  rdf:predicate cardano:indexes ;
+  rdf:object n:eutxo ;
+  dcterms:description "Blockfrost indexes the UTxO set and provides REST APIs for querying chain state, script datums, and transaction history." .
+
+n:mesh-sdk cardano:buildsTransactionsFor n:plutus .
+[] a rdf:Statement ;
+  rdf:subject n:mesh-sdk ;
+  rdf:predicate cardano:buildsTransactionsFor ;
+  rdf:object n:plutus ;
+  dcterms:description "Mesh SDK provides high-level TypeScript APIs for building transactions that interact with smart contracts." .
+
+n:lucid-evolution cardano:buildsTransactionsFor n:plutus .
+[] a rdf:Statement ;
+  rdf:subject n:lucid-evolution ;
+  rdf:predicate cardano:buildsTransactionsFor ;
+  rdf:object n:plutus ;
+  dcterms:description "Lucid Evolution constructs off-chain transactions that interact with Plutus validators, handling datum/redeemer serialization." .
+
+n:djed cardano:builtOn n:plutus .
+[] a rdf:Statement ;
+  rdf:subject n:djed ;
+  rdf:predicate cardano:builtOn ;
+  rdf:object n:plutus ;
+  dcterms:description "Djed stablecoin uses Plutus validators with formally verified peg stability properties." .
+
+n:hydra gbedge:replicates n:eutxo .
+[] a rdf:Statement ;
+  rdf:subject n:hydra ;
+  rdf:predicate gbedge:replicates ;
+  rdf:object n:eutxo ;
+  dcterms:description "Hydra L2 heads replicate the full EUTxO model off-chain with the same smart contract semantics." .
+
+n:liqwid cardano:writtenIn n:plutarch .
+[] a rdf:Statement ;
+  rdf:subject n:liqwid ;
+  rdf:predicate cardano:writtenIn ;
+  rdf:object n:plutarch ;
+  dcterms:description "Liqwid uses Plutarch for performance-critical lending/borrowing validators." .
+
+n:minswap cardano:writtenIn n:aiken .
+[] a rdf:Statement ;
+  rdf:subject n:minswap ;
+  rdf:predicate cardano:writtenIn ;
+  rdf:object n:aiken ;
+  dcterms:description "Minswap V2 validators are written in Aiken for production-grade AMM DEX." .
+
+n:aiken prov:generated n:cip-57 .
+[] a rdf:Statement ;
+  rdf:subject n:aiken ;
+  rdf:predicate prov:generated ;
+  rdf:object n:cip-57 ;
+  dcterms:description "Aiken automatically generates CIP-57 Plutus blueprints from contract source code." .
+
+n:cip-57 cardano:documents n:plutus .
+[] a rdf:Statement ;
+  rdf:subject n:cip-57 ;
+  rdf:predicate cardano:documents ;
+  rdf:object n:plutus ;
+  dcterms:description "CIP-57 blueprints provide machine-readable interface documentation for Plutus contracts." .
+
+n:cip-68 cardano:succeeds n:cip-25 .
+[] a rdf:Statement ;
+  rdf:subject n:cip-68 ;
+  rdf:predicate cardano:succeeds ;
+  rdf:object n:cip-25 ;
+  dcterms:description "CIP-68 is the successor to CIP-25, adding mutability and richer metadata capabilities." .
+
+n:cip-68 prov:used n:datum .
+[] a rdf:Statement ;
+  rdf:subject n:cip-68 ;
+  rdf:predicate prov:used ;
+  rdf:object n:datum ;
+  dcterms:description "CIP-68 stores rich metadata in UTxO datums, enabling mutable token metadata." .
+
+n:cip-25 dcterms:requires n:minting-policy .
+[] a rdf:Statement ;
+  rdf:subject n:cip-25 ;
+  rdf:predicate dcterms:requires ;
+  rdf:object n:minting-policy ;
+  dcterms:description "CIP-25 defines how NFT metadata is attached to minting transactions via label 721." .
+
+n:oracle-pattern prov:used n:reference-inputs .
+[] a rdf:Statement ;
+  rdf:subject n:oracle-pattern ;
+  rdf:predicate prov:used ;
+  rdf:object n:reference-inputs ;
+  dcterms:description "Oracles publish data in UTxO datums; consumers read via reference inputs without contention." .
+
+n:state-machine prov:used n:datum .
+[] a rdf:Statement ;
+  rdf:subject n:state-machine ;
+  rdf:predicate prov:used ;
+  rdf:object n:datum ;
+  dcterms:description "State machines store contract state in the datum, with validators enforcing valid transitions." .
+
+n:staking-validator cardano:optimizes n:eutxo .
+[] a rdf:Statement ;
+  rdf:subject n:staking-validator ;
+  rdf:predicate cardano:optimizes ;
+  rdf:object n:eutxo ;
+  dcterms:description "The withdraw-zero pattern reduces validation cost from O(n²) to O(n) by consolidating logic in a staking validator." .
+
+n:marlowe cardano:compilesTo n:plutus-core .
+[] a rdf:Statement ;
+  rdf:subject n:marlowe ;
+  rdf:predicate cardano:compilesTo ;
+  rdf:object n:plutus-core ;
+  dcterms:description "Marlowe financial contracts compile to Plutus Core validators with formal verification guarantees." .
+
+n:plu-ts cardano:compilesTo n:plutus-core .
+[] a rdf:Statement ;
+  rdf:subject n:plu-ts ;
+  rdf:predicate cardano:compilesTo ;
+  rdf:object n:plutus-core ;
+  dcterms:description "plu-ts constructs UPLC AST directly in TypeScript." .
+
+n:plutarch cardano:compilesTo n:plutus-core .
+[] a rdf:Statement ;
+  rdf:subject n:plutarch ;
+  rdf:predicate cardano:compilesTo ;
+  rdf:object n:plutus-core ;
+  dcterms:description "Plutarch generates UPLC with fine-grained control, producing highly optimized validators." .
+
+n:scalus cardano:compilesTo n:plutus-core .
+[] a rdf:Statement ;
+  rdf:subject n:scalus ;
+  rdf:predicate cardano:compilesTo ;
+  rdf:object n:plutus-core ;
+  dcterms:description "Scalus compiles Scala 3 to UPLC with compile-time partial evaluation." .
+
+n:helios cardano:compilesTo n:plutus-core .
+[] a rdf:Statement ;
+  rdf:subject n:helios ;
+  rdf:predicate cardano:compilesTo ;
+  rdf:object n:plutus-core ;
+  dcterms:description "Helios compiles its TypeScript-embedded DSL to Plutus Core." .
+
+n:opshin cardano:compilesTo n:plutus-core .
+[] a rdf:Statement ;
+  rdf:subject n:opshin ;
+  rdf:predicate cardano:compilesTo ;
+  rdf:object n:plutus-core ;
+  dcterms:description "OpShin compiles Python syntax to UPLC, enforcing a strict type system at compile time." .
+
+n:plinth cardano:compilesTo n:plutus-core .
+[] a rdf:Statement ;
+  rdf:subject n:plinth ;
+  rdf:predicate cardano:compilesTo ;
+  rdf:object n:plutus-core ;
+  dcterms:description "Plinth (formerly PlutusTx) compiles a Haskell subset to Plutus Core via GHC plugin." .
+
+n:aiken cardano:compilesTo n:plutus-core .
+[] a rdf:Statement ;
+  rdf:subject n:aiken ;
+  rdf:predicate cardano:compilesTo ;
+  rdf:object n:plutus-core ;
+  dcterms:description "Aiken compiles directly to UPLC (Untyped Plutus Core) with aggressive optimization passes." .
+
+n:action-param-change cardano:affects n:exunits .
+[] a rdf:Statement ;
+  rdf:subject n:action-param-change ;
+  rdf:predicate cardano:affects ;
+  rdf:object n:exunits ;
+  dcterms:description "Parameter changes can modify ExUnits prices, changing how much ada scripts cost to run." .
+
+n:action-param-change <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20modify> n:cost-models .
+[] a rdf:Statement ;
+  rdf:subject n:action-param-change ;
+  rdf:predicate <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20modify> ;
+  rdf:object n:cost-models ;
+  dcterms:description "Parameter change governance actions can update cost model values, affecting smart contract execution costs." .
+
+n:guardrails-script cardano:writtenIn n:plutus .
+[] a rdf:Statement ;
+  rdf:subject n:guardrails-script ;
+  rdf:predicate cardano:writtenIn ;
+  rdf:object n:plutus ;
+  dcterms:description "The on-chain guardrails script is a Plutus validator that enforces constitutional rules on governance parameter changes." .
+
+n:minting-policy <https://lambdasistemi.github.io/graph-browser/vocab/edges#type%20of> n:plutus .
+[] a rdf:Statement ;
+  rdf:subject n:minting-policy ;
+  rdf:predicate <https://lambdasistemi.github.io/graph-browser/vocab/edges#type%20of> ;
+  rdf:object n:plutus ;
+  dcterms:description "Minting policies are Plutus scripts that control native token creation and destruction." .
+
+n:inline-datums dcterms:relation n:datum .
+[] a rdf:Statement ;
+  rdf:subject n:inline-datums ;
+  rdf:predicate dcterms:relation ;
+  rdf:object n:datum ;
+  dcterms:description "Inline datums store the full datum in the UTxO, eliminating off-chain datum management." .
+
+n:reference-inputs dcterms:requires n:eutxo .
+[] a rdf:Statement ;
+  rdf:subject n:reference-inputs ;
+  rdf:predicate dcterms:requires ;
+  rdf:object n:eutxo ;
+  dcterms:description "Reference inputs add read-only UTxO access to the EUTxO model, enabling oracle and shared state patterns." .
+
+n:reference-scripts cardano:optimizes n:plutus .
+[] a rdf:Statement ;
+  rdf:subject n:reference-scripts ;
+  rdf:predicate cardano:optimizes ;
+  rdf:object n:plutus ;
+  dcterms:description "Reference scripts reduce costs by allowing scripts to be stored on-chain once and reused across transactions." .
+
+n:eutxo cardano:enables n:plutus .
+[] a rdf:Statement ;
+  rdf:subject n:eutxo ;
+  rdf:predicate cardano:enables ;
+  rdf:object n:plutus ;
+  dcterms:description "The EUTxO model is what makes Plutus smart contracts possible — validators receive datum, redeemer, and context." .
+
+n:script-context gbedge:provides n:eutxo .
+[] a rdf:Statement ;
+  rdf:subject n:script-context ;
+  rdf:predicate gbedge:provides ;
+  rdf:object n:eutxo ;
+  dcterms:description "The script context gives validators full visibility into the transaction being validated." .
+
+n:redeemer dcterms:requires n:eutxo .
+[] a rdf:Statement ;
+  rdf:subject n:redeemer ;
+  rdf:predicate dcterms:requires ;
+  rdf:object n:eutxo ;
+  dcterms:description "Redeemers provide the action/input mechanism for EUTxO script validation." .
+
+n:datum dcterms:requires n:eutxo .
+[] a rdf:Statement ;
+  rdf:subject n:datum ;
+  rdf:predicate dcterms:requires ;
+  rdf:object n:eutxo ;
+  dcterms:description "Datums are the key extension that transforms the UTxO model into EUTxO, enabling stateful contracts." .
+
+n:cost-models cardano:belongsToGroup n:param-group-technical .
+[] a rdf:Statement ;
+  rdf:subject n:cost-models ;
+  rdf:predicate cardano:belongsToGroup ;
+  rdf:object n:param-group-technical ;
+  dcterms:description "Cost model parameters are part of the technical parameter group." .
+
+n:exunits cardano:pricedBy n:cost-models .
+[] a rdf:Statement ;
+  rdf:subject n:exunits ;
+  rdf:predicate cardano:pricedBy ;
+  rdf:object n:cost-models ;
+  dcterms:description "ExUnits are converted to ada fees using price parameters from the cost model." .
+
+n:cek-machine prov:used n:exunits .
+[] a rdf:Statement ;
+  rdf:subject n:cek-machine ;
+  rdf:predicate prov:used ;
+  rdf:object n:exunits ;
+  dcterms:description "The CEK machine tracks CPU steps and memory units during script evaluation, enforcing ExUnits budgets." .
+
+n:plutus-core cardano:evaluatedBy n:cek-machine .
+[] a rdf:Statement ;
+  rdf:subject n:plutus-core ;
+  rdf:predicate cardano:evaluatedBy ;
+  rdf:object n:cek-machine ;
+  dcterms:description "Plutus Core programs are evaluated by the CEK machine, which tracks resource consumption." .
+
+n:plutus cardano:compilesTo n:plutus-core .
+[] a rdf:Statement ;
+  rdf:subject n:plutus ;
+  rdf:predicate cardano:compilesTo ;
+  rdf:object n:plutus-core ;
+  dcterms:description "Plutus Tx (Haskell) compiles to Plutus Core, the on-chain language executed by the CEK machine." .
+
+n:guardrails-script gbedge:enforces n:param-exceptions .
+[] a rdf:Statement ;
+  rdf:subject n:guardrails-script ;
+  rdf:predicate gbedge:enforces ;
+  rdf:object n:param-exceptions ;
+  dcterms:description "The Guardrails Script implements the per-parameter threshold exceptions on-chain. When a Protocol Parameter Change governance action is submitted, the script checks not just the permitted value ranges but also whether the correct voting bodies and thresholds apply for each specific parameter being changed." .
+
+n:param-exceptions cardano:modifiesVotingFor n:action-param-change .
+[] a rdf:Statement ;
+  rdf:subject n:param-exceptions ;
+  rdf:predicate cardano:modifiesVotingFor ;
+  rdf:object n:action-param-change ;
+  dcterms:description "Per-parameter threshold exceptions change which bodies vote and at what thresholds for specific parameter changes. For example, committeeMaxTermLength only requires DRep 67% with no CC or SPO vote — a unique exception where the CC is excluded because the parameter directly governs CC member terms, and self-governance would be a conflict of interest." .
+
+n:param-exceptions <https://lambdasistemi.github.io/graph-browser/vocab/edges#overrides%20thresholds%20from> n:param-group-governance .
+[] a rdf:Statement ;
+  rdf:subject n:param-exceptions ;
+  rdf:predicate <https://lambdasistemi.github.io/graph-browser/vocab/edges#overrides%20thresholds%20from> ;
+  rdf:object n:param-group-governance ;
+  dcterms:description "Some parameters that belong to the Economic or Technical groups are constitutionally elevated to Governance group thresholds (DRep 75% + CC 2/3). This includes dRepDeposit, stakePoolDeposit, stakeAddressDeposit, minPoolCost, and committeeMinSize. The Constitution treats these as governance-critical despite their technical classification." .
+
+n:action-info <https://lambdasistemi.github.io/graph-browser/vocab/edges#used%20for> n:treasury-budgeting .
+[] a rdf:Statement ;
+  rdf:subject n:action-info ;
+  rdf:predicate <https://lambdasistemi.github.io/graph-browser/vocab/edges#used%20for> ;
+  rdf:object n:treasury-budgeting ;
+  dcterms:description "Info Actions, despite having no direct on-chain effect, are the mechanism for the treasury budgeting process. Net Change Limits and Budget approvals are submitted as Info Actions with effective voting thresholds of DRep 50% + CC 2/3. This repurposes the Info Action type for binding community decisions that gate subsequent Treasury Withdrawals." .
+
+n:treasury-budgeting gbedge:gates n:action-treasury .
+[] a rdf:Statement ;
+  rdf:subject n:treasury-budgeting ;
+  rdf:predicate gbedge:gates ;
+  rdf:object n:action-treasury ;
+  dcterms:description "Treasury Withdrawals can only be submitted after a Net Change Limit and Budget have been approved. The Net Change Limit (Info Action, DRep 50% + CC 2/3) sets the maximum withdrawal amount per period. Budget proposals (also Info Actions, DRep 50% + CC 2/3) allocate portions of that limit. Only then can Treasury Withdrawal governance actions be submitted against the approved budget." .
+
+n:cost-models <https://lambdasistemi.github.io/graph-browser/vocab/edges#updated%20via> n:action-param-change .
+[] a rdf:Statement ;
+  rdf:subject n:cost-models ;
+  rdf:predicate <https://lambdasistemi.github.io/graph-browser/vocab/edges#updated%20via> ;
+  rdf:object n:action-param-change ;
+  dcterms:description "Cost model updates go through Protocol Parameter Change governance: the Plutus team benchmarks builtins, fits cost functions via R scripts, and the new coefficients are submitted as a governance action requiring CC 2/3 and DRep 67% (Technical group threshold)." .
+
+n:sanchonet gbedge:tested n:conway-era .
+[] a rdf:Statement ;
+  rdf:subject n:sanchonet ;
+  rdf:predicate gbedge:tested ;
+  rdf:object n:conway-era ;
+  dcterms:description "SanchoNet was a dedicated governance testnet (launched 2023) where the community tested CIP-1694 features before mainnet. It validated the Conway implementation and allowed governance tooling development against a live environment." .
+
+n:govtool <https://lambdasistemi.github.io/graph-browser/vocab/edges#enables%20registration%20as> n:drep .
+[] a rdf:Statement ;
+  rdf:subject n:govtool ;
+  rdf:predicate <https://lambdasistemi.github.io/graph-browser/vocab/edges#enables%20registration%20as> ;
+  rdf:object n:drep ;
+  dcterms:description "GovTool provides a web interface for DRep registration and delegation, handling certificate submission and deposit payment without CLI tools." .
+
+n:govtool cardano:enables n:voting .
+[] a rdf:Statement ;
+  rdf:subject n:govtool ;
+  rdf:predicate cardano:enables ;
+  rdf:object n:voting ;
+  dcterms:description "GovTool connects to wallets via CIP-95 and enables viewing governance actions, reading metadata, and casting votes on-chain. It makes governance accessible to non-technical participants." .
+
+n:cardano-foundation cardano:evaluatesAndVotesOn n:governance-action .
+[] a rdf:Statement ;
+  rdf:subject n:cardano-foundation ;
+  rdf:predicate cardano:evaluatesAndVotesOn ;
+  rdf:object n:governance-action ;
+  dcterms:description "The CF evaluates governance actions for constitutional compliance and governance merit through its Governance Advisory Team. It publishes vote rationales and created the Proposal Examiner tool for structured evaluation." .
+
+n:cardano-foundation <https://lambdasistemi.github.io/graph-browser/vocab/edges#registered%20as> n:drep .
+[] a rdf:Statement ;
+  rdf:subject n:cardano-foundation ;
+  rdf:predicate <https://lambdasistemi.github.io/graph-browser/vocab/edges#registered%20as> ;
+  rdf:object n:drep ;
+  dcterms:description "The CF registered as a DRep to actively participate in governance, bringing institutional expertise and a Governance Advisory Team. It publishes detailed vote rationales, setting a standard for transparent governance engagement." .
+
+n:intersect cardano:facilitates n:governance-model .
+[] a rdf:Statement ;
+  rdf:subject n:intersect ;
+  rdf:predicate cardano:facilitates ;
+  rdf:object n:governance-model ;
+  dcterms:description "Intersect provides off-chain governance infrastructure: Parameter Committee, CC elections, working groups, hard fork coordination, CIP process, and GovTool. It fills the coordination gap between decentralized on-chain governance and the practical need for organized deliberation." .
+
+n:cip-105 <https://lambdasistemi.github.io/graph-browser/vocab/edges#derives%20keys%20for> n:drep .
+[] a rdf:Statement ;
+  rdf:subject n:cip-105 ;
+  rdf:predicate <https://lambdasistemi.github.io/graph-browser/vocab/edges#derives%20keys%20for> ;
+  rdf:object n:drep ;
+  dcterms:description "CIP-105 specifies how wallets derive governance key pairs (for DRep registration and voting) from a master seed, ensuring keys are recoverable from a mnemonic phrase." .
+
+n:cip-129 <https://lambdasistemi.github.io/graph-browser/vocab/edges#standardizes%20IDs%20for> n:governance-action .
+[] a rdf:Statement ;
+  rdf:subject n:cip-129 ;
+  rdf:predicate <https://lambdasistemi.github.io/graph-browser/vocab/edges#standardizes%20IDs%20for> ;
+  rdf:object n:governance-action ;
+  dcterms:description "CIP-129 defines canonical governance action IDs used across wallets, explorers, and governance tools for consistent cross-tool reference." .
+
+n:cip-129 <https://lambdasistemi.github.io/graph-browser/vocab/edges#standardizes%20IDs%20for> n:drep .
+[] a rdf:Statement ;
+  rdf:subject n:cip-129 ;
+  rdf:predicate <https://lambdasistemi.github.io/graph-browser/vocab/edges#standardizes%20IDs%20for> ;
+  rdf:object n:drep ;
+  dcterms:description "CIP-129 defines canonical string representations for DRep IDs, ensuring all tools display the same identifier for the same representative." .
+
+n:cc <https://lambdasistemi.github.io/graph-browser/vocab/edges#publishes%20rationales%20via> n:cip-136 .
+[] a rdf:Statement ;
+  rdf:subject n:cc ;
+  rdf:predicate <https://lambdasistemi.github.io/graph-browser/vocab/edges#publishes%20rationales%20via> ;
+  rdf:object n:cip-136 ;
+  dcterms:description "CC members publish structured vote rationales using CIP-136 metadata. This format requires citing specific constitutional articles, creating a public record of constitutional interpretation that builds governance case law." .
+
+n:govtool <https://lambdasistemi.github.io/graph-browser/vocab/edges#connects%20wallets%20via> n:cip-95 .
+[] a rdf:Statement ;
+  rdf:subject n:govtool ;
+  rdf:predicate <https://lambdasistemi.github.io/graph-browser/vocab/edges#connects%20wallets%20via> ;
+  rdf:object n:cip-95 ;
+  dcterms:description "GovTool uses CIP-95 to connect to users' browser wallets. CIP-95 extends the CIP-30 wallet connector with governance capabilities: DRep registration, delegation, and voting transactions." .
+
+n:cip-108 dcterms:requires n:cip-100 .
+[] a rdf:Statement ;
+  rdf:subject n:cip-108 ;
+  rdf:predicate dcterms:requires ;
+  rdf:object n:cip-100 ;
+  dcterms:description "CIP-108 builds on CIP-100's base metadata format, adding governance-action-specific fields (title, abstract, motivation, rationale). CIP-100 defines the general anchor structure; CIP-108 defines what goes inside it for governance actions." .
+
+n:governance-action <https://lambdasistemi.github.io/graph-browser/vocab/edges#structured%20as> n:cip-108 .
+[] a rdf:Statement ;
+  rdf:subject n:governance-action ;
+  rdf:predicate <https://lambdasistemi.github.io/graph-browser/vocab/edges#structured%20as> ;
+  rdf:object n:cip-108 ;
+  dcterms:description "Governance action metadata is structured according to CIP-108, which defines required fields: title, abstract, motivation, rationale, and references. This ensures voters have consistent information when evaluating proposals." .
+
+n:governance-action <https://lambdasistemi.github.io/graph-browser/vocab/edges#metadata%20follows> n:cip-100 .
+[] a rdf:Statement ;
+  rdf:subject n:governance-action ;
+  rdf:predicate <https://lambdasistemi.github.io/graph-browser/vocab/edges#metadata%20follows> ;
+  rdf:object n:cip-100 ;
+  dcterms:description "Every governance action includes a metadata anchor (URL + hash) following CIP-100's general governance metadata format. The metadata is stored off-chain but its hash is recorded on-chain for integrity verification." .
+
+n:drep cardano:requires n:deposit-mechanism .
+[] a rdf:Statement ;
+  rdf:subject n:drep ;
+  rdf:predicate cardano:requires ;
+  rdf:object n:deposit-mechanism ;
+  dcterms:description "DRep registration requires 500 ada (refundable on retirement). This prevents spam registrations while keeping registration accessible. The amount is a Governance group protocol parameter changeable with 75% DRep threshold." .
+
+n:governance-action cardano:requires n:deposit-mechanism .
+[] a rdf:Statement ;
+  rdf:subject n:governance-action ;
+  rdf:predicate cardano:requires ;
+  rdf:object n:deposit-mechanism ;
+  dcterms:description "Submitting a governance action requires 100,000 ada (refundable). This anti-spam mechanism prevents frivolous proposals from flooding the chain. The amount is a Governance group parameter, also classified as security-relevant (requires SPO approval to change)." .
+
+n:cc cardano:subjectTo n:cc-threshold .
+[] a rdf:Statement ;
+  rdf:subject n:cc ;
+  rdf:predicate cardano:subjectTo ;
+  rdf:object n:cc-threshold ;
+  dcterms:description "CC uses one-member-one-vote with a configurable threshold (currently 2/3). Expired members cannot vote. Minimum committee size is 7 on mainnet. The threshold is changeable via the Update Committee governance action." .
+
+n:spo cardano:subjectTo n:spo-thresholds .
+[] a rdf:Statement ;
+  rdf:subject n:spo ;
+  rdf:predicate cardano:subjectTo ;
+  rdf:object n:spo-thresholds ;
+  dcterms:description "SPO votes are tallied at 51% of active pool stake for all applicable actions: No-Confidence (Q1), Committee Update (Q2a/Q2b), Hard Fork (Q4), security parameters (Q5), and Info (100% fixed)." .
+
+n:drep cardano:subjectTo n:drep-thresholds .
+[] a rdf:Statement ;
+  rdf:subject n:drep ;
+  rdf:predicate cardano:subjectTo ;
+  rdf:object n:drep-thresholds ;
+  dcterms:description "DRep votes are tallied against action-type-specific thresholds of active voting stake: No-Confidence 67%, Committee Update 67%/60%, New Constitution 75%, Hard Fork 60%, Network/Economic/Technical params 67%, Governance params 75%, Treasury 67%, Info 100%." .
+
+n:conway-era <https://lambdasistemi.github.io/graph-browser/vocab/edges#started%20with> n:bootstrap-phase .
+[] a rdf:Statement ;
+  rdf:subject n:conway-era ;
+  rdf:predicate <https://lambdasistemi.github.io/graph-browser/vocab/edges#started%20with> ;
+  rdf:object n:bootstrap-phase ;
+  dcterms:description "Conway began with a bootstrap phase where only CC could approve parameter changes and CC + SPOs could approve hard forks. DRep participation was not required. This phased rollout prevented governance deadlocks while DRep registration ramped up. Ended with the Plomin hard fork in December 2024." .
+
+n:cip-1694 cardano:implementedIn n:conway-era .
+[] a rdf:Statement ;
+  rdf:subject n:cip-1694 ;
+  rdf:predicate cardano:implementedIn ;
+  rdf:object n:conway-era ;
+  dcterms:description "CIP-1694 was implemented in the Conway ledger era via two phases: Chang #1 (August 2024, bootstrap) and Plomin hard fork (December 2024, full activation). Conway is the current ledger era, representing the Voltaire phase of Cardano's roadmap." .
+
+n:cip-1694 cardano:specifies n:governance-model .
+[] a rdf:Statement ;
+  rdf:subject n:cip-1694 ;
+  rdf:predicate cardano:specifies ;
+  rdf:object n:governance-model ;
+  dcterms:description "CIP-1694 formally specifies the entire on-chain governance mechanism: three bodies, seven action types, voting/ratification rules, CC structure, DRep mechanics, deposits, action chaining, and the full governance lifecycle. It is the authoritative technical specification." .
+
+n:governance-model <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> n:cc .
+[] a rdf:Statement ;
+  rdf:subject n:governance-model ;
+  rdf:predicate <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> ;
+  rdf:object n:cc ;
+  dcterms:description "The CC forms the third governance body with one-member-one-vote (not stake-weighted). Its role is purely constitutional review. It votes on actions that change protocol rules but not on actions about its own composition, preventing self-dealing." .
+
+n:governance-model <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> n:spo .
+[] a rdf:Statement ;
+  rdf:subject n:governance-model ;
+  rdf:predicate <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> ;
+  rdf:object n:spo ;
+  dcterms:description "SPOs form the second governance body, representing the infrastructure layer. They vote on a limited subset: Hard Forks, No-Confidence, Committee Updates, security parameters, and Info. This focused scope ensures operators have voice on matters affecting their operations." .
+
+n:governance-model <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> n:drep .
+[] a rdf:Statement ;
+  rdf:subject n:governance-model ;
+  rdf:predicate <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> ;
+  rdf:object n:drep ;
+  dcterms:description "DReps form the first of three governance bodies, representing all ada holders who delegate to them. They vote on all seven action types with stake-weighted voting, providing the democratic legitimacy layer of governance." .
+
+n:governance-model gbedge:implements n:liquid-democracy .
+[] a rdf:Statement ;
+  rdf:subject n:governance-model ;
+  rdf:predicate gbedge:implements ;
+  rdf:object n:liquid-democracy ;
+  dcterms:description "Cardano's governance combines direct and representative democracy. Ada holders can vote directly (as DReps) or delegate. Delegation is fluid — changeable at any time with immediate effect. This ensures all stake can participate without requiring every holder to be actively engaged." .
+
+n:action-update-committee cardano:changesMembershipOf n:cc .
+[] a rdf:Statement ;
+  rdf:subject n:action-update-committee ;
+  rdf:predicate cardano:changesMembershipOf ;
+  rdf:object n:cc ;
+  dcterms:description "The sole mechanism for modifying CC membership, terms, and approval threshold. Can add new members with term expirations, remove members, and adjust the approval fraction. Used both for routine updates and to replace a committee in no-confidence state." .
+
+n:action-no-confidence cardano:putsIntoNoConfidenceState n:cc .
+[] a rdf:Statement ;
+  rdf:subject n:action-no-confidence ;
+  rdf:predicate cardano:putsIntoNoConfidenceState ;
+  rdf:object n:cc ;
+  dcterms:description "When ratified, the CC enters no-confidence state and cannot approve any governance actions. This blocks all action types requiring CC approval. Recovery requires electing a new committee via Update Committee, which has a lower DRep threshold (60% vs 67%) in no-confidence state." .
+
+n:action-new-constitution <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20update> n:guardrails-script .
+[] a rdf:Statement ;
+  rdf:subject n:action-new-constitution ;
+  rdf:predicate <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20update> ;
+  rdf:object n:guardrails-script ;
+  dcterms:description "Can optionally include a new Guardrails Script hash. This is the only mechanism for updating the enforcement script, ensuring it stays synchronized with constitutional amendments." .
+
+n:action-new-constitution gbedge:modifies n:constitution .
+[] a rdf:Statement ;
+  rdf:subject n:action-new-constitution ;
+  rdf:predicate gbedge:modifies ;
+  rdf:object n:constitution ;
+  dcterms:description "The only mechanism for amending the Cardano Constitution. The action includes an anchor to the new text. Requires DRep 75% and CC 2/3 majority. The current Constitution was ratified at the Buenos Aires Constitutional Convention in December 2024." .
+
+n:constitution cardano:codifiedIn n:guardrails-script .
+[] a rdf:Statement ;
+  rdf:subject n:constitution ;
+  rdf:predicate cardano:codifiedIn ;
+  rdf:object n:guardrails-script ;
+  dcterms:description "The Constitution's enforceable rules — particularly Appendix I's parameter ranges and treasury limits — are codified in the on-chain Guardrails Script. The Constitution provides the authoritative rules; the script automates enforcement of the programmatically expressible subset." .
+
+n:guardrails-script cardano:constrains n:action-treasury .
+[] a rdf:Statement ;
+  rdf:subject n:guardrails-script ;
+  rdf:predicate cardano:constrains ;
+  rdf:object n:action-treasury ;
+  dcterms:description "The Guardrails Script enforces treasury withdrawal limits (TREASURY-01a through TREASURY-04a). This automated enforcement ensures treasury funds cannot be drained beyond constitutional bounds even if sufficient votes are gathered." .
+
+n:guardrails-script cardano:constrains n:action-param-change .
+[] a rdf:Statement ;
+  rdf:subject n:guardrails-script ;
+  rdf:predicate cardano:constrains ;
+  rdf:object n:action-param-change ;
+  dcterms:description "The Guardrails Script checks that proposed parameter values fall within permitted ranges from the Constitution's Appendix I. Named guardrails PARAM-01 through PARAM-06a define rules. The script rejects non-compliant transactions before they reach voting." .
+
+n:param-group-governance skos:related n:security-params .
+[] a rdf:Statement ;
+  rdf:subject n:param-group-governance ;
+  rdf:predicate skos:related ;
+  rdf:object n:security-params ;
+  dcterms:description "govActionDeposit is the only Governance group security-relevant parameter. Currently 100,000 ada, it prevents spam governance actions. SPO approval at Q5 = 51% is required to change it." .
+
+n:param-group-economic skos:related n:security-params .
+[] a rdf:Statement ;
+  rdf:subject n:param-group-economic ;
+  rdf:predicate skos:related ;
+  rdf:object n:security-params ;
+  dcterms:description "Economic security-relevant parameters: txFeePerByte, txFeeFixed, utxoCostPerByte, minFeeRefScriptCostPerByte. Setting these too low enables denial-of-service via cheap spam transactions. SPO approval at Q5 = 51% is required." .
+
+n:param-group-network skos:related n:security-params .
+[] a rdf:Statement ;
+  rdf:subject n:param-group-network ;
+  rdf:predicate skos:related ;
+  rdf:object n:security-params ;
+  dcterms:description "Network security-relevant parameters: maxBlockBodySize, maxTxSize, maxBlockHeaderSize, maxValueSize, maxBlockExecutionUnits. Changes to these additionally require SPO approval at Q5 = 51%, giving infrastructure operators a veto." .
+
+n:param-group-technical skos:member n:cost-models .
+[] a rdf:Statement ;
+  rdf:subject n:param-group-technical ;
+  rdf:predicate skos:member ;
+  rdf:object n:cost-models ;
+  dcterms:description "Plutus cost models assign abstract CPU and memory costs to each builtin function, calibrated by benchmarking on a reference machine. These are consensus-critical — every node must compute identical ExUnits. Updates go through the Technical group governance threshold." .
+
+n:action-param-change cardano:canChange n:param-group-governance .
+[] a rdf:Statement ;
+  rdf:subject n:action-param-change ;
+  rdf:predicate cardano:canChange ;
+  rdf:object n:param-group-governance ;
+  dcterms:description "Governance group includes all 15 voting thresholds, govActionLifetime, govActionDeposit, dRepDeposit, dRepActivity, committeeMinSize, and committeeMaxTermLength. Changes require the highest DRep threshold at 75% plus CC 2/3, reflecting the self-referential nature of changing governance rules." .
+
+n:action-param-change cardano:canChange n:param-group-technical .
+[] a rdf:Statement ;
+  rdf:subject n:action-param-change ;
+  rdf:predicate cardano:canChange ;
+  rdf:object n:param-group-technical ;
+  dcterms:description "Technical group includes poolPledgeInfluence, poolRetireMaxEpoch, stakePoolTargetNum, costModels, and collateralPercentage. The costModels parameter determines Plutus builtin pricing. Changes require CC 2/3 and DRep 67%." .
+
+n:action-param-change cardano:canChange n:param-group-economic .
+[] a rdf:Statement ;
+  rdf:subject n:action-param-change ;
+  rdf:predicate cardano:canChange ;
+  rdf:object n:param-group-economic ;
+  dcterms:description "Economic group includes txFeePerByte, txFeeFixed, stakeAddressDeposit, stakePoolDeposit, monetaryExpansion, treasuryCut, minPoolCost, utxoCostPerByte, executionUnitPrices, and minFeeRefScriptCostPerByte. Changes require CC 2/3 and DRep 67%." .
+
+n:action-param-change cardano:canChange n:param-group-network .
+[] a rdf:Statement ;
+  rdf:subject n:action-param-change ;
+  rdf:predicate cardano:canChange ;
+  rdf:object n:param-group-network ;
+  dcterms:description "Network group includes maxBlockBodySize, maxTxSize, maxBlockHeaderSize, maxValueSize, maxTxExecutionUnits, maxBlockExecutionUnits, and maxCollateralInputs. Changes require CC 2/3 and DRep 67%. Several are security-relevant, additionally requiring SPO 51%." .
+
+n:action-info rdfs:subClassOf n:governance-action .
+[] a rdf:Statement ;
+  rdf:subject n:action-info ;
+  rdf:predicate rdfs:subClassOf ;
+  rdf:object n:governance-action ;
+  dcterms:description "Info Action has no on-chain effect and uses a fixed 100% threshold. It records community sentiment and polls stakeholders before committing to binding actions. Does not require action chaining." .
+
+n:action-treasury rdfs:subClassOf n:governance-action .
+[] a rdf:Statement ;
+  rdf:subject n:action-treasury ;
+  rdf:predicate rdfs:subClassOf ;
+  rdf:object n:governance-action ;
+  dcterms:description "Treasury Withdrawal disburses ada from the treasury. Requires CC 2/3 and DRep 67%. Does not require action chaining, allowing multiple independent withdrawals to proceed concurrently." .
+
+n:action-param-change rdfs:subClassOf n:governance-action .
+[] a rdf:Statement ;
+  rdf:subject n:action-param-change ;
+  rdf:predicate rdfs:subClassOf ;
+  rdf:object n:governance-action ;
+  dcterms:description "Protocol Parameter Changes modify one or more of ~30 updatable parameters in four groups (Network, Economic, Technical, Governance). Each group has its own DRep threshold. Security-relevant parameters additionally require SPO approval." .
+
+n:action-hard-fork rdfs:subClassOf n:governance-action .
+[] a rdf:Statement ;
+  rdf:subject n:action-hard-fork ;
+  rdf:predicate rdfs:subClassOf ;
+  rdf:object n:governance-action ;
+  dcterms:description "Hard Fork Initiation is the only action requiring all three bodies: CC 2/3, DReps 60%, SPOs 51%. It specifies a new major protocol version. A ratified hard fork delays all other pending ratifications." .
+
+n:action-new-constitution rdfs:subClassOf n:governance-action .
+[] a rdf:Statement ;
+  rdf:subject n:action-new-constitution ;
+  rdf:predicate rdfs:subClassOf ;
+  rdf:object n:governance-action ;
+  dcterms:description "New Constitution / Guardrails Script requires the highest DRep threshold at 75% plus CC 2/3 majority. SPOs do not vote. It can update both the Constitution text and the automated enforcement script." .
+
+n:action-update-committee rdfs:subClassOf n:governance-action .
+[] a rdf:Statement ;
+  rdf:subject n:action-update-committee ;
+  rdf:predicate rdfs:subClassOf ;
+  rdf:object n:governance-action ;
+  dcterms:description "Update Committee can add/remove CC members, set term expirations, and adjust the CC threshold. The CC does not vote. Thresholds differ by CC state: normal DRep 67% + SPO 51%; no-confidence DRep 60% + SPO 51%." .
+
+n:action-no-confidence rdfs:subClassOf n:governance-action .
+[] a rdf:Statement ;
+  rdf:subject n:action-no-confidence ;
+  rdf:predicate rdfs:subClassOf ;
+  rdf:object n:governance-action ;
+  dcterms:description "Motion of No-Confidence is the highest-priority action type. It requires DRep 67% and SPO 51%. The CC does not vote. When ratified, it blocks the CC from participating until a new committee is elected." .
+
+n:governance-action prov:used n:action-chaining .
+[] a rdf:Statement ;
+  rdf:subject n:governance-action ;
+  rdf:predicate prov:used ;
+  rdf:object n:action-chaining ;
+  dcterms:description "Most action types (except Treasury and Info) must reference the most recently enacted action of the same type. This prevents conflicting same-type actions from both ratifying when they assume incompatible starting states." .
+
+n:voting gbedge:determines n:ratification .
+[] a rdf:Statement ;
+  rdf:subject n:voting ;
+  rdf:predicate gbedge:determines ;
+  rdf:object n:ratification ;
+  dcterms:description "Accumulated votes determine whether an action meets its thresholds. At each epoch boundary, a fresh tally is calculated using the current stake snapshot. An action is ratified when all required thresholds are simultaneously met." .
+
+n:governance-action <https://lambdasistemi.github.io/graph-browser/vocab/edges#open%20for> n:voting .
+[] a rdf:Statement ;
+  rdf:subject n:governance-action ;
+  rdf:predicate <https://lambdasistemi.github.io/graph-browser/vocab/edges#open%20for> ;
+  rdf:object n:voting ;
+  dcterms:description "Once submitted, a governance action is immediately available for voting. DRep and SPO votes are stake-weighted; CC votes are one-member-one-vote. Votes can be changed at any time before ratification. Registered stake that did not vote counts as 'No'." .
+
+n:ratification cardano:leadsTo n:enactment .
+[] a rdf:Statement ;
+  rdf:subject n:ratification ;
+  rdf:predicate cardano:leadsTo ;
+  rdf:object n:enactment ;
+  dcterms:description "Ratified actions are enacted at the next epoch boundary. There is always at least a one-epoch gap. If a high-priority action (No-Confidence, Committee Update, New Constitution, or Hard Fork) is ratified, it delays ratification of all other pending actions until after its enactment." .
+
+n:governance-action gbedge:undergoes n:ratification .
+[] a rdf:Statement ;
+  rdf:subject n:governance-action ;
+  rdf:predicate gbedge:undergoes ;
+  rdf:object n:ratification ;
+  dcterms:description "Every governance action enters ratification for up to govActionLifetime epochs (currently 6 / ~30 days). Ratification is checked only at epoch boundaries. An action can become ratified without new votes if delegation changes shift the stake distribution." .
+
+n:cc prov:used n:hot-cold-keys .
+[] a rdf:Statement ;
+  rdf:subject n:cc ;
+  rdf:predicate prov:used ;
+  rdf:object n:hot-cold-keys ;
+  dcterms:description "CC members use a hot/cold key credential system. The cold key is the member's identity, kept offline. The hot key is used for day-to-day voting. If compromised, the hot key can be rotated without changing the member's identity or requiring a Committee Update governance action." .
+
+n:cc cardano:evaluatesAgainst n:constitution .
+[] a rdf:Statement ;
+  rdf:subject n:cc ;
+  rdf:predicate cardano:evaluatesAgainst ;
+  rdf:object n:constitution ;
+  dcterms:description "The CC's sole mandate is constitutional review — it evaluates whether governance actions comply with the Cardano Constitution. The CC does NOT assess merit or desirability; it only checks constitutionality. CC members cite specific articles when publishing vote rationales via CIP-136." .
+
+n:cc cardano:votesOn n:action-info .
+[] a rdf:Statement ;
+  rdf:subject n:cc ;
+  rdf:predicate cardano:votesOn ;
+  rdf:object n:action-info ;
+  dcterms:description "The CC can vote on Info actions to signal its position. CC members may use CIP-136 metadata to cite specific constitutional articles in their vote rationale, providing constitutional analysis even on non-binding proposals." .
+
+n:cc cardano:votesOn n:action-treasury .
+[] a rdf:Statement ;
+  rdf:subject n:cc ;
+  rdf:predicate cardano:votesOn ;
+  rdf:object n:action-treasury ;
+  dcterms:description "The CC reviews treasury withdrawals for constitutional compliance, including requirements that withdrawals specify purpose, expected costs, and provide for auditable accounts. CC approval at 2/3 is required alongside DRep approval at 67%." .
+
+n:cc cardano:votesOn n:action-param-change .
+[] a rdf:Statement ;
+  rdf:subject n:cc ;
+  rdf:predicate cardano:votesOn ;
+  rdf:object n:action-param-change ;
+  dcterms:description "The CC reviews parameter changes for constitutional compliance, particularly against Appendix I which defines permitted parameter ranges. CC approval at 2/3 majority is required for all parameter groups." .
+
+n:cc cardano:votesOn n:action-hard-fork .
+[] a rdf:Statement ;
+  rdf:subject n:cc ;
+  rdf:predicate cardano:votesOn ;
+  rdf:object n:action-hard-fork ;
+  dcterms:description "The CC reviews hard fork proposals for constitutional compliance — whether the upgrade respects tenets on transaction freedom, predictable costs, and backward compatibility. CC approval at 2/3 is required alongside DRep and SPO approval." .
+
+n:cc cardano:votesOn n:action-new-constitution .
+[] a rdf:Statement ;
+  rdf:subject n:cc ;
+  rdf:predicate cardano:votesOn ;
+  rdf:object n:action-new-constitution ;
+  dcterms:description "The CC must approve constitutional amendments because its mandate is ensuring governance actions comply with the Constitution. CC approval at 2/3 majority is required alongside the highest DRep threshold (75%)." .
+
+n:spo cardano:votesOn n:action-info .
+[] a rdf:Statement ;
+  rdf:subject n:spo ;
+  rdf:predicate cardano:votesOn ;
+  rdf:object n:action-info ;
+  dcterms:description "SPOs can vote on Info actions to signal their position on community proposals. Since Info actions have no on-chain effect and use a fixed 100% threshold, SPO votes serve purely as a gauge of infrastructure operator sentiment." .
+
+n:spo <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on%20changes%20to> n:security-params .
+[] a rdf:Statement ;
+  rdf:subject n:spo ;
+  rdf:predicate <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on%20changes%20to> ;
+  rdf:object n:security-params ;
+  dcterms:description "Security-relevant parameters (maxBlockBodySize, maxTxSize, txFeePerByte, etc.) directly affect node resource requirements. SPO approval at Q5 = 51% gives infrastructure operators a veto over modifications that could make block production uneconomical or destabilize the network." .
+
+n:spo cardano:votesOn n:action-hard-fork .
+[] a rdf:Statement ;
+  rdf:subject n:spo ;
+  rdf:predicate cardano:votesOn ;
+  rdf:object n:action-hard-fork ;
+  dcterms:description "Hard Fork Initiation requires approval from all three bodies. SPOs must approve at Q4 = 51% because they must actually upgrade their node software. Guardrail HARDFORK-04a requires at least 85% of stake pools to have upgraded before enactment." .
+
+n:spo cardano:votesOn n:action-update-committee .
+[] a rdf:Statement ;
+  rdf:subject n:spo ;
+  rdf:predicate cardano:votesOn ;
+  rdf:object n:action-update-committee ;
+  dcterms:description "SPOs vote on Committee Updates because the CC's role in ratifying hard forks and security parameter changes directly affects node operators. SPO approval at Q2a/Q2b = 51% is required." .
+
+n:spo cardano:votesOn n:action-no-confidence .
+[] a rdf:Statement ;
+  rdf:subject n:spo ;
+  rdf:predicate cardano:votesOn ;
+  rdf:object n:action-no-confidence ;
+  dcterms:description "SPOs vote on Motions of No-Confidence because a dysfunctional CC could block critical protocol upgrades. SPO approval at Q1 = 51% is required alongside DRep approval at 67%." .
+
+n:drep cardano:votesOn n:governance-action .
+[] a rdf:Statement ;
+  rdf:subject n:drep ;
+  rdf:predicate cardano:votesOn ;
+  rdf:object n:governance-action ;
+  dcterms:description "DReps vote Yes, No, or Abstain on all seven types of governance actions. Their vote weight equals the total lovelace delegated to them. DReps must vote regularly or become inactive after the dRepActivity period (currently 20 epochs / 100 days)." .
+
+n:ada-holder cardano:canRegisterAs n:drep .
+[] a rdf:Statement ;
+  rdf:subject n:ada-holder ;
+  rdf:predicate cardano:canRegisterAs ;
+  rdf:object n:drep ;
+  dcterms:description "Any ada holder can register as a DRep by paying a refundable dRepDeposit (currently 500 ada). Self-delegation means the holder votes with their own stake weight. This is the 'direct democracy' path in Cardano's liquid democracy model." .
+
+n:ada-holder cardano:submits n:governance-action .
+[] a rdf:Statement ;
+  rdf:subject n:ada-holder ;
+  rdf:predicate cardano:submits ;
+  rdf:object n:governance-action ;
+  dcterms:description "Any ada holder can submit a governance action on-chain by paying the govActionDeposit (currently 100,000 ada, refundable). The submitter must include a metadata anchor following CIP-100/CIP-108 standards and, for most action types, a reference to the most recently enacted action of the same type." .
+
+n:ada-holder cardano:delegatesStakeTo n:spo .
+[] a rdf:Statement ;
+  rdf:subject n:ada-holder ;
+  rdf:predicate cardano:delegatesStakeTo ;
+  rdf:object n:spo ;
+  dcterms:description "Ada holders delegate stake to stake pools for block production via Ouroboros Praos. This is separate from DRep delegation — ada holders independently choose who produces blocks and who votes on governance. The pool's total stake also determines the SPO's governance voting weight." .
+
+n:ada-holder cardano:canDelegateTo n:no-confidence-option .
+[] a rdf:Statement ;
+  rdf:subject n:ada-holder ;
+  rdf:predicate cardano:canDelegateTo ;
+  rdf:object n:no-confidence-option ;
+  dcterms:description "Ada holders who distrust the current governance state can delegate to No Confidence. This stake IS counted in the active voting stake and automatically votes 'Yes' on every Motion of No-Confidence and 'No' on all other governance actions." .
+
+n:ada-holder cardano:canDelegateTo n:abstain-option .
+[] a rdf:Statement ;
+  rdf:subject n:ada-holder ;
+  rdf:predicate cardano:canDelegateTo ;
+  rdf:object n:abstain-option ;
+  dcterms:description "Ada holders who do not wish to participate in governance can delegate to the pre-defined Abstain option. Stake delegated to Abstain is excluded from the active voting stake denominator, meaning it neither helps nor blocks ratification of any governance action." .
+
+n:ada-holder cardano:delegatesVotingPowerTo n:drep .
+[] a rdf:Statement ;
+  rdf:subject n:ada-holder ;
+  rdf:predicate cardano:delegatesVotingPowerTo ;
+  rdf:object n:drep ;
+  dcterms:description "Under CIP-1694's liquid democracy model, ada holders delegate their voting power to any registered DRep. The delegated stake counts toward the DRep's vote weight on governance actions. Unlike stake pool delegation, DRep delegation takes effect immediately with no two-epoch lag and can be changed at any time." .
+
+# -- Nodes ----------------------------------------------------------------
+
+n:cip-88
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#registers%20metadata%20for> n:minting-policy ;
+  gb:description "Token Policy Registration — a metadata standard for registering information about a token's minting policy on-chain. Enables policy authors to declare the token's name, description, logo, decimals, and project details in a verifiable way. Helps wallets, explorers, and marketplaces display accurate token information without relying on centralized registries." ;
+  gb:group gbgroup:standards ;
+  rdfs:label "CIP-88" ;
+  gb:nodeId "cip-88" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:standard ;
+  a gb:Node ;
+  foaf:page <https://cips.cardano.org/cip/CIP-0088> .
+
+n:cip-85
+  gbedge:optimizes n:plutus-core ;
+  gb:description "Sums-of-Products (SOPs) for Plutus Core — replaces the Scott-encoded data representation with native constructor/case expressions. This makes compiled Plutus scripts significantly smaller and faster by eliminating the overhead of encoding algebraic data types as lambda terms. SOPs shipped with Plutus V3 and are a key driver of the script size and execution cost reductions in the Conway era." ;
+  gb:group gbgroup:standards ;
+  rdfs:label "CIP-85" ;
+  gb:nodeId "cip-85" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:standard ;
+  a gb:Node ;
+  foaf:page <https://cips.cardano.org/cip/CIP-0085> .
+
+n:cip-381
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#adds%20built-ins%20to> n:plutus-core ;
+  gb:description "Adds BLS12-381 elliptic curve primitives as Plutus built-in functions. Enables zero-knowledge proofs (Groth16, PLONK), BLS signature verification, and advanced cryptographic protocols directly on-chain. These primitives support sidechains, bridges, and privacy-preserving applications on Cardano. Shipped with Plutus V3 in the Conway era." ;
+  gb:group gbgroup:standards ;
+  rdfs:label "CIP-381" ;
+  gb:nodeId "cip-381" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:standard ;
+  a gb:Node ;
+  foaf:page <https://cips.cardano.org/cip/CIP-0381> .
+
+n:cip-69
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#unifies%20script%20types%20in> n:plutus ;
+  gb:description "Plutus Script Type Uniformization — unifies the interface for all Plutus script purposes (spending, minting, certifying, rewarding) into a single uniform signature. Before CIP-69, minting policies received two arguments (redeemer, context) while spending validators received three (datum, redeemer, context). CIP-69 makes all script types take the same arguments, simplifying multi-purpose scripts and enabling a single validator to serve as both spending and minting script." ;
+  gb:group gbgroup:standards ;
+  rdfs:label "CIP-69" ;
+  gb:nodeId "cip-69" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:standard ;
+  a gb:Node ;
+  foaf:page <https://cips.cardano.org/cip/CIP-0069> .
+
+n:govtool
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#renders%20profiles%20from> n:cip-119 ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#enables%20registration%20as> n:drep ;
+  gbedge:enables n:voting ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#connects%20wallets%20via> n:cip-95 ;
+  gb:description "A web application for participating in Cardano governance. GovTool's four architectural pillars: Proposal Discussion, Delegation, Outcomes, and Voting. Users can delegate to DReps, register as DReps, view and vote on governance actions, and track outcomes. It connects to the user's wallet via CIP-95 (the Conway-era web-wallet bridge)." ;
+  gb:group gbgroup:ecosystem ;
+  rdfs:label "GovTool" ;
+  gb:nodeId "govtool" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:tool ;
+  a gb:Node ;
+  foaf:page <https://docs.gov.tools/overview/what-is-cardano-govtool> ;
+  rdfs:seeAlso <https://gov.tools> .
+
+n:drep
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#profile%20follows> n:cip-119 ;
+  gbedge:requires n:deposit-mechanism ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#subject%20to> n:drep-thresholds ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> n:governance-action ;
+  gb:description "Any ada holder can register as a DRep by paying a refundable deposit (currently 500 ada). DReps accumulate voting power from ada holders who delegate to them. Their vote weight equals the total lovelace delegated to them — one lovelace = one vote. DReps must vote regularly or they become inactive after the dRepActivity period (currently 20 epochs / 100 days). Inactive DReps do not count toward the active voting stake. DRep delegation is separate from stake pool delegation and takes effect immediately (no two-epoch lag). DReps are identified by a credential: an Ed25519 verification key or a native/Plutus script." ;
+  gb:group gbgroup:actors ;
+  rdfs:label "Delegated Representative (DRep)" ;
+  gb:nodeId "drep" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:actor ;
+  a gb:Node ;
+  foaf:page <https://cardanofoundation.org/blog/strengthens-commitment-governance-drep> ;
+  rdfs:seeAlso <https://developers.cardano.org/docs/governance/cardano-governance/governance-model/> ;
+  rdfs:seeAlso <https://docs.cardano.org/about-cardano/governance-overview> .
+
+n:cip-119
+  gbedge:extends n:cip-100 ;
+  gb:description "CIP-119 defines the governance metadata standard for Delegated Representatives. It extends CIP-100 with DRep-specific fields: display name, bio, motivations, qualifications, payment address, and references. This structured profile metadata helps ada holders make informed delegation decisions. GovTool and other governance interfaces render CIP-119 metadata on DRep profile pages." ;
+  gb:group gbgroup:framework ;
+  rdfs:label "CIP-119" ;
+  gb:nodeId "cip-119" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:artifact ;
+  a gb:Node ;
+  foaf:page <https://cips.cardano.org/cip/CIP-0119> .
+
+n:mesh-sdk
+  gbedge:uses n:cip-30 ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#builds%20transactions%20for> n:plutus ;
+  gb:description "TypeScript SDK with transaction builder, React components, wallet connectors, and smart contract integration. Higher-level alternative to Lucid with more out-of-the-box UI components." ;
+  gb:group gbgroup:tooling ;
+  rdfs:label "Mesh SDK" ;
+  gb:nodeId "mesh-sdk" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:tool ;
+  a gb:Node ;
+  foaf:page <https://github.com/MeshJS/mesh> ;
+  rdfs:seeAlso <https://meshjs.dev/> .
+
+n:lucid-evolution
+  gbedge:uses n:cip-30 ;
+  gbedge:consumes n:cip-57 ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#builds%20transactions%20for> n:plutus ;
+  gb:description "Production-ready TypeScript off-chain transaction builder. Successor to the original Lucid, maintained by Anastasia Labs. Supports Plutus V1/V2/V3, Conway hard fork ready. The standard choice for building Cardano dApp frontends." ;
+  gb:group gbgroup:tooling ;
+  rdfs:label "Lucid Evolution" ;
+  gb:nodeId "lucid-evolution" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:tool ;
+  a gb:Node ;
+  foaf:page <https://anastasia-labs.com/> ;
+  rdfs:seeAlso <https://github.com/Anastasia-Labs/lucid-evolution> ;
+  rdfs:seeAlso <https://anastasia-labs.github.io/lucid-evolution/> .
+
+n:cip-95
+  gbedge:extends n:cip-30 ;
+  gb:description "CIP-95 defines the web-wallet bridge for the Conway era. It extends the CIP-30 wallet connector with governance-specific capabilities: DRep registration, vote delegation, and governance action submission from browser-based wallets. Without CIP-95, governance tools like GovTool couldn't interact with users' wallets. It enables the 'connect wallet' flow that makes on-chain governance accessible to non-technical participants." ;
+  gb:group gbgroup:framework ;
+  rdfs:label "CIP-95" ;
+  gb:nodeId "cip-95" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:artifact ;
+  a gb:Node ;
+  foaf:page <https://cips.cardano.org/cip/CIP-0095> .
+
+n:demeter
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#hosts%20infrastructure%20for> n:plutus ;
+  gb:description "Cloud development platform for Cardano. Provides managed nodes, indexers, and Hydra infrastructure across mainnet/preprod/preview. No local infrastructure needed — develop and test in the cloud." ;
+  gb:group gbgroup:tooling ;
+  rdfs:label "Demeter.run" ;
+  gb:nodeId "demeter" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:tool ;
+  a gb:Node ;
+  foaf:page <https://docs.demeter.run/> ;
+  rdfs:seeAlso <https://demeter.run/> .
+
+n:blockfrost
+  gbedge:indexes n:eutxo ;
+  gb:description "Hosted REST API for Cardano blockchain data. Free tier available. SDKs in 15+ languages. The most common way dApps query chain state without running a full node. Also offers self-hosted option." ;
+  gb:group gbgroup:tooling ;
+  rdfs:label "Blockfrost" ;
+  gb:nodeId "blockfrost" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:tool ;
+  a gb:Node ;
+  foaf:page <https://github.com/blockfrost> ;
+  rdfs:seeAlso <https://docs.blockfrost.io/> ;
+  rdfs:seeAlso <https://blockfrost.io/> .
+
+n:djed
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#built%20on> n:plutus ;
+  gb:description "Overcollateralized algorithmic stablecoin. Maintained peg since January 2023 launch. Demonstrates formal verification applied to DeFi — the Djed paper provides mathematical proofs of peg stability under defined conditions." ;
+  gb:group gbgroup:protocols ;
+  rdfs:label "Djed" ;
+  gb:nodeId "djed" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:protocol ;
+  a gb:Node ;
+  foaf:page <https://eprint.iacr.org/2021/1069> ;
+  rdfs:seeAlso <https://djed.xyz/> .
+
+n:hydra
+  gbedge:replicates n:eutxo ;
+  gb:description "Layer 2 isomorphic state channels. Each \"head\" is a mini-ledger replicating Cardano's full functionality off-chain with sub-second latency and 1,000 TPS per head. Multiple heads scale linearly. Uses the same smart contract model as L1." ;
+  gb:group gbgroup:protocols ;
+  rdfs:label "Hydra" ;
+  gb:nodeId "hydra" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:protocol ;
+  a gb:Node ;
+  foaf:page <https://github.com/cardano-scaling/hydra> ;
+  rdfs:seeAlso <https://docs.cardano.org/developer-resources/scalability-solutions/hydra> ;
+  rdfs:seeAlso <https://hydra.family/head-protocol/> .
+
+n:liqwid
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#written%20in> n:plutarch ;
+  gb:description "Leading lending/borrowing protocol on Cardano. Non-custodial, supports liquid staking. DAO-governed via LQ token. Uses Plutarch for performance-critical validators. Demonstrates complex multi-contract DeFi on EUTxO." ;
+  gb:group gbgroup:protocols ;
+  rdfs:label "Liqwid Finance" ;
+  gb:nodeId "liqwid" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:protocol ;
+  a gb:Node ;
+  foaf:page <https://docs.liqwid.finance/> ;
+  rdfs:seeAlso <https://liqwid.finance/> .
+
+n:minswap
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#written%20in> n:aiken ;
+  gb:description "Largest Cardano DEX by TVL and weekly volume. Multi-pool AMM using the constant-product formula. Written in Aiken. Demonstrates production-scale smart contract usage on Cardano with batched order settlement." ;
+  gb:group gbgroup:protocols ;
+  rdfs:label "Minswap" ;
+  gb:nodeId "minswap" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:protocol ;
+  a gb:Node ;
+  foaf:page <https://github.com/minswap> ;
+  rdfs:seeAlso <https://docs.minswap.org/> ;
+  rdfs:seeAlso <https://minswap.org/> .
+
+n:aiken
+  gbedge:generates n:cip-57 ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> n:plutus-core ;
+  gb:description "Rust-inspired, purpose-built language for Cardano smart contracts. Most popular on-chain language — 75%+ of developers use it. Compiles directly to UPLC with excellent optimization. First-class Plutus blueprint (CIP-57) generation." ;
+  gb:group gbgroup:languages ;
+  rdfs:label "Aiken" ;
+  gb:nodeId "aiken" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:language ;
+  a gb:Node ;
+  foaf:page <https://aiken-lang.org/stdlib> ;
+  rdfs:seeAlso <https://aiken-lang.org/fundamentals/getting-started> ;
+  rdfs:seeAlso <https://github.com/aiken-lang/aiken> ;
+  rdfs:seeAlso <https://aiken-lang.org/> .
+
+n:cip-57
+  gbedge:documents n:plutus ;
+  gb:description "Plutus Contract Blueprint — machine-readable JSON schema (plutus.json) documenting a smart contract's interface: validators, parameters, datum/redeemer types. Enables tooling to auto-generate off-chain bindings. Aiken generates blueprints automatically." ;
+  gb:group gbgroup:standards ;
+  rdfs:label "CIP-57" ;
+  gb:nodeId "cip-57" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:standard ;
+  a gb:Node ;
+  foaf:page <https://aiken-lang.org/fundamentals/getting-started> ;
+  rdfs:seeAlso <https://cips.cardano.org/cip/CIP-57> .
+
+n:cip-68
+  gbedge:succeeds n:cip-25 ;
+  gbedge:uses n:datum ;
+  gb:description "Rich, mutable metadata standard. Uses a reference NFT (label 100) carrying metadata in its datum, paired with a user token (label 222 for NFTs, 333 for FTs). Metadata can be updated by spending the reference UTxO. Successor to CIP-25." ;
+  gb:group gbgroup:standards ;
+  rdfs:label "CIP-68" ;
+  gb:nodeId "cip-68" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:standard ;
+  a gb:Node ;
+  foaf:page <https://developers.cardano.org/docs/native-tokens/> ;
+  rdfs:seeAlso <https://cips.cardano.org/cip/CIP-68> .
+
+n:cip-25
+  gbedge:extends n:minting-policy ;
+  gb:description "Original NFT metadata standard. Metadata attached to minting transactions via transaction metadata label 721. Simple and widely adopted but metadata is immutable after minting. The foundation for Cardano's NFT ecosystem." ;
+  gb:group gbgroup:standards ;
+  rdfs:label "CIP-25" ;
+  gb:nodeId "cip-25" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:standard ;
+  a gb:Node ;
+  foaf:page <https://developers.cardano.org/docs/native-tokens/minting-nfts/> ;
+  rdfs:seeAlso <https://cips.cardano.org/cip/CIP-25> .
+
+n:oracle-pattern
+  gbedge:uses n:reference-inputs ;
+  gb:description "Leverages CIP-31 reference inputs: an oracle publishes price/data in a UTxO datum, and multiple contracts read it simultaneously without spending it. Eliminates contention. Charli3 and Orcfax are the main Cardano oracle providers." ;
+  gb:group gbgroup:smart-contracts ;
+  rdfs:label "Oracle Pattern" ;
+  gb:nodeId "oracle-pattern" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node ;
+  foaf:page <https://orcfax.io/> ;
+  rdfs:seeAlso <https://charli3.io/> ;
+  rdfs:seeAlso <https://github.com/Anastasia-Labs/design-patterns> .
+
+n:state-machine
+  gbedge:uses n:datum ;
+  gb:description "Model contract state as a datum on a UTxO. The validator checks that input datum + redeemer produces a valid output datum, enforcing legal state transitions. Used for multi-step protocols: escrow, auctions, governance, DEX order matching." ;
+  gb:group gbgroup:smart-contracts ;
+  rdfs:label "State Machine Pattern" ;
+  gb:nodeId "state-machine" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node ;
+  foaf:page <https://github.com/input-output-hk/plutus-pioneer-program> ;
+  rdfs:seeAlso <https://scalus.org/docs/design-patterns> ;
+  rdfs:seeAlso <https://github.com/Anastasia-Labs/design-patterns> .
+
+n:staking-validator
+  gbedge:optimizes n:eutxo ;
+  gb:description "Validators attached to staking credentials. The \"withdraw zero\" pattern delegates expensive validation logic to a staking validator (called once per transaction) instead of a spending validator (called per input), reducing cost from O(n²) to O(n). Key optimization pattern." ;
+  gb:group gbgroup:smart-contracts ;
+  rdfs:label "Staking Validators" ;
+  gb:nodeId "staking-validator" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node ;
+  foaf:page <https://anastasia-labs.com/> ;
+  rdfs:seeAlso <https://github.com/Anastasia-Labs/design-patterns> .
+
+n:marlowe
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> n:plutus-core ;
+  gb:description "Domain-specific language for financial contracts. High-level, non-Turing-complete by design — contracts can be exhaustively analyzed and formally verified via Isabelle. Transitioned to community ownership (Marlowe Language CIC) in 2024." ;
+  gb:group gbgroup:languages ;
+  rdfs:label "Marlowe" ;
+  gb:nodeId "marlowe" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:language ;
+  a gb:Node ;
+  foaf:page <https://developers.cardano.org/docs/smart-contracts/smart-contract-languages/marlowe/> ;
+  rdfs:seeAlso <https://github.com/marlowe-lang> ;
+  rdfs:seeAlso <https://marlowe.iohk.io/> .
+
+n:plu-ts
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> n:plutus-core ;
+  gb:description "TypeScript-embedded DSL for on-chain smart contracts plus off-chain transaction building. Constructs UPLC AST directly in TypeScript. Single-language stack for JS/TS developers. Maintained by Harmonic Labs." ;
+  gb:group gbgroup:languages ;
+  rdfs:label "plu-ts" ;
+  gb:nodeId "plu-ts" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:language ;
+  a gb:Node ;
+  foaf:page <https://github.com/HarmonicLabs/plu-ts> ;
+  rdfs:seeAlso <https://pluts.harmoniclabs.tech/> .
+
+n:plutarch
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> n:plutus-core ;
+  gb:description "Haskell eDSL giving fine-grained control over generated UPLC. Produces significantly more efficient validators than PlutusTx. Created by Liqwid Labs / MLabs. Used by several high-TVL protocols for performance-critical validators." ;
+  gb:group gbgroup:languages ;
+  rdfs:label "Plutarch" ;
+  gb:nodeId "plutarch" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:language ;
+  a gb:Node ;
+  foaf:page <https://github.com/Plutonomicon/plutonomicon> ;
+  rdfs:seeAlso <https://github.com/Plutonomicon/plutarch-plutus> .
+
+n:scalus
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> n:plutus-core ;
+  gb:description "Write smart contracts in Scala 3, compiled to UPLC. Runs on JVM, JS, and Native. UPLC optimizer with compile-time partial evaluation produces competitive script sizes. Full ScalaTest/ScalaCheck support for property-based testing." ;
+  gb:group gbgroup:languages ;
+  rdfs:label "Scalus" ;
+  gb:nodeId "scalus" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:language ;
+  a gb:Node ;
+  foaf:page <https://scalus.org/docs/design-patterns> ;
+  rdfs:seeAlso <https://github.com/scalus3/scalus> ;
+  rdfs:seeAlso <https://scalus.org/> .
+
+n:helios
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> n:plutus-core ;
+  gb:description "JavaScript/TypeScript SDK with its own on-chain DSL — functional, strongly typed, curly-brace syntax. Compiles to Plutus Core. Also handles off-chain transaction building, making it an all-in-one toolkit for JS developers." ;
+  gb:group gbgroup:languages ;
+  rdfs:label "Helios" ;
+  gb:nodeId "helios" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:language ;
+  a gb:Node ;
+  foaf:page <https://github.com/HeliosLang/compiler> ;
+  rdfs:seeAlso <https://helios-lang.io/> .
+
+n:opshin
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> n:plutus-core ;
+  gb:description "Write Cardano smart contracts in 100% valid Python syntax. Enforces a strict type system on top of Python. Integrates with PyCardano for off-chain code. Lowers the barrier for Python developers entering the Cardano ecosystem." ;
+  gb:group gbgroup:languages ;
+  rdfs:label "OpShin" ;
+  gb:nodeId "opshin" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:language ;
+  a gb:Node ;
+  foaf:page <https://pycardano.readthedocs.io/> ;
+  rdfs:seeAlso <https://github.com/OpShin/opshin> ;
+  rdfs:seeAlso <https://opshin.dev/> .
+
+n:plinth
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> n:plutus-core ;
+  gb:description "Write smart contracts in a subset of Haskell, compiled to UPLC. Formerly PlutusTx, rebranded in February 2025. The original on-chain language maintained by IntersectMBO. Tight integration with the Haskell ecosystem and GHC type system." ;
+  gb:group gbgroup:languages ;
+  rdfs:label "Plinth" ;
+  gb:nodeId "plinth" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:language ;
+  a gb:Node ;
+  foaf:page <https://github.com/input-output-hk/plutus-pioneer-program> ;
+  rdfs:seeAlso <https://github.com/IntersectMBO/plutus> ;
+  rdfs:seeAlso <https://plutus.cardano.intersectmbo.org/docs/> .
+
+n:action-param-change
+  gbedge:affects n:exunits ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20modify> n:cost-models ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> n:param-group-governance ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> n:param-group-technical ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> n:param-group-economic ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> n:param-group-network ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> n:governance-action ;
+  gb:description "Changes one or more updatable protocol parameters. Parameters are grouped into four categories (Network, Economic, Technical, Governance), each with its own DRep voting threshold. Requires CC approval (2/3 majority) for all groups. If the change touches security-relevant parameters, SPOs must also approve at 51%. The Guardrails Script enforces permitted ranges for each parameter. This is the mechanism used for Plutus cost model updates — cost model parameters are part of the Technical group." ;
+  gb:group gbgroup:actions ;
+  rdfs:label "5. Protocol Parameter Changes" ;
+  gb:nodeId "action-param-change" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:action-type ;
+  a gb:Node ;
+  foaf:page <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> ;
+  rdfs:seeAlso <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> .
+
+n:guardrails-script
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#written%20in> n:plutus ;
+  gbedge:enforces n:param-exceptions ;
+  gbedge:constrains n:action-treasury ;
+  gbedge:constrains n:action-param-change ;
+  gb:description "An on-chain Plutus script that enforces specific constitutional rules programmatically. It applies ONLY to protocol parameter changes and treasury withdrawals — these are the two governance action types where automated enforcement is feasible. The script checks parameter bounds (e.g., maxBlockBodySize must be between 24,576 and 122,880 bytes) and treasury withdrawal limits. Named guardrails include PARAM-01 through PARAM-06a (parameter rules), TREASURY-01a through TREASURY-04a (withdrawal limits), HARDFORK-01 through HARDFORK-08, and committee/constitution update rules. The guardrails script can be updated via a New Constitution governance action." ;
+  gb:group gbgroup:framework ;
+  rdfs:label "Guardrails Script" ;
+  gb:nodeId "guardrails-script" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:artifact ;
+  a gb:Node ;
+  foaf:page <https://developers.cardano.org/docs/governance/cardano-governance/submitting-governance-actions/> ;
+  rdfs:seeAlso <https://cips.cardano.org/cip/CIP-1694> .
+
+n:minting-policy
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#type%20of> n:plutus ;
+  gb:description "A Plutus script that controls the creation and destruction of native tokens. The policy receives the script context and decides whether to allow minting or burning. The policy hash becomes the first part of the token's asset ID, cryptographically binding tokens to their minting rules." ;
+  gb:group gbgroup:smart-contracts ;
+  rdfs:label "Minting Policy" ;
+  gb:nodeId "minting-policy" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node ;
+  foaf:page <https://cips.cardano.org/cip/CIP-25> ;
+  rdfs:seeAlso <https://aiken-lang.org/fundamentals/getting-started> ;
+  rdfs:seeAlso <https://developers.cardano.org/docs/native-tokens/minting/> .
+
+n:inline-datums
+  gbedge:improves n:datum ;
+  gb:description "CIP-32 feature that stores the full datum directly in the UTxO instead of just a hash. Eliminates the need for off-chain datum management — anyone can see the contract state by reading the UTxO. Essential for composability between protocols." ;
+  gb:group gbgroup:smart-contracts ;
+  rdfs:label "Inline Datums" ;
+  gb:nodeId "inline-datums" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:mechanism ;
+  a gb:Node ;
+  foaf:page <https://docs.cardano.org/about-cardano/evolution/upgrades/vasil/> ;
+  rdfs:seeAlso <https://cips.cardano.org/cip/CIP-0032> .
+
+n:reference-inputs
+  gbedge:extends n:eutxo ;
+  gb:description "CIP-31 feature allowing transactions to read UTxOs without spending them. Enables oracle patterns, shared state, and read-only access to on-chain data. Referenced UTxOs appear in the script context but remain unspent." ;
+  gb:group gbgroup:smart-contracts ;
+  rdfs:label "Reference Inputs" ;
+  gb:nodeId "reference-inputs" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:mechanism ;
+  a gb:Node ;
+  foaf:page <https://github.com/Anastasia-Labs/design-patterns> ;
+  rdfs:seeAlso <https://developers.cardano.org/docs/smart-contracts/plutus/> ;
+  rdfs:seeAlso <https://cips.cardano.org/cip/CIP-0031> .
+
+n:reference-scripts
+  gbedge:optimizes n:plutus ;
+  gb:description "CIP-33 feature allowing scripts to be stored on-chain in a UTxO and referenced by transactions without including the script in the transaction body. Dramatically reduces transaction size and fees for popular contracts. The reference script UTxO is not spent." ;
+  gb:group gbgroup:smart-contracts ;
+  rdfs:label "Reference Scripts" ;
+  gb:nodeId "reference-scripts" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:mechanism ;
+  a gb:Node ;
+  foaf:page <https://docs.cardano.org/about-cardano/evolution/upgrades/vasil/> ;
+  rdfs:seeAlso <https://developers.cardano.org/docs/smart-contracts/plutus/> ;
+  rdfs:seeAlso <https://cips.cardano.org/cip/CIP-0033> .
+
+n:eutxo
+  gbedge:enables n:plutus ;
+  gb:description "Extended UTxO — Cardano's transaction model that extends Bitcoin's UTxO with datum, redeemer, and script validation. Each UTxO can be locked by a validator script. Spending requires providing a redeemer that satisfies the validator. The model enables deterministic transaction validation — fees and outcomes are known before submission." ;
+  gb:group gbgroup:smart-contracts ;
+  rdfs:label "EUTxO Model" ;
+  gb:nodeId "eutxo" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node ;
+  foaf:page <https://ucarecdn.com/3da33f2f-73ac-4c9b-844b-f215dcce0628/EUTXOhandbook_for_ec.pdf> ;
+  rdfs:seeAlso <https://developers.cardano.org/docs/smart-contracts/> ;
+  rdfs:seeAlso <https://docs.cardano.org/about-cardano/learn/eutxo-explainer/> ;
+  rdfs:seeAlso <https://iohk.io/en/research/library/papers/the-extended-utxo-model/> .
+
+n:script-context
+  gbedge:provides n:eutxo ;
+  gb:description "The full transaction context passed to a Plutus validator. Includes all inputs, outputs, minting, certificates, withdrawals, validity range, signatories, and datum map. Scripts can inspect any part of the transaction to enforce arbitrary conditions." ;
+  gb:group gbgroup:smart-contracts ;
+  rdfs:label "Script Context" ;
+  gb:nodeId "script-context" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node ;
+  foaf:page <https://plutus.cardano.intersectmbo.org/docs/> ;
+  rdfs:seeAlso <https://aiken-lang.org/fundamentals/getting-started> ;
+  rdfs:seeAlso <https://developers.cardano.org/docs/smart-contracts/plutus/> .
+
+n:redeemer
+  gbedge:extends n:eutxo ;
+  gb:description "User-provided data included in a transaction to unlock a script-locked UTxO. The redeemer represents the action the user wants to perform. The validator script receives the datum, redeemer, and script context and decides whether to allow the spending." ;
+  gb:group gbgroup:smart-contracts ;
+  rdfs:label "Redeemer" ;
+  gb:nodeId "redeemer" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node ;
+  foaf:page <https://aiken-lang.org/fundamentals/getting-started> ;
+  rdfs:seeAlso <https://developers.cardano.org/docs/smart-contracts/plutus/> .
+
+n:datum
+  gbedge:extends n:eutxo ;
+  gb:description "Data attached to a UTxO that is locked by a Plutus script. The datum represents the state of the contract. When spending the UTxO, the datum is passed to the validator script along with a redeemer and the transaction context. Can be stored inline (CIP-32) or as a hash with the full datum provided in the transaction." ;
+  gb:group gbgroup:smart-contracts ;
+  rdfs:label "Datum" ;
+  gb:nodeId "datum" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node ;
+  foaf:page <https://aiken-lang.org/fundamentals/getting-started> ;
+  rdfs:seeAlso <https://cips.cardano.org/cip/CIP-32> ;
+  rdfs:seeAlso <https://developers.cardano.org/docs/smart-contracts/plutus/> .
+
+n:cost-models
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#belongs%20to> n:param-group-technical ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#updated%20via> n:action-param-change ;
+  gb:description "Protocol parameters that assign abstract CPU and memory costs (ExUnits) to each Plutus builtin function. These are part of the Technical parameter group. Cost models are calibrated by benchmarking each builtin on a reference machine through the Haskell CEK machine, then fitting cost functions via R scripts. Coefficients are stored as 64-bit integers (picoseconds) for cross-platform reproducibility. The cost model ensures that maxBlockExUnits worth of abstract work fits within the real block validation time budget. Every node implementation (Haskell, Rust, etc.) must compute identical ExUnits — the abstract costs are consensus-critical. Updates go through the governance process as Protocol Parameter Changes." ;
+  gb:group gbgroup:parameters ;
+  rdfs:label "Plutus Cost Models" ;
+  gb:nodeId "cost-models" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:parameter ;
+  a gb:Node ;
+  foaf:page <https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/models.R> ;
+  rdfs:seeAlso <https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/data/benching-conway.csv> ;
+  rdfs:seeAlso <https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/CostModelGeneration.md> .
+
+n:exunits
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#priced%20by> n:cost-models ;
+  gb:description "Execution units — the two-dimensional resource budget for Plutus scripts. CPU steps measure computation time, memory units measure peak memory usage. Every transaction specifies ExUnits for each script it runs. Fees are computed from ExUnits using protocol parameters (prices per step/unit)." ;
+  gb:group gbgroup:smart-contracts ;
+  rdfs:label "ExUnits" ;
+  gb:nodeId "exunits" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node ;
+  foaf:page <https://plutus.cardano.intersectmbo.org/docs/reference/cardano/plutus-core-builtins-ref/> ;
+  rdfs:seeAlso <https://docs.cardano.org/about-cardano/explore-more/fee-structure/> ;
+  rdfs:seeAlso <https://developers.cardano.org/docs/smart-contracts/plutus/> .
+
+n:cek-machine
+  gbedge:consumes n:exunits ;
+  gb:description "The abstract machine that evaluates Plutus Core on-chain. Tracks CPU and memory consumption using ExUnits budgets. If a script exceeds its budget, the transaction fails. The CEK machine is deterministic — same inputs always produce same outputs and same costs." ;
+  gb:group gbgroup:smart-contracts ;
+  rdfs:label "CEK Machine" ;
+  gb:nodeId "cek-machine" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:runtime ;
+  a gb:Node ;
+  foaf:page <https://developers.cardano.org/docs/smart-contracts/plutus/> ;
+  rdfs:seeAlso <https://plutus.cardano.intersectmbo.org/resources/plutus-core-spec.pdf> .
+
+n:plutus-core
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluated%20by> n:cek-machine ;
+  gb:description "The low-level language that Plutus scripts compile to. An untyped lambda calculus with built-in functions for cryptography, arithmetic, and data manipulation. Executed by the CEK machine on-chain. Each built-in function has an associated cost in CPU and memory units defined by the cost model." ;
+  gb:group gbgroup:smart-contracts ;
+  rdfs:label "Plutus Core" ;
+  gb:nodeId "plutus-core" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:runtime ;
+  a gb:Node ;
+  foaf:page <https://plutus.cardano.intersectmbo.org/docs/reference/cardano/plutus-core-builtins-ref/> ;
+  rdfs:seeAlso <https://github.com/IntersectMBO/plutus> ;
+  rdfs:seeAlso <https://plutus.cardano.intersectmbo.org/resources/plutus-core-spec.pdf> .
+
+n:plutus
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> n:plutus-core ;
+  gb:description "The native smart contract platform for Cardano. Plutus scripts are written in PureScript-like Haskell, compiled to Plutus Core (an untyped lambda calculus), and executed on-chain by the Plutus evaluator. Scripts validate transactions — they receive a datum, redeemer, and script context, returning true or false." ;
+  gb:group gbgroup:smart-contracts ;
+  rdfs:label "Plutus" ;
+  gb:nodeId "plutus" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node ;
+  foaf:page <https://plutus.cardano.intersectmbo.org/resources/plutus-core-spec.pdf> ;
+  rdfs:seeAlso <https://developers.cardano.org/docs/smart-contracts/> ;
+  rdfs:seeAlso <https://github.com/input-output-hk/plutus-pioneer-program> ;
+  rdfs:seeAlso <https://plutus.cardano.intersectmbo.org/docs/> .
+
+n:param-exceptions
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#modifies%20voting%20for> n:action-param-change ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#overrides%20thresholds%20from> n:param-group-governance ;
+  gb:description "Some protocol parameters have voting thresholds that differ from their group defaults, as defined in the Cardano Constitution and implemented in the Guardrails Script. For example: committeeMaxTermLength requires only DRep 67% with no CC vote; deposit parameters (dRepDeposit, stakePoolDeposit, stakeAddressDeposit, minPoolCost, committeeMinSize) use the Governance group threshold (DRep 75% + CC 2/3) rather than their native Economic/Technical group thresholds. These exceptions reflect the constitutional significance of these specific parameters." ;
+  gb:group gbgroup:parameters ;
+  rdfs:label "Per-Parameter Threshold Exceptions" ;
+  gb:nodeId "param-exceptions" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:mechanism ;
+  a gb:Node ;
+  foaf:page <https://github.com/cardano-foundation/cardano-org/tree/main/src/data> ;
+  rdfs:seeAlso <https://cardano.org/insights/governance-actions/?category=Critical+Parameter+Changes> .
+
+n:action-info
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#used%20for> n:treasury-budgeting ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> n:governance-action ;
+  gb:description "Has no on-chain effect — it's a mechanism for recording community sentiment on-chain. Requires 100% threshold from all three bodies (meaning it can never technically be 'ratified' in the normal sense, but serves as a signal). Info actions are useful for polling the community on proposals before committing to a binding governance action. They do not require chaining to previous actions." ;
+  gb:group gbgroup:actions ;
+  rdfs:label "7. Info Action" ;
+  gb:nodeId "action-info" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:action-type ;
+  a gb:Node ;
+  foaf:page <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> .
+
+n:treasury-budgeting
+  gbedge:gates n:action-treasury ;
+  gb:description "Treasury withdrawals follow a multi-step budgeting process defined by the Cardano Constitution. First, a Net Change Limit must be approved via an Info Action (DRep 50% + CC 2/3) to set the maximum amount that can be withdrawn in a period. Then, individual Budget proposals are approved (also Info Actions with DRep 50% + CC 2/3). Only after both are in place can Treasury Withdrawal governance actions be submitted against the approved budget. This layered process prevents unchecked treasury spending." ;
+  gb:group gbgroup:lifecycle ;
+  rdfs:label "Treasury Budgeting Process" ;
+  gb:nodeId "treasury-budgeting" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:process ;
+  a gb:Node ;
+  foaf:page <https://github.com/cardano-foundation/cardano-org/tree/main/src/data> ;
+  rdfs:seeAlso <https://cardano.org/insights/governance-actions/> .
+
+n:sanchonet
+  gbedge:tested n:conway-era ;
+  gb:description "A dedicated governance testnet for experimenting with CIP-1694 features. Launched in 2023, it allowed the community to test DRep registration, voting, governance action submission, and the full lifecycle before Conway went live on mainnet. Named after Sancho Panza (Don Quixote's practical companion)." ;
+  gb:group gbgroup:ecosystem ;
+  rdfs:label "SanchoNet" ;
+  gb:nodeId "sanchonet" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:tool ;
+  a gb:Node ;
+  foaf:page <https://sancho.network> .
+
+n:cardano-foundation
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluates%20and%20votes%20on> n:governance-action ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#registered%20as> n:drep ;
+  gb:description "One of the three founding entities of Cardano (alongside IOG and EMURGO). The CF is registered as a DRep on-chain and operates a Governance Advisory Team of subject-matter experts. It evaluates proposals on constitutional alignment and governance merit, publishing vote rationales with each governance action vote. The CF served on the interim Constitutional Committee during the bootstrap phase and created the Cardano Proposal Examiner tool. The founding entities relinquished their genesis keys, transitioning control to the community." ;
+  gb:group gbgroup:ecosystem ;
+  rdfs:label "Cardano Foundation" ;
+  gb:nodeId "cardano-foundation" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:actor ;
+  a gb:Node ;
+  foaf:page <https://cardanofoundation.org/blog/strengthens-commitment-governance-drep> ;
+  rdfs:seeAlso <https://proposalexaminer.cardanofoundation.org/> ;
+  rdfs:seeAlso <https://cardanofoundation.org/governance> .
+
+n:intersect
+  gbedge:facilitates n:governance-model ;
+  gb:description "A not-for-profit organization (registered in Wyoming, USA) that facilitates off-chain governance processes. Intersect manages the Parameter Committee, organizes elections, runs working groups, and coordinates the governance tooling ecosystem. It is NOT a governance body — it does not vote or ratify. Its role is facilitation and coordination: hosting discussions, managing the CIP process, coordinating hard fork readiness, and providing infrastructure like GovTool." ;
+  gb:group gbgroup:ecosystem ;
+  rdfs:label "Intersect" ;
+  gb:nodeId "intersect" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:actor ;
+  a gb:Node ;
+  foaf:page <https://www.intersectmbo.org> .
+
+n:cip-105
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#derives%20keys%20for> n:drep ;
+  gb:description "CIP-105 defines the Conway-era HD wallet key derivation paths for governance credentials. It specifies how wallets derive the key pairs used for DRep registration, vote delegation, and CC member credentials from a single master seed. This ensures that governance keys are deterministically recoverable from a wallet's mnemonic phrase, following the same BIP-32/BIP-44 patterns used for payment and staking keys." ;
+  gb:group gbgroup:framework ;
+  rdfs:label "CIP-105" ;
+  gb:nodeId "cip-105" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:artifact ;
+  a gb:Node ;
+  foaf:page <https://cips.cardano.org/cip/CIP-0105> .
+
+n:cip-129
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#standardizes%20IDs%20for> n:governance-action ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#standardizes%20IDs%20for> n:drep ;
+  gb:description "CIP-129 standardizes governance identifiers across the ecosystem. It defines canonical string representations for governance credentials (DRep IDs, CC member IDs, governance action IDs) that work consistently across wallets, explorers, and governance tools. Without this standard, different tools might represent the same DRep or action differently, causing confusion when sharing links or referencing proposals." ;
+  gb:group gbgroup:framework ;
+  rdfs:label "CIP-129" ;
+  gb:nodeId "cip-129" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:artifact ;
+  a gb:Node ;
+  foaf:page <https://cips.cardano.org/cip/CIP-0129> .
+
+n:cc
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#publishes%20rationales%20via> n:cip-136 ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#subject%20to> n:cc-threshold ;
+  gbedge:uses n:hot-cold-keys ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluates%20actions%20against> n:constitution ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> n:action-info ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> n:action-treasury ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> n:action-param-change ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> n:action-hard-fork ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> n:action-new-constitution ;
+  gb:description "A community-elected oversight body responsible for ensuring that governance actions respect the Cardano Constitution. Each CC member holds exactly one vote (not stake-weighted). The CC does NOT create proposals and does NOT evaluate merit — it reviews constitutionality only. Members use a hot/cold key credential system (like genesis delegation). Each member has an individual term expiration epoch; expired members cannot vote. Members can resign early. The CC can enter a 'no-confidence' state via a Motion of No-Confidence, which blocks it from participating in ratification until a new committee is elected. The CC does not vote on No-Confidence motions or Committee updates (since those are about the CC itself)." ;
+  gb:group gbgroup:actors ;
+  rdfs:label "Constitutional Committee (CC)" ;
+  gb:nodeId "cc" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:actor ;
+  a gb:Node ;
+  foaf:page <https://gov.tools> ;
+  rdfs:seeAlso <https://developers.cardano.org/docs/governance/cardano-governance/constitutional-committee-guide/> .
+
+n:cip-108
+  gbedge:extends n:cip-100 ;
+  gb:description "CIP-108 extends CIP-100 with a specific metadata format for governance actions. It defines required fields: title, abstract, motivation, rationale, and supporting references. This structured format ensures that voters have consistent, comparable information when evaluating proposals. GovTool and other governance interfaces render CIP-108 metadata to present proposals in a human-readable format." ;
+  gb:group gbgroup:framework ;
+  rdfs:label "CIP-108" ;
+  gb:nodeId "cip-108" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:artifact ;
+  a gb:Node ;
+  foaf:page <https://cips.cardano.org/cip/CIP-0108> .
+
+n:governance-action
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#structured%20as> n:cip-108 ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#metadata%20follows> n:cip-100 ;
+  gbedge:requires n:deposit-mechanism ;
+  gbedge:uses n:action-chaining ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#open%20for> n:voting ;
+  gbedge:undergoes n:ratification ;
+  gb:description "An on-chain event triggered by a transaction. Any ada holder can submit a governance action by paying the govActionDeposit (currently 100,000 ada, refundable). Every action includes: the deposit amount, a reward address for deposit return, a metadata anchor (URL + hash, following CIP-100/CIP-108 standards), and — for most types — a hash reference to the most recently enacted action of the same type (to prevent collisions). Actions have a lifespan of govActionLifetime epochs (currently 6 epochs / ~30 days). There are 7 types of governance actions." ;
+  gb:group gbgroup:actions ;
+  rdfs:label "Governance Action" ;
+  gb:nodeId "governance-action" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node ;
+  foaf:page <https://cardano.org/insights/governance-actions/> ;
+  rdfs:seeAlso <https://cardanofoundation.org/blog/understanding-cardano-governance-actions> ;
+  rdfs:seeAlso <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> .
+
+n:spo
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#subject%20to> n:spo-thresholds ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> n:action-info ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on%20changes%20to> n:security-params ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> n:action-hard-fork ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> n:action-update-committee ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> n:action-no-confidence ;
+  gb:description "Block producers who also participate in governance voting. SPOs vote on a specific subset of governance action types: No Confidence motions, Committee updates, Hard Fork Initiation, security-relevant protocol parameter changes, and Info actions. Their voting power is proportional to the total stake delegated to their pool. SPOs implement approved protocol upgrades (hard forks) on their infrastructure." ;
+  gb:group gbgroup:actors ;
+  rdfs:label "Stake Pool Operator (SPO)" ;
+  gb:nodeId "spo" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:actor ;
+  a gb:Node ;
+  foaf:page <https://developers.cardano.org/docs/governance/cardano-governance/governance-model/> .
+
+n:conway-era
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#started%20with> n:bootstrap-phase ;
+  gb:description "The current Cardano ledger era that implements CIP-1694 governance. Named after mathematician John Horton Conway. Introduced via two hard forks: Chang #1 (August 2024) — bootstrap phase with limited governance (DRep registration, interim CC, parameter changes and hard forks only); and Plomin hard fork / Chang #2 (December 2024) — full governance activation with all 7 action types and treasury withdrawals. The bootstrap phase ended when the CC and SPOs ratified the Plomin hard fork." ;
+  gb:group gbgroup:framework ;
+  rdfs:label "Conway Ledger Era" ;
+  gb:nodeId "conway-era" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node ;
+  foaf:page <https://docs.cardano.org/about-cardano/evolution/upgrades/chang> .
+
+n:cip-1694
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#implemented%20in> n:conway-era ;
+  gbedge:specifies n:governance-model ;
+  gb:description "The Cardano Improvement Proposal that specifies the on-chain governance mechanism. Authored by Jared Corduan and Andre Knispel, it defines the three governance bodies, seven action types, voting and ratification rules, the Constitutional Committee structure, DRep mechanics, and the full lifecycle of governance actions. CIP-1694 was implemented in the Conway ledger era (named after John Horton Conway)." ;
+  gb:group gbgroup:framework ;
+  rdfs:label "CIP-1694" ;
+  gb:nodeId "cip-1694" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:artifact ;
+  a gb:Node ;
+  foaf:page <https://cips.cardano.org/cip/CIP-1694> .
+
+n:governance-model
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> n:cc ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> n:spo ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> n:drep ;
+  gbedge:implements n:liquid-democracy ;
+  gb:description "Cardano uses a tricameral (three-body) governance model implementing liquid democracy, introduced by CIP-1694 as part of the Voltaire phase. Ada holders can vote directly on every governance matter or delegate their voting power to Delegated Representatives (DReps). Three governance bodies — DReps, Stake Pool Operators (SPOs), and the Constitutional Committee (CC) — each play distinct roles in reviewing and ratifying governance actions. Every governance action requires approval from at least two of the three bodies." ;
+  gb:group gbgroup:core ;
+  rdfs:label "Cardano Governance" ;
+  gb:nodeId "governance-model" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node ;
+  foaf:page <https://cardanofoundation.org/governance> ;
+  rdfs:seeAlso <https://docs.cardano.org/about-cardano/governance-overview> ;
+  rdfs:seeAlso <https://cips.cardano.org/cip/CIP-1694> .
+
+n:action-update-committee
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#changes%20membership%20of> n:cc ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> n:governance-action ;
+  gb:description "Changes the Constitutional Committee membership, its signature threshold, and/or member term limits. Can add new members (with term expiration epochs), remove existing members, and adjust the fraction of CC members required to approve actions. Thresholds differ depending on CC state: in normal state, requires DRep 67% + SPO 51%; in no-confidence state, DRep 60% + SPO 51% (lower DRep threshold to make it easier to replace a failed CC). The CC does not vote on this." ;
+  gb:group gbgroup:actions ;
+  rdfs:label "2. Update Committee / Threshold" ;
+  gb:nodeId "action-update-committee" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:action-type ;
+  a gb:Node ;
+  foaf:page <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> .
+
+n:action-no-confidence
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#puts%20into%20no-confidence%20state> n:cc ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> n:governance-action ;
+  gb:description "Creates a state of no-confidence in the current Constitutional Committee. When ratified, the CC enters a no-confidence state and cannot participate in governance until a new committee is elected via an Update Committee action. This is the highest-priority governance action — if ratified in the same epoch as other actions, it is enacted first. Requires: DRep approval at 67% of active voting stake + SPO approval at 51% of active pool stake. The CC does not vote on this (since it's about them)." ;
+  gb:group gbgroup:actions ;
+  rdfs:label "1. Motion of No-Confidence" ;
+  gb:nodeId "action-no-confidence" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:action-type ;
+  a gb:Node ;
+  foaf:page <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> .
+
+n:action-new-constitution
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20update> n:guardrails-script ;
+  gbedge:modifies n:constitution ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> n:governance-action ;
+  gb:description "Modifies the Cardano Constitution and/or the on-chain Guardrails Script. The action includes an anchor to the new Constitution text and optionally a new script hash for the Guardrails Script. Requires: CC approval (2/3 majority) + DRep approval at 75% of active voting stake. SPOs do not vote on this. This is the action with the highest DRep threshold (alongside Governance group parameter changes), reflecting the significance of constitutional amendments." ;
+  gb:group gbgroup:actions ;
+  rdfs:label "3. New Constitution / Guardrails Script" ;
+  gb:nodeId "action-new-constitution" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:action-type ;
+  a gb:Node ;
+  foaf:page <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> .
+
+n:constitution
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#codified%20in> n:guardrails-script ;
+  gb:description "An off-chain text document whose hash is recorded on-chain. It defines shared values and guiding principles for Cardano governance. The current Constitution was ratified at the Buenos Aires Constitutional Convention (December 4-6, 2024) with 95% delegate approval after 63 workshops across 51 countries, and became effective on-chain on January 24, 2026. It contains: a Preamble (not used for constitutionality assessments), 10 Tenets (core principles including transaction freedom, predictable costs, ada supply cap at 45 billion), Articles covering community participation, decentralized governance, CC responsibilities, and treasury provisions, plus Appendix I with permitted parameter ranges. The on-chain version (hash) prevails over the documented version in case of conflict." ;
+  gb:group gbgroup:framework ;
+  rdfs:label "Cardano Constitution" ;
+  gb:nodeId "constitution" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:artifact ;
+  a gb:Node ;
+  foaf:page <https://cardanofoundation.org/blog/proposal-for-cardano-constitution> ;
+  rdfs:seeAlso <https://gov.tools> .
+
+n:param-group-governance
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#some%20params%20are> n:security-params ;
+  gb:description "Protocol parameters that govern governance itself. DRep voting threshold: 75% (P5d) — the highest threshold for parameter changes, reflecting the self-referential nature of changing governance rules. Includes: all 15 voting thresholds (P1–P6 for DReps, Q1–Q5 for SPOs), govActionLifetime (1–15 epochs), govActionDeposit (1M–10T lovelace), dRepDeposit (1M–100B lovelace), dRepActivity (13–37 epochs), committeeMinSize (3–10), committeeMaxTermLength (18–293 epochs)." ;
+  gb:group gbgroup:parameters ;
+  rdfs:label "Governance Parameter Group" ;
+  gb:nodeId "param-group-governance" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:param-group ;
+  a gb:Node ;
+  foaf:page <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> .
+
+n:param-group-economic
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#some%20params%20are> n:security-params ;
+  gb:description "Protocol parameters related to transaction fees, deposits, and monetary policy. DRep voting threshold: 67% (P5b). Includes: txFeePerByte (30–1,000 lovelace), txFeeFixed (100,000–10,000,000 lovelace), stakeAddressDeposit, stakePoolDeposit, monetaryExpansion (0.001–0.005), treasuryCut (10%–30%), minPoolCost, utxoCostPerByte (3,000–6,500), executionUnitPrices (priceMemory and priceSteps), minFeeRefScriptCostPerByte." ;
+  gb:group gbgroup:parameters ;
+  rdfs:label "Economic Parameter Group" ;
+  gb:nodeId "param-group-economic" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:param-group ;
+  a gb:Node ;
+  foaf:page <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> .
+
+n:param-group-network
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#some%20params%20are> n:security-params ;
+  gb:description "Protocol parameters related to network capacity and transaction limits. DRep voting threshold: 67% (P5a). Includes: maxBlockBodySize (24,576–122,880 bytes), maxTxSize (up to 32,768 bytes), maxBlockHeaderSize (up to 5,000 bytes), maxValueSize (up to 12,288 bytes), maxTxExecutionUnits (memory and steps), maxBlockExecutionUnits (memory and steps), maxCollateralInputs (minimum 1). Guardrail NETWORK-01: should not change more than once per 2 epochs. NETWORK-02: only one parameter should change per epoch unless correlated." ;
+  gb:group gbgroup:parameters ;
+  rdfs:label "Network Parameter Group" ;
+  gb:nodeId "param-group-network" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:param-group ;
+  a gb:Node ;
+  foaf:page <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> .
+
+n:param-group-technical
+  gbedge:contains n:cost-models ;
+  gb:description "Protocol parameters related to stake pool mechanics, Plutus execution, and script validation. DRep voting threshold: 67% (P5c). Includes: poolPledgeInfluence (0.1–1.0), poolRetireMaxEpoch, stakePoolTargetNum (250–2,000), costModels (the Plutus cost model parameters — benchmarked values for each builtin function), collateralPercentage (100–200). The costModels parameter is what gets updated when the Plutus team reprices builtins based on new benchmarks." ;
+  gb:group gbgroup:parameters ;
+  rdfs:label "Technical Parameter Group" ;
+  gb:nodeId "param-group-technical" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:param-group ;
+  a gb:Node ;
+  foaf:page <https://github.com/IntersectMBO/plutus/blob/master/plutus-core/cost-model/CostModelGeneration.md> ;
+  rdfs:seeAlso <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> .
+
+n:action-treasury
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> n:governance-action ;
+  gb:description "Withdraws ada from the Cardano treasury. The action specifies a map from stake credentials to positive lovelace amounts. Requires: CC approval (2/3 majority) + DRep approval at 67%. SPOs do not vote on this. The Guardrails Script enforces withdrawal limits (TREASURY-01a through TREASURY-04a). Treasury withdrawals must specify purpose, expected costs, and provide for auditable accounts. This action type does NOT require chaining to previous actions of the same type (unlike most other types)." ;
+  gb:group gbgroup:actions ;
+  rdfs:label "6. Treasury Withdrawal" ;
+  gb:nodeId "action-treasury" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:action-type ;
+  a gb:Node ;
+  foaf:page <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> .
+
+n:action-hard-fork
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> n:governance-action ;
+  gb:description "Triggers a non-backwards-compatible protocol upgrade. The action specifies a new major protocol version (must be exactly +1 from current). This is the only governance action that requires approval from ALL THREE bodies: CC (2/3 majority), DReps (60%), and SPOs (51%). Guardrail HARDFORK-04a requires at least 85% of stake pools by active stake to have upgraded their node software before enactment. A ratified hard fork delays ratification of all other pending actions until after enactment." ;
+  gb:group gbgroup:actions ;
+  rdfs:label "4. Hard Fork Initiation" ;
+  gb:nodeId "action-hard-fork" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:action-type ;
+  a gb:Node ;
+  foaf:page <https://docs.cardano.org/about-cardano/evolution/upgrades/chang> ;
+  rdfs:seeAlso <https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/> .
+
+n:voting
+  gbedge:determines n:ratification ;
+  gb:description "Each governance body votes Yes, No, or Abstain on applicable governance actions. Votes are recorded on-chain via transactions. DRep and SPO votes are weighted by delegated stake; CC votes are one-member-one-vote. Votes can be changed at any time before the action is ratified. The voting period lasts up to govActionLifetime epochs (currently 6 epochs / ~30 days). Abstain votes are NOT counted in the active voting stake denominator. Post-bootstrap: ada holders must delegate to a DRep (or Abstain/No Confidence) to withdraw staking rewards." ;
+  gb:group gbgroup:lifecycle ;
+  rdfs:label "Voting" ;
+  gb:nodeId "voting" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:process ;
+  a gb:Node ;
+  foaf:page <https://gov.tools> ;
+  rdfs:seeAlso <https://docs.cardano.org/about-cardano/governance-overview> .
+
+n:ratification
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#leads%20to> n:enactment ;
+  gb:description "The process by which a governance action accumulates enough votes to be approved. Ratification is checked ONLY at epoch boundaries — a new tally is calculated each epoch using the current stake snapshot. An action can become ratified even without new votes if delegation changes shift the stake distribution. Votes can be changed at any time before ratification. Registered stake that did not vote counts as 'No'. Unregistered stake counts as 'Abstain'. Each action type has specific thresholds for each governance body. A successful No-Confidence, Committee Update, New Constitution, or Hard Fork delays ratification of ALL other pending actions until after enactment." ;
+  gb:group gbgroup:lifecycle ;
+  rdfs:label "Ratification" ;
+  gb:nodeId "ratification" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:process ;
+  a gb:Node ;
+  foaf:page <https://cips.cardano.org/cip/CIP-1694#ratification> .
+
+n:ada-holder
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20register%20as> n:drep ;
+  gbedge:submits n:governance-action ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#delegates%20stake%20to> n:spo ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20delegate%20to> n:no-confidence-option ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20delegate%20to> n:abstain-option ;
+  <https://lambdasistemi.github.io/graph-browser/vocab/edges#delegates%20voting%20power%20to> n:drep ;
+  gb:description "Any holder of ada. Ada holders are the foundation of Cardano governance — they have 'skin in the game' and can participate in governance in multiple ways: vote directly by registering as a DRep, delegate their voting power to a DRep (or to the pre-defined Abstain/No Confidence options), submit governance actions (with a deposit), and delegate stake to SPOs for block production. Voting power is proportional: one lovelace = one vote." ;
+  gb:group gbgroup:actors ;
+  rdfs:label "Ada Holder" ;
+  gb:nodeId "ada-holder" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:actor ;
+  a gb:Node ;
+  foaf:page <https://developers.cardano.org/docs/governance/cardano-governance/governance-model/> ;
+  rdfs:seeAlso <https://gov.tools> .
+
+n:spo-thresholds
+  gb:description "SPO thresholds are expressed as a fraction of active pool stake. SPOs only vote on specific action types. Current mainnet values: No-Confidence (Q1) = 51%, Committee Update normal (Q2a) = 51%, Committee Update no-confidence (Q2b) = 51%, Hard Fork (Q4) = 51%, Security-relevant params (Q5) = 51%, Info = 100% (fixed). SPOs do NOT vote on: New Constitution, non-security parameter changes, or Treasury Withdrawals." ;
+  gb:group gbgroup:thresholds ;
+  rdfs:label "SPO Voting Thresholds" ;
+  gb:nodeId "spo-thresholds" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:mechanism ;
+  a gb:Node ;
+  foaf:page <https://cips.cardano.org/cip/CIP-1694#ratification> .
+
+n:security-params
+  gb:description "A subset of protocol parameters that additionally require SPO approval (at Q5 = 51% threshold) when changed. These parameters directly affect network security and node operator costs. The list: maxBlockBodySize, maxTxSize, maxBlockHeaderSize, maxValueSize, maxBlockExecutionUnits, txFeePerByte, txFeeFixed, utxoCostPerByte, govActionDeposit, minFeeRefScriptCostPerByte. This gives SPOs a veto over changes that could destabilize the network or make block production uneconomical." ;
+  gb:group gbgroup:parameters ;
+  rdfs:label "Security-Relevant Parameters" ;
+  gb:nodeId "security-params" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:mechanism ;
+  a gb:Node ;
+  foaf:page <https://cips.cardano.org/cip/CIP-1694> .
+
+n:no-confidence-option
+  gb:description "A pre-defined voting option for ada holders. When delegating to No Confidence, the holder's stake automatically votes 'Yes' on every Motion of No-Confidence and 'No' on every other governance action. Unlike Abstain, this stake IS counted in the active voting stake — it actively opposes all governance actions except no-confidence motions. This is a signal of dissatisfaction with the current governance state." ;
+  gb:group gbgroup:actors ;
+  rdfs:label "No Confidence (Pre-defined DRep)" ;
+  gb:nodeId "no-confidence-option" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:mechanism ;
+  a gb:Node ;
+  foaf:page <https://cips.cardano.org/cip/CIP-1694#pre-defined-voting-options> .
+
+n:liquid-democracy
+  gb:description "The democratic model used by Cardano governance. Ada holders can vote directly on every governance matter (by registering as their own DRep) OR delegate their voting power to any registered DRep. Delegation can be changed at any time and takes effect immediately. This combines the benefits of direct democracy (anyone can participate) with representative democracy (expertise can be delegated to). DRep delegation is SEPARATE from stake pool delegation — you choose who produces blocks and who votes on your behalf independently." ;
+  gb:group gbgroup:core ;
+  rdfs:label "Liquid Democracy" ;
+  gb:nodeId "liquid-democracy" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node ;
+  foaf:page <https://docs.cardano.org/about-cardano/governance-overview> .
+
+n:hot-cold-keys
+  gb:description "The credential system used by Constitutional Committee members. Similar to genesis delegation certificates. The cold key is the CC member's identity — kept offline for security. The hot key is authorized by the cold key for day-to-day voting. If a hot key is compromised, it can be rotated without changing the CC member's identity. This separation protects against key compromise while allowing active participation. CC members can also use native or Plutus script credentials instead of key pairs." ;
+  gb:group gbgroup:framework ;
+  rdfs:label "Hot/Cold Key System" ;
+  gb:nodeId "hot-cold-keys" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:mechanism ;
+  a gb:Node ;
+  foaf:page <https://developers.cardano.org/docs/governance/cardano-governance/constitutional-committee-guide/> .
+
+n:enactment
+  gb:description "Ratified governance actions are enacted on the epoch boundary FOLLOWING ratification. When multiple actions are ratified in the same epoch, they are enacted in a fixed priority order: (1) No-Confidence, (2) Committee Update, (3) New Constitution, (4) Hard Fork, (5) Parameter Changes, (6) Treasury Withdrawals, (7) Info. Within the same type, actions are enacted in the order they were accepted to the chain. After enactment, the governance action deposit is returned to the specified reward address." ;
+  gb:group gbgroup:lifecycle ;
+  rdfs:label "Enactment" ;
+  gb:nodeId "enactment" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:process ;
+  a gb:Node ;
+  foaf:page <https://cips.cardano.org/cip/CIP-1694#enactment> .
+
+n:drep-thresholds
+  gb:description "DRep thresholds are expressed as a fraction of active DRep voting stake. Active voting stake = all stake delegated to registered, active DReps (excluding Abstain delegations). Current mainnet values: No-Confidence (P1) = 67%, Committee Update normal (P2a) = 67%, Committee Update no-confidence (P2b) = 60%, New Constitution (P3) = 75%, Hard Fork (P4) = 60%, Network params (P5a) = 67%, Economic params (P5b) = 67%, Technical params (P5c) = 67%, Governance params (P5d) = 75%, Treasury Withdrawal (P6) = 67%, Info = 100% (fixed)." ;
+  gb:group gbgroup:thresholds ;
+  rdfs:label "DRep Voting Thresholds" ;
+  gb:nodeId "drep-thresholds" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:mechanism ;
+  a gb:Node ;
+  foaf:page <https://cips.cardano.org/cip/CIP-1694#ratification> .
+
+n:deposit-mechanism
+  gb:description "Several governance actions require refundable deposits to prevent spam. govActionDeposit (currently 100,000 ada) is required to submit any governance action — returned when the action is ratified or expires. dRepDeposit (currently 500 ada) is required to register as a DRep — returned on retirement. These deposits are protocol parameters in the Governance group, changeable via governance actions with a 75% DRep threshold." ;
+  gb:group gbgroup:lifecycle ;
+  rdfs:label "Deposit Mechanism" ;
+  gb:nodeId "deposit-mechanism" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:mechanism ;
+  a gb:Node ;
+  foaf:page <https://developers.cardano.org/docs/governance/cardano-governance/governance-model/> .
+
+n:cip-30
+  gb:description "Cardano dApp-Wallet Web Bridge — the original standard for connecting browser-based dApps to Cardano wallets. Defines a JavaScript API injected into window.cardano that lets dApps discover wallets, request access, query balances, submit transactions, and sign data. Nearly every Cardano dApp uses CIP-30 for wallet interaction. CIP-95 extends it with governance capabilities." ;
+  gb:group gbgroup:standards ;
+  rdfs:label "CIP-30" ;
+  gb:nodeId "cip-30" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:standard ;
+  a gb:Node ;
+  foaf:page <https://cips.cardano.org/cip/CIP-0030> .
+
+n:cip-136
+  gb:description "CIP-136 defines the metadata standard for Constitutional Committee vote rationales. When CC members vote on governance actions, they are expected to explain their constitutional reasoning. CIP-136 provides a structured format for these rationales, including which constitutional articles were considered and why the action was deemed constitutional or not. This creates a public record of constitutional interpretation — effectively building governance case law over time." ;
+  gb:group gbgroup:framework ;
+  rdfs:label "CIP-136" ;
+  gb:nodeId "cip-136" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:artifact ;
+  a gb:Node ;
+  foaf:page <https://cips.cardano.org/cip/CIP-0136> .
+
+n:cip-100
+  gb:description "CIP-100 defines the general governance metadata standard. Every governance action includes a metadata anchor — a URL pointing to a JSON document plus its hash for integrity. CIP-100 specifies the base format for this metadata, ensuring all governance tools can parse and display proposal information consistently. The metadata is stored off-chain (to avoid blockchain bloat) but its hash is recorded on-chain, making it tamper-proof." ;
+  gb:group gbgroup:framework ;
+  rdfs:label "CIP-100" ;
+  gb:nodeId "cip-100" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:artifact ;
+  a gb:Node ;
+  foaf:page <https://cips.cardano.org/cip/CIP-0100> .
+
+n:cc-threshold
+  gb:description "The CC uses one-member-one-vote (not stake-weighted). The required fraction of CC members who must approve is a configurable threshold (currently 2/3 on mainnet). The CC votes on: New Constitution, Hard Fork, all Protocol Parameter Changes, Treasury Withdrawals, and Info actions. The CC does NOT vote on: No-Confidence motions or Committee Updates (since those are about the CC itself). Expired members cannot vote. The committee has a minimum size (committeeMinSize = 7 on mainnet)." ;
+  gb:group gbgroup:thresholds ;
+  rdfs:label "CC Voting Threshold" ;
+  gb:nodeId "cc-threshold" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:mechanism ;
+  a gb:Node ;
+  foaf:page <https://developers.cardano.org/docs/governance/cardano-governance/constitutional-committee-guide/> .
+
+n:bootstrap-phase
+  gb:description "The initial governance phase after Chang #1 (August 2024) and before the Plomin hard fork (December 2024). During bootstrap: CC vote alone was sufficient for protocol parameter changes; CC + SPO vote was sufficient for hard fork initiation; Info actions were available; no other governance actions were possible; DRep participation was not required. The bootstrap phase ended when CC and SPOs ratified the Plomin hard fork, transitioning to full governance." ;
+  gb:group gbgroup:lifecycle ;
+  rdfs:label "Bootstrap Phase" ;
+  gb:nodeId "bootstrap-phase" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:process ;
+  a gb:Node ;
+  foaf:page <https://docs.cardano.org/about-cardano/evolution/upgrades/chang> .
+
+n:action-chaining
+  gb:description "A collision-prevention mechanism. Each governance action (except Treasury Withdrawals and Info) must include the governance action ID of the most recently enacted action of its same type. This forms a chain that prevents two competing same-type actions from both being ratified when they assume incompatible starting states. For example, two parameter change proposals that both assume the current parameter values cannot both be valid after one of them changes those values." ;
+  gb:group gbgroup:lifecycle ;
+  rdfs:label "Action Chaining" ;
+  gb:nodeId "action-chaining" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:mechanism ;
+  a gb:Node ;
+  foaf:page <https://cips.cardano.org/cip/CIP-1694#governance-actions> .
+
+n:abstain-option
+  gb:description "A pre-defined voting option for ada holders. When delegating to Abstain, the holder's stake is marked as not participating — it is NOT counted in the active voting stake denominator. This means it neither helps nor hinders ratification of any action. The holder still counts as registered for staking reward incentives." ;
+  gb:group gbgroup:actors ;
+  rdfs:label "Abstain (Pre-defined DRep)" ;
+  gb:nodeId "abstain-option" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:mechanism ;
+  a gb:Node ;
+  foaf:page <https://cips.cardano.org/cip/CIP-1694#pre-defined-voting-options> .
+
+# -- Metadata -------------------------------------------------------------
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#written%20in>
+  gb:edgeLabel "written in" ;
+  rdfs:label "written in" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on%20changes%20to>
+  gb:edgeLabel "votes on changes to" ;
+  rdfs:label "votes on changes to" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on>
+  gb:edgeLabel "votes on" ;
+  rdfs:label "votes on" ;
+  a rdf:Property .
+
+gbedge:uses
+  gb:edgeLabel "uses" ;
+  rdfs:label "uses" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#used%20for>
+  gb:edgeLabel "used for" ;
+  rdfs:label "used for" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#updated%20via>
+  gb:edgeLabel "updated via" ;
+  rdfs:label "updated via" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#unifies%20script%20types%20in>
+  gb:edgeLabel "unifies script types in" ;
+  rdfs:label "unifies script types in" ;
+  a rdf:Property .
+
+gbedge:undergoes
+  gb:edgeLabel "undergoes" ;
+  rdfs:label "undergoes" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#type%20of>
+  gb:edgeLabel "type of" ;
+  rdfs:label "type of" ;
+  a rdf:Property .
+
+gbedge:tested
+  gb:edgeLabel "tested" ;
+  rdfs:label "tested" ;
+  a rdf:Property .
+
+gbedge:succeeds
+  gb:edgeLabel "succeeds" ;
+  rdfs:label "succeeds" ;
+  a rdf:Property .
+
+gbedge:submits
+  gb:edgeLabel "submits" ;
+  rdfs:label "submits" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#subject%20to>
+  gb:edgeLabel "subject to" ;
+  rdfs:label "subject to" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#structured%20as>
+  gb:edgeLabel "structured as" ;
+  rdfs:label "structured as" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#started%20with>
+  gb:edgeLabel "started with" ;
+  rdfs:label "started with" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#standardizes%20IDs%20for>
+  gb:edgeLabel "standardizes IDs for" ;
+  rdfs:label "standardizes IDs for" ;
+  a rdf:Property .
+
+gbedge:specifies
+  gb:edgeLabel "specifies" ;
+  rdfs:label "specifies" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#some%20params%20are>
+  gb:edgeLabel "some params are" ;
+  rdfs:label "some params are" ;
+  a rdf:Property .
+
+gbedge:requires
+  gb:edgeLabel "requires" ;
+  rdfs:label "requires" ;
+  a rdf:Property .
+
+gbedge:replicates
+  gb:edgeLabel "replicates" ;
+  rdfs:label "replicates" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#renders%20profiles%20from>
+  gb:edgeLabel "renders profiles from" ;
+  rdfs:label "renders profiles from" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#registers%20metadata%20for>
+  gb:edgeLabel "registers metadata for" ;
+  rdfs:label "registers metadata for" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#registered%20as>
+  gb:edgeLabel "registered as" ;
+  rdfs:label "registered as" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#puts%20into%20no-confidence%20state>
+  gb:edgeLabel "puts into no-confidence state" ;
+  rdfs:label "puts into no-confidence state" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#publishes%20rationales%20via>
+  gb:edgeLabel "publishes rationales via" ;
+  rdfs:label "publishes rationales via" ;
+  a rdf:Property .
+
+gbedge:provides
+  gb:edgeLabel "provides" ;
+  rdfs:label "provides" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#profile%20follows>
+  gb:edgeLabel "profile follows" ;
+  rdfs:label "profile follows" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#priced%20by>
+  gb:edgeLabel "priced by" ;
+  rdfs:label "priced by" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#overrides%20thresholds%20from>
+  gb:edgeLabel "overrides thresholds from" ;
+  rdfs:label "overrides thresholds from" ;
+  a rdf:Property .
+
+gbedge:optimizes
+  gb:edgeLabel "optimizes" ;
+  rdfs:label "optimizes" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#open%20for>
+  gb:edgeLabel "open for" ;
+  rdfs:label "open for" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#modifies%20voting%20for>
+  gb:edgeLabel "modifies voting for" ;
+  rdfs:label "modifies voting for" ;
+  a rdf:Property .
+
+gbedge:modifies
+  gb:edgeLabel "modifies" ;
+  rdfs:label "modifies" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#metadata%20follows>
+  gb:edgeLabel "metadata follows" ;
+  rdfs:label "metadata follows" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#leads%20to>
+  gb:edgeLabel "leads to" ;
+  rdfs:label "leads to" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of>
+  gb:edgeLabel "is a type of" ;
+  rdfs:label "is a type of" ;
+  a rdf:Property .
+
+gbedge:indexes
+  gb:edgeLabel "indexes" ;
+  rdfs:label "indexes" ;
+  a rdf:Property .
+
+gbedge:improves
+  gb:edgeLabel "improves" ;
+  rdfs:label "improves" ;
+  a rdf:Property .
+
+gbedge:implements
+  gb:edgeLabel "implements" ;
+  rdfs:label "implements" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#implemented%20in>
+  gb:edgeLabel "implemented in" ;
+  rdfs:label "implemented in" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#hosts%20infrastructure%20for>
+  gb:edgeLabel "hosts infrastructure for" ;
+  rdfs:label "hosts infrastructure for" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body>
+  gb:edgeLabel "governance body" ;
+  rdfs:label "governance body" ;
+  a rdf:Property .
+
+gbedge:generates
+  gb:edgeLabel "generates" ;
+  rdfs:label "generates" ;
+  a rdf:Property .
+
+gbedge:gates
+  gb:edgeLabel "gates" ;
+  rdfs:label "gates" ;
+  a rdf:Property .
+
+gbedge:facilitates
+  gb:edgeLabel "facilitates" ;
+  rdfs:label "facilitates" ;
+  a rdf:Property .
+
+gbedge:extends
+  gb:edgeLabel "extends" ;
+  rdfs:label "extends" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluates%20and%20votes%20on>
+  gb:edgeLabel "evaluates and votes on" ;
+  rdfs:label "evaluates and votes on" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluates%20actions%20against>
+  gb:edgeLabel "evaluates actions against" ;
+  rdfs:label "evaluates actions against" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluated%20by>
+  gb:edgeLabel "evaluated by" ;
+  rdfs:label "evaluated by" ;
+  a rdf:Property .
+
+gbedge:enforces
+  gb:edgeLabel "enforces" ;
+  rdfs:label "enforces" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#enables%20registration%20as>
+  gb:edgeLabel "enables registration as" ;
+  rdfs:label "enables registration as" ;
+  a rdf:Property .
+
+gbedge:enables
+  gb:edgeLabel "enables" ;
+  rdfs:label "enables" ;
+  a rdf:Property .
+
+gbedge:documents
+  gb:edgeLabel "documents" ;
+  rdfs:label "documents" ;
+  a rdf:Property .
+
+gbedge:determines
+  gb:edgeLabel "determines" ;
+  rdfs:label "determines" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#derives%20keys%20for>
+  gb:edgeLabel "derives keys for" ;
+  rdfs:label "derives keys for" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#delegates%20voting%20power%20to>
+  gb:edgeLabel "delegates voting power to" ;
+  rdfs:label "delegates voting power to" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#delegates%20stake%20to>
+  gb:edgeLabel "delegates stake to" ;
+  rdfs:label "delegates stake to" ;
+  a rdf:Property .
+
+gbedge:contains
+  gb:edgeLabel "contains" ;
+  rdfs:label "contains" ;
+  a rdf:Property .
+
+gbedge:consumes
+  gb:edgeLabel "consumes" ;
+  rdfs:label "consumes" ;
+  a rdf:Property .
+
+gbedge:constrains
+  gb:edgeLabel "constrains" ;
+  rdfs:label "constrains" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#connects%20wallets%20via>
+  gb:edgeLabel "connects wallets via" ;
+  rdfs:label "connects wallets via" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to>
+  gb:edgeLabel "compiles to" ;
+  rdfs:label "compiles to" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#codified%20in>
+  gb:edgeLabel "codified in" ;
+  rdfs:label "codified in" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#changes%20membership%20of>
+  gb:edgeLabel "changes membership of" ;
+  rdfs:label "changes membership of" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20update>
+  gb:edgeLabel "can update" ;
+  rdfs:label "can update" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20register%20as>
+  gb:edgeLabel "can register as" ;
+  rdfs:label "can register as" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20modify>
+  gb:edgeLabel "can modify" ;
+  rdfs:label "can modify" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20delegate%20to>
+  gb:edgeLabel "can delegate to" ;
+  rdfs:label "can delegate to" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change>
+  gb:edgeLabel "can change" ;
+  rdfs:label "can change" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#built%20on>
+  gb:edgeLabel "built on" ;
+  rdfs:label "built on" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#builds%20transactions%20for>
+  gb:edgeLabel "builds transactions for" ;
+  rdfs:label "builds transactions for" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#belongs%20to>
+  gb:edgeLabel "belongs to" ;
+  rdfs:label "belongs to" ;
+  a rdf:Property .
+
+gbedge:affects
+  gb:edgeLabel "affects" ;
+  rdfs:label "affects" ;
+  a rdf:Property .
+
+<https://lambdasistemi.github.io/graph-browser/vocab/edges#adds%20built-ins%20to>
+  gb:edgeLabel "adds built-ins to" ;
+  rdfs:label "adds built-ins to" ;
+  a rdf:Property .
+
+gbgroup:tooling
+  gb:groupId "tooling" ;
+  rdfs:label "tooling" ;
+  a gb:Group .
+
+gbgroup:thresholds
+  gb:groupId "thresholds" ;
+  rdfs:label "thresholds" ;
+  a gb:Group .
+
+gbgroup:standards
+  gb:groupId "standards" ;
+  rdfs:label "standards" ;
+  a gb:Group .
+
+gbgroup:smart-contracts
+  gb:groupId "smart-contracts" ;
+  rdfs:label "smart-contracts" ;
+  a gb:Group .
+
+gbgroup:protocols
+  gb:groupId "protocols" ;
+  rdfs:label "protocols" ;
+  a gb:Group .
+
+gbgroup:parameters
+  gb:groupId "parameters" ;
+  rdfs:label "parameters" ;
+  a gb:Group .
+
+gbgroup:lifecycle
+  gb:groupId "lifecycle" ;
+  rdfs:label "lifecycle" ;
+  a gb:Group .
+
+gbgroup:languages
+  gb:groupId "languages" ;
+  rdfs:label "languages" ;
+  a gb:Group .
+
+gbgroup:framework
+  gb:groupId "framework" ;
+  rdfs:label "framework" ;
+  a gb:Group .
+
+gbgroup:ecosystem
+  gb:groupId "ecosystem" ;
+  rdfs:label "ecosystem" ;
+  a gb:Group .
+
+gbgroup:core
+  gb:groupId "core" ;
+  rdfs:label "core" ;
+  a gb:Group .
+
+gbgroup:actors
+  gb:groupId "actors" ;
+  rdfs:label "actors" ;
+  a gb:Group .
+
+gbgroup:actions
+  gb:groupId "actions" ;
+  rdfs:label "actions" ;
+  a gb:Group .
+
+gbkind:tool
+  gb:shape "round-pentagon" ;
+  gb:color "#56d4dd" ;
+  gb:kindId "tool" ;
+  rdfs:label "Tool" ;
+  a rdfs:Class .
+
+gbkind:standard
+  gb:shape "round-pentagon" ;
+  gb:color "#e3b341" ;
+  gb:kindId "standard" ;
+  rdfs:label "Standard" ;
+  a rdfs:Class .
+
+gbkind:runtime
+  gb:shape "round-hexagon" ;
+  gb:color "#ff7b72" ;
+  gb:kindId "runtime" ;
+  rdfs:label "Runtime" ;
+  a rdfs:Class .
+
+gbkind:protocol
+  gb:shape "barrel" ;
+  gb:color "#f0883e" ;
+  gb:kindId "protocol" ;
+  rdfs:label "Protocol" ;
+  a rdfs:Class .
+
+gbkind:process
+  gb:shape "diamond" ;
+  gb:color "#3fb950" ;
+  gb:kindId "process" ;
+  rdfs:label "Process" ;
+  a rdfs:Class .
+
+gbkind:parameter
+  gb:shape "round-rectangle" ;
+  gb:color "#a5d6a7" ;
+  gb:kindId "parameter" ;
+  rdfs:label "Parameter" ;
+  a rdfs:Class .
+
+gbkind:param-group
+  gb:shape "barrel" ;
+  gb:color "#e3b341" ;
+  gb:kindId "param-group" ;
+  rdfs:label "Param Group" ;
+  a rdfs:Class .
+
+gbkind:mechanism
+  gb:shape "round-hexagon" ;
+  gb:color "#bc8cff" ;
+  gb:kindId "mechanism" ;
+  rdfs:label "Mechanism" ;
+  a rdfs:Class .
+
+gbkind:language
+  gb:shape "diamond" ;
+  gb:color "#d2a8ff" ;
+  gb:kindId "language" ;
+  rdfs:label "Language" ;
+  a rdfs:Class .
+
+gbkind:concept
+  gb:shape "round-octagon" ;
+  gb:color "#79c0ff" ;
+  gb:kindId "concept" ;
+  rdfs:label "Concept" ;
+  a rdfs:Class .
+
+gbkind:artifact
+  gb:shape "rectangle" ;
+  gb:color "#f778ba" ;
+  gb:kindId "artifact" ;
+  rdfs:label "Artifact" ;
+  a rdfs:Class .
+
+gbkind:actor
+  gb:shape "ellipse" ;
+  gb:color "#58a6ff" ;
+  gb:kindId "actor" ;
+  rdfs:label "Actor" ;
+  a rdfs:Class .
+
+gbkind:action-type
+  gb:shape "round-rectangle" ;
+  gb:color "#d29922" ;
+  gb:kindId "action-type" ;
+  rdfs:label "Action Type" ;
+  a rdfs:Class .
+
+<https://github.com/lambdasistemi/cardano-knowledge-maps/rdf>
+  gb:sourceRepository "https://github.com/lambdasistemi/cardano-knowledge-maps"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
+  gb:edgeCount 129 ;
+  gb:nodeCount 88 ;
+  dcterms:description "Interactive knowledge maps of the Cardano ecosystem — governance, smart contracts, and more." ;
+  dcterms:title "Cardano Knowledge Maps" ;
+  a gb:Dataset .
+

--- a/data/rdf/graph.ttl
+++ b/data/rdf/graph.ttl
@@ -922,7 +922,7 @@ n:ada-holder cardano:delegatesVotingPowerTo n:drep .
 
 n:cip-88
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#registers%20metadata%20for> n:minting-policy ;
-  gb:description "Token Policy Registration — a metadata standard for registering information about a token's minting policy on-chain. Enables policy authors to declare the token's name, description, logo, decimals, and project details in a verifiable way. Helps wallets, explorers, and marketplaces display accurate token information without relying on centralized registries." ;
+  dcterms:description "Token Policy Registration — a metadata standard for registering information about a token's minting policy on-chain. Enables policy authors to declare the token's name, description, logo, decimals, and project details in a verifiable way. Helps wallets, explorers, and marketplaces display accurate token information without relying on centralized registries." ;
   gb:group gbgroup:standards ;
   rdfs:label "CIP-88" ;
   gb:nodeId "cip-88" ;
@@ -933,7 +933,7 @@ n:cip-88
 
 n:cip-85
   gbedge:optimizes n:plutus-core ;
-  gb:description "Sums-of-Products (SOPs) for Plutus Core — replaces the Scott-encoded data representation with native constructor/case expressions. This makes compiled Plutus scripts significantly smaller and faster by eliminating the overhead of encoding algebraic data types as lambda terms. SOPs shipped with Plutus V3 and are a key driver of the script size and execution cost reductions in the Conway era." ;
+  dcterms:description "Sums-of-Products (SOPs) for Plutus Core — replaces the Scott-encoded data representation with native constructor/case expressions. This makes compiled Plutus scripts significantly smaller and faster by eliminating the overhead of encoding algebraic data types as lambda terms. SOPs shipped with Plutus V3 and are a key driver of the script size and execution cost reductions in the Conway era." ;
   gb:group gbgroup:standards ;
   rdfs:label "CIP-85" ;
   gb:nodeId "cip-85" ;
@@ -944,7 +944,7 @@ n:cip-85
 
 n:cip-381
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#adds%20built-ins%20to> n:plutus-core ;
-  gb:description "Adds BLS12-381 elliptic curve primitives as Plutus built-in functions. Enables zero-knowledge proofs (Groth16, PLONK), BLS signature verification, and advanced cryptographic protocols directly on-chain. These primitives support sidechains, bridges, and privacy-preserving applications on Cardano. Shipped with Plutus V3 in the Conway era." ;
+  dcterms:description "Adds BLS12-381 elliptic curve primitives as Plutus built-in functions. Enables zero-knowledge proofs (Groth16, PLONK), BLS signature verification, and advanced cryptographic protocols directly on-chain. These primitives support sidechains, bridges, and privacy-preserving applications on Cardano. Shipped with Plutus V3 in the Conway era." ;
   gb:group gbgroup:standards ;
   rdfs:label "CIP-381" ;
   gb:nodeId "cip-381" ;
@@ -955,7 +955,7 @@ n:cip-381
 
 n:cip-69
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#unifies%20script%20types%20in> n:plutus ;
-  gb:description "Plutus Script Type Uniformization — unifies the interface for all Plutus script purposes (spending, minting, certifying, rewarding) into a single uniform signature. Before CIP-69, minting policies received two arguments (redeemer, context) while spending validators received three (datum, redeemer, context). CIP-69 makes all script types take the same arguments, simplifying multi-purpose scripts and enabling a single validator to serve as both spending and minting script." ;
+  dcterms:description "Plutus Script Type Uniformization — unifies the interface for all Plutus script purposes (spending, minting, certifying, rewarding) into a single uniform signature. Before CIP-69, minting policies received two arguments (redeemer, context) while spending validators received three (datum, redeemer, context). CIP-69 makes all script types take the same arguments, simplifying multi-purpose scripts and enabling a single validator to serve as both spending and minting script." ;
   gb:group gbgroup:standards ;
   rdfs:label "CIP-69" ;
   gb:nodeId "cip-69" ;
@@ -969,7 +969,7 @@ n:govtool
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#enables%20registration%20as> n:drep ;
   gbedge:enables n:voting ;
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#connects%20wallets%20via> n:cip-95 ;
-  gb:description "A web application for participating in Cardano governance. GovTool's four architectural pillars: Proposal Discussion, Delegation, Outcomes, and Voting. Users can delegate to DReps, register as DReps, view and vote on governance actions, and track outcomes. It connects to the user's wallet via CIP-95 (the Conway-era web-wallet bridge)." ;
+  dcterms:description "A web application for participating in Cardano governance. GovTool's four architectural pillars: Proposal Discussion, Delegation, Outcomes, and Voting. Users can delegate to DReps, register as DReps, view and vote on governance actions, and track outcomes. It connects to the user's wallet via CIP-95 (the Conway-era web-wallet bridge)." ;
   gb:group gbgroup:ecosystem ;
   rdfs:label "GovTool" ;
   gb:nodeId "govtool" ;
@@ -984,7 +984,7 @@ n:drep
   gbedge:requires n:deposit-mechanism ;
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#subject%20to> n:drep-thresholds ;
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> n:governance-action ;
-  gb:description "Any ada holder can register as a DRep by paying a refundable deposit (currently 500 ada). DReps accumulate voting power from ada holders who delegate to them. Their vote weight equals the total lovelace delegated to them — one lovelace = one vote. DReps must vote regularly or they become inactive after the dRepActivity period (currently 20 epochs / 100 days). Inactive DReps do not count toward the active voting stake. DRep delegation is separate from stake pool delegation and takes effect immediately (no two-epoch lag). DReps are identified by a credential: an Ed25519 verification key or a native/Plutus script." ;
+  dcterms:description "Any ada holder can register as a DRep by paying a refundable deposit (currently 500 ada). DReps accumulate voting power from ada holders who delegate to them. Their vote weight equals the total lovelace delegated to them — one lovelace = one vote. DReps must vote regularly or they become inactive after the dRepActivity period (currently 20 epochs / 100 days). Inactive DReps do not count toward the active voting stake. DRep delegation is separate from stake pool delegation and takes effect immediately (no two-epoch lag). DReps are identified by a credential: an Ed25519 verification key or a native/Plutus script." ;
   gb:group gbgroup:actors ;
   rdfs:label "Delegated Representative (DRep)" ;
   gb:nodeId "drep" ;
@@ -997,7 +997,7 @@ n:drep
 
 n:cip-119
   gbedge:extends n:cip-100 ;
-  gb:description "CIP-119 defines the governance metadata standard for Delegated Representatives. It extends CIP-100 with DRep-specific fields: display name, bio, motivations, qualifications, payment address, and references. This structured profile metadata helps ada holders make informed delegation decisions. GovTool and other governance interfaces render CIP-119 metadata on DRep profile pages." ;
+  dcterms:description "CIP-119 defines the governance metadata standard for Delegated Representatives. It extends CIP-100 with DRep-specific fields: display name, bio, motivations, qualifications, payment address, and references. This structured profile metadata helps ada holders make informed delegation decisions. GovTool and other governance interfaces render CIP-119 metadata on DRep profile pages." ;
   gb:group gbgroup:framework ;
   rdfs:label "CIP-119" ;
   gb:nodeId "cip-119" ;
@@ -1009,7 +1009,7 @@ n:cip-119
 n:mesh-sdk
   gbedge:uses n:cip-30 ;
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#builds%20transactions%20for> n:plutus ;
-  gb:description "TypeScript SDK with transaction builder, React components, wallet connectors, and smart contract integration. Higher-level alternative to Lucid with more out-of-the-box UI components." ;
+  dcterms:description "TypeScript SDK with transaction builder, React components, wallet connectors, and smart contract integration. Higher-level alternative to Lucid with more out-of-the-box UI components." ;
   gb:group gbgroup:tooling ;
   rdfs:label "Mesh SDK" ;
   gb:nodeId "mesh-sdk" ;
@@ -1023,7 +1023,7 @@ n:lucid-evolution
   gbedge:uses n:cip-30 ;
   gbedge:consumes n:cip-57 ;
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#builds%20transactions%20for> n:plutus ;
-  gb:description "Production-ready TypeScript off-chain transaction builder. Successor to the original Lucid, maintained by Anastasia Labs. Supports Plutus V1/V2/V3, Conway hard fork ready. The standard choice for building Cardano dApp frontends." ;
+  dcterms:description "Production-ready TypeScript off-chain transaction builder. Successor to the original Lucid, maintained by Anastasia Labs. Supports Plutus V1/V2/V3, Conway hard fork ready. The standard choice for building Cardano dApp frontends." ;
   gb:group gbgroup:tooling ;
   rdfs:label "Lucid Evolution" ;
   gb:nodeId "lucid-evolution" ;
@@ -1036,7 +1036,7 @@ n:lucid-evolution
 
 n:cip-95
   gbedge:extends n:cip-30 ;
-  gb:description "CIP-95 defines the web-wallet bridge for the Conway era. It extends the CIP-30 wallet connector with governance-specific capabilities: DRep registration, vote delegation, and governance action submission from browser-based wallets. Without CIP-95, governance tools like GovTool couldn't interact with users' wallets. It enables the 'connect wallet' flow that makes on-chain governance accessible to non-technical participants." ;
+  dcterms:description "CIP-95 defines the web-wallet bridge for the Conway era. It extends the CIP-30 wallet connector with governance-specific capabilities: DRep registration, vote delegation, and governance action submission from browser-based wallets. Without CIP-95, governance tools like GovTool couldn't interact with users' wallets. It enables the 'connect wallet' flow that makes on-chain governance accessible to non-technical participants." ;
   gb:group gbgroup:framework ;
   rdfs:label "CIP-95" ;
   gb:nodeId "cip-95" ;
@@ -1047,7 +1047,7 @@ n:cip-95
 
 n:demeter
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#hosts%20infrastructure%20for> n:plutus ;
-  gb:description "Cloud development platform for Cardano. Provides managed nodes, indexers, and Hydra infrastructure across mainnet/preprod/preview. No local infrastructure needed — develop and test in the cloud." ;
+  dcterms:description "Cloud development platform for Cardano. Provides managed nodes, indexers, and Hydra infrastructure across mainnet/preprod/preview. No local infrastructure needed — develop and test in the cloud." ;
   gb:group gbgroup:tooling ;
   rdfs:label "Demeter.run" ;
   gb:nodeId "demeter" ;
@@ -1059,7 +1059,7 @@ n:demeter
 
 n:blockfrost
   gbedge:indexes n:eutxo ;
-  gb:description "Hosted REST API for Cardano blockchain data. Free tier available. SDKs in 15+ languages. The most common way dApps query chain state without running a full node. Also offers self-hosted option." ;
+  dcterms:description "Hosted REST API for Cardano blockchain data. Free tier available. SDKs in 15+ languages. The most common way dApps query chain state without running a full node. Also offers self-hosted option." ;
   gb:group gbgroup:tooling ;
   rdfs:label "Blockfrost" ;
   gb:nodeId "blockfrost" ;
@@ -1072,7 +1072,7 @@ n:blockfrost
 
 n:djed
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#built%20on> n:plutus ;
-  gb:description "Overcollateralized algorithmic stablecoin. Maintained peg since January 2023 launch. Demonstrates formal verification applied to DeFi — the Djed paper provides mathematical proofs of peg stability under defined conditions." ;
+  dcterms:description "Overcollateralized algorithmic stablecoin. Maintained peg since January 2023 launch. Demonstrates formal verification applied to DeFi — the Djed paper provides mathematical proofs of peg stability under defined conditions." ;
   gb:group gbgroup:protocols ;
   rdfs:label "Djed" ;
   gb:nodeId "djed" ;
@@ -1084,7 +1084,7 @@ n:djed
 
 n:hydra
   gbedge:replicates n:eutxo ;
-  gb:description "Layer 2 isomorphic state channels. Each \"head\" is a mini-ledger replicating Cardano's full functionality off-chain with sub-second latency and 1,000 TPS per head. Multiple heads scale linearly. Uses the same smart contract model as L1." ;
+  dcterms:description "Layer 2 isomorphic state channels. Each \"head\" is a mini-ledger replicating Cardano's full functionality off-chain with sub-second latency and 1,000 TPS per head. Multiple heads scale linearly. Uses the same smart contract model as L1." ;
   gb:group gbgroup:protocols ;
   rdfs:label "Hydra" ;
   gb:nodeId "hydra" ;
@@ -1097,7 +1097,7 @@ n:hydra
 
 n:liqwid
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#written%20in> n:plutarch ;
-  gb:description "Leading lending/borrowing protocol on Cardano. Non-custodial, supports liquid staking. DAO-governed via LQ token. Uses Plutarch for performance-critical validators. Demonstrates complex multi-contract DeFi on EUTxO." ;
+  dcterms:description "Leading lending/borrowing protocol on Cardano. Non-custodial, supports liquid staking. DAO-governed via LQ token. Uses Plutarch for performance-critical validators. Demonstrates complex multi-contract DeFi on EUTxO." ;
   gb:group gbgroup:protocols ;
   rdfs:label "Liqwid Finance" ;
   gb:nodeId "liqwid" ;
@@ -1109,7 +1109,7 @@ n:liqwid
 
 n:minswap
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#written%20in> n:aiken ;
-  gb:description "Largest Cardano DEX by TVL and weekly volume. Multi-pool AMM using the constant-product formula. Written in Aiken. Demonstrates production-scale smart contract usage on Cardano with batched order settlement." ;
+  dcterms:description "Largest Cardano DEX by TVL and weekly volume. Multi-pool AMM using the constant-product formula. Written in Aiken. Demonstrates production-scale smart contract usage on Cardano with batched order settlement." ;
   gb:group gbgroup:protocols ;
   rdfs:label "Minswap" ;
   gb:nodeId "minswap" ;
@@ -1123,7 +1123,7 @@ n:minswap
 n:aiken
   gbedge:generates n:cip-57 ;
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> n:plutus-core ;
-  gb:description "Rust-inspired, purpose-built language for Cardano smart contracts. Most popular on-chain language — 75%+ of developers use it. Compiles directly to UPLC with excellent optimization. First-class Plutus blueprint (CIP-57) generation." ;
+  dcterms:description "Rust-inspired, purpose-built language for Cardano smart contracts. Most popular on-chain language — 75%+ of developers use it. Compiles directly to UPLC with excellent optimization. First-class Plutus blueprint (CIP-57) generation." ;
   gb:group gbgroup:languages ;
   rdfs:label "Aiken" ;
   gb:nodeId "aiken" ;
@@ -1137,7 +1137,7 @@ n:aiken
 
 n:cip-57
   gbedge:documents n:plutus ;
-  gb:description "Plutus Contract Blueprint — machine-readable JSON schema (plutus.json) documenting a smart contract's interface: validators, parameters, datum/redeemer types. Enables tooling to auto-generate off-chain bindings. Aiken generates blueprints automatically." ;
+  dcterms:description "Plutus Contract Blueprint — machine-readable JSON schema (plutus.json) documenting a smart contract's interface: validators, parameters, datum/redeemer types. Enables tooling to auto-generate off-chain bindings. Aiken generates blueprints automatically." ;
   gb:group gbgroup:standards ;
   rdfs:label "CIP-57" ;
   gb:nodeId "cip-57" ;
@@ -1150,7 +1150,7 @@ n:cip-57
 n:cip-68
   gbedge:succeeds n:cip-25 ;
   gbedge:uses n:datum ;
-  gb:description "Rich, mutable metadata standard. Uses a reference NFT (label 100) carrying metadata in its datum, paired with a user token (label 222 for NFTs, 333 for FTs). Metadata can be updated by spending the reference UTxO. Successor to CIP-25." ;
+  dcterms:description "Rich, mutable metadata standard. Uses a reference NFT (label 100) carrying metadata in its datum, paired with a user token (label 222 for NFTs, 333 for FTs). Metadata can be updated by spending the reference UTxO. Successor to CIP-25." ;
   gb:group gbgroup:standards ;
   rdfs:label "CIP-68" ;
   gb:nodeId "cip-68" ;
@@ -1162,7 +1162,7 @@ n:cip-68
 
 n:cip-25
   gbedge:extends n:minting-policy ;
-  gb:description "Original NFT metadata standard. Metadata attached to minting transactions via transaction metadata label 721. Simple and widely adopted but metadata is immutable after minting. The foundation for Cardano's NFT ecosystem." ;
+  dcterms:description "Original NFT metadata standard. Metadata attached to minting transactions via transaction metadata label 721. Simple and widely adopted but metadata is immutable after minting. The foundation for Cardano's NFT ecosystem." ;
   gb:group gbgroup:standards ;
   rdfs:label "CIP-25" ;
   gb:nodeId "cip-25" ;
@@ -1174,7 +1174,7 @@ n:cip-25
 
 n:oracle-pattern
   gbedge:uses n:reference-inputs ;
-  gb:description "Leverages CIP-31 reference inputs: an oracle publishes price/data in a UTxO datum, and multiple contracts read it simultaneously without spending it. Eliminates contention. Charli3 and Orcfax are the main Cardano oracle providers." ;
+  dcterms:description "Leverages CIP-31 reference inputs: an oracle publishes price/data in a UTxO datum, and multiple contracts read it simultaneously without spending it. Eliminates contention. Charli3 and Orcfax are the main Cardano oracle providers." ;
   gb:group gbgroup:smart-contracts ;
   rdfs:label "Oracle Pattern" ;
   gb:nodeId "oracle-pattern" ;
@@ -1187,7 +1187,7 @@ n:oracle-pattern
 
 n:state-machine
   gbedge:uses n:datum ;
-  gb:description "Model contract state as a datum on a UTxO. The validator checks that input datum + redeemer produces a valid output datum, enforcing legal state transitions. Used for multi-step protocols: escrow, auctions, governance, DEX order matching." ;
+  dcterms:description "Model contract state as a datum on a UTxO. The validator checks that input datum + redeemer produces a valid output datum, enforcing legal state transitions. Used for multi-step protocols: escrow, auctions, governance, DEX order matching." ;
   gb:group gbgroup:smart-contracts ;
   rdfs:label "State Machine Pattern" ;
   gb:nodeId "state-machine" ;
@@ -1200,7 +1200,7 @@ n:state-machine
 
 n:staking-validator
   gbedge:optimizes n:eutxo ;
-  gb:description "Validators attached to staking credentials. The \"withdraw zero\" pattern delegates expensive validation logic to a staking validator (called once per transaction) instead of a spending validator (called per input), reducing cost from O(n²) to O(n). Key optimization pattern." ;
+  dcterms:description "Validators attached to staking credentials. The \"withdraw zero\" pattern delegates expensive validation logic to a staking validator (called once per transaction) instead of a spending validator (called per input), reducing cost from O(n²) to O(n). Key optimization pattern." ;
   gb:group gbgroup:smart-contracts ;
   rdfs:label "Staking Validators" ;
   gb:nodeId "staking-validator" ;
@@ -1212,7 +1212,7 @@ n:staking-validator
 
 n:marlowe
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> n:plutus-core ;
-  gb:description "Domain-specific language for financial contracts. High-level, non-Turing-complete by design — contracts can be exhaustively analyzed and formally verified via Isabelle. Transitioned to community ownership (Marlowe Language CIC) in 2024." ;
+  dcterms:description "Domain-specific language for financial contracts. High-level, non-Turing-complete by design — contracts can be exhaustively analyzed and formally verified via Isabelle. Transitioned to community ownership (Marlowe Language CIC) in 2024." ;
   gb:group gbgroup:languages ;
   rdfs:label "Marlowe" ;
   gb:nodeId "marlowe" ;
@@ -1225,7 +1225,7 @@ n:marlowe
 
 n:plu-ts
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> n:plutus-core ;
-  gb:description "TypeScript-embedded DSL for on-chain smart contracts plus off-chain transaction building. Constructs UPLC AST directly in TypeScript. Single-language stack for JS/TS developers. Maintained by Harmonic Labs." ;
+  dcterms:description "TypeScript-embedded DSL for on-chain smart contracts plus off-chain transaction building. Constructs UPLC AST directly in TypeScript. Single-language stack for JS/TS developers. Maintained by Harmonic Labs." ;
   gb:group gbgroup:languages ;
   rdfs:label "plu-ts" ;
   gb:nodeId "plu-ts" ;
@@ -1237,7 +1237,7 @@ n:plu-ts
 
 n:plutarch
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> n:plutus-core ;
-  gb:description "Haskell eDSL giving fine-grained control over generated UPLC. Produces significantly more efficient validators than PlutusTx. Created by Liqwid Labs / MLabs. Used by several high-TVL protocols for performance-critical validators." ;
+  dcterms:description "Haskell eDSL giving fine-grained control over generated UPLC. Produces significantly more efficient validators than PlutusTx. Created by Liqwid Labs / MLabs. Used by several high-TVL protocols for performance-critical validators." ;
   gb:group gbgroup:languages ;
   rdfs:label "Plutarch" ;
   gb:nodeId "plutarch" ;
@@ -1249,7 +1249,7 @@ n:plutarch
 
 n:scalus
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> n:plutus-core ;
-  gb:description "Write smart contracts in Scala 3, compiled to UPLC. Runs on JVM, JS, and Native. UPLC optimizer with compile-time partial evaluation produces competitive script sizes. Full ScalaTest/ScalaCheck support for property-based testing." ;
+  dcterms:description "Write smart contracts in Scala 3, compiled to UPLC. Runs on JVM, JS, and Native. UPLC optimizer with compile-time partial evaluation produces competitive script sizes. Full ScalaTest/ScalaCheck support for property-based testing." ;
   gb:group gbgroup:languages ;
   rdfs:label "Scalus" ;
   gb:nodeId "scalus" ;
@@ -1262,7 +1262,7 @@ n:scalus
 
 n:helios
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> n:plutus-core ;
-  gb:description "JavaScript/TypeScript SDK with its own on-chain DSL — functional, strongly typed, curly-brace syntax. Compiles to Plutus Core. Also handles off-chain transaction building, making it an all-in-one toolkit for JS developers." ;
+  dcterms:description "JavaScript/TypeScript SDK with its own on-chain DSL — functional, strongly typed, curly-brace syntax. Compiles to Plutus Core. Also handles off-chain transaction building, making it an all-in-one toolkit for JS developers." ;
   gb:group gbgroup:languages ;
   rdfs:label "Helios" ;
   gb:nodeId "helios" ;
@@ -1274,7 +1274,7 @@ n:helios
 
 n:opshin
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> n:plutus-core ;
-  gb:description "Write Cardano smart contracts in 100% valid Python syntax. Enforces a strict type system on top of Python. Integrates with PyCardano for off-chain code. Lowers the barrier for Python developers entering the Cardano ecosystem." ;
+  dcterms:description "Write Cardano smart contracts in 100% valid Python syntax. Enforces a strict type system on top of Python. Integrates with PyCardano for off-chain code. Lowers the barrier for Python developers entering the Cardano ecosystem." ;
   gb:group gbgroup:languages ;
   rdfs:label "OpShin" ;
   gb:nodeId "opshin" ;
@@ -1287,7 +1287,7 @@ n:opshin
 
 n:plinth
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> n:plutus-core ;
-  gb:description "Write smart contracts in a subset of Haskell, compiled to UPLC. Formerly PlutusTx, rebranded in February 2025. The original on-chain language maintained by IntersectMBO. Tight integration with the Haskell ecosystem and GHC type system." ;
+  dcterms:description "Write smart contracts in a subset of Haskell, compiled to UPLC. Formerly PlutusTx, rebranded in February 2025. The original on-chain language maintained by IntersectMBO. Tight integration with the Haskell ecosystem and GHC type system." ;
   gb:group gbgroup:languages ;
   rdfs:label "Plinth" ;
   gb:nodeId "plinth" ;
@@ -1306,7 +1306,7 @@ n:action-param-change
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> n:param-group-economic ;
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20change> n:param-group-network ;
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> n:governance-action ;
-  gb:description "Changes one or more updatable protocol parameters. Parameters are grouped into four categories (Network, Economic, Technical, Governance), each with its own DRep voting threshold. Requires CC approval (2/3 majority) for all groups. If the change touches security-relevant parameters, SPOs must also approve at 51%. The Guardrails Script enforces permitted ranges for each parameter. This is the mechanism used for Plutus cost model updates — cost model parameters are part of the Technical group." ;
+  dcterms:description "Changes one or more updatable protocol parameters. Parameters are grouped into four categories (Network, Economic, Technical, Governance), each with its own DRep voting threshold. Requires CC approval (2/3 majority) for all groups. If the change touches security-relevant parameters, SPOs must also approve at 51%. The Guardrails Script enforces permitted ranges for each parameter. This is the mechanism used for Plutus cost model updates — cost model parameters are part of the Technical group." ;
   gb:group gbgroup:actions ;
   rdfs:label "5. Protocol Parameter Changes" ;
   gb:nodeId "action-param-change" ;
@@ -1321,7 +1321,7 @@ n:guardrails-script
   gbedge:enforces n:param-exceptions ;
   gbedge:constrains n:action-treasury ;
   gbedge:constrains n:action-param-change ;
-  gb:description "An on-chain Plutus script that enforces specific constitutional rules programmatically. It applies ONLY to protocol parameter changes and treasury withdrawals — these are the two governance action types where automated enforcement is feasible. The script checks parameter bounds (e.g., maxBlockBodySize must be between 24,576 and 122,880 bytes) and treasury withdrawal limits. Named guardrails include PARAM-01 through PARAM-06a (parameter rules), TREASURY-01a through TREASURY-04a (withdrawal limits), HARDFORK-01 through HARDFORK-08, and committee/constitution update rules. The guardrails script can be updated via a New Constitution governance action." ;
+  dcterms:description "An on-chain Plutus script that enforces specific constitutional rules programmatically. It applies ONLY to protocol parameter changes and treasury withdrawals — these are the two governance action types where automated enforcement is feasible. The script checks parameter bounds (e.g., maxBlockBodySize must be between 24,576 and 122,880 bytes) and treasury withdrawal limits. Named guardrails include PARAM-01 through PARAM-06a (parameter rules), TREASURY-01a through TREASURY-04a (withdrawal limits), HARDFORK-01 through HARDFORK-08, and committee/constitution update rules. The guardrails script can be updated via a New Constitution governance action." ;
   gb:group gbgroup:framework ;
   rdfs:label "Guardrails Script" ;
   gb:nodeId "guardrails-script" ;
@@ -1333,7 +1333,7 @@ n:guardrails-script
 
 n:minting-policy
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#type%20of> n:plutus ;
-  gb:description "A Plutus script that controls the creation and destruction of native tokens. The policy receives the script context and decides whether to allow minting or burning. The policy hash becomes the first part of the token's asset ID, cryptographically binding tokens to their minting rules." ;
+  dcterms:description "A Plutus script that controls the creation and destruction of native tokens. The policy receives the script context and decides whether to allow minting or burning. The policy hash becomes the first part of the token's asset ID, cryptographically binding tokens to their minting rules." ;
   gb:group gbgroup:smart-contracts ;
   rdfs:label "Minting Policy" ;
   gb:nodeId "minting-policy" ;
@@ -1346,7 +1346,7 @@ n:minting-policy
 
 n:inline-datums
   gbedge:improves n:datum ;
-  gb:description "CIP-32 feature that stores the full datum directly in the UTxO instead of just a hash. Eliminates the need for off-chain datum management — anyone can see the contract state by reading the UTxO. Essential for composability between protocols." ;
+  dcterms:description "CIP-32 feature that stores the full datum directly in the UTxO instead of just a hash. Eliminates the need for off-chain datum management — anyone can see the contract state by reading the UTxO. Essential for composability between protocols." ;
   gb:group gbgroup:smart-contracts ;
   rdfs:label "Inline Datums" ;
   gb:nodeId "inline-datums" ;
@@ -1358,7 +1358,7 @@ n:inline-datums
 
 n:reference-inputs
   gbedge:extends n:eutxo ;
-  gb:description "CIP-31 feature allowing transactions to read UTxOs without spending them. Enables oracle patterns, shared state, and read-only access to on-chain data. Referenced UTxOs appear in the script context but remain unspent." ;
+  dcterms:description "CIP-31 feature allowing transactions to read UTxOs without spending them. Enables oracle patterns, shared state, and read-only access to on-chain data. Referenced UTxOs appear in the script context but remain unspent." ;
   gb:group gbgroup:smart-contracts ;
   rdfs:label "Reference Inputs" ;
   gb:nodeId "reference-inputs" ;
@@ -1371,7 +1371,7 @@ n:reference-inputs
 
 n:reference-scripts
   gbedge:optimizes n:plutus ;
-  gb:description "CIP-33 feature allowing scripts to be stored on-chain in a UTxO and referenced by transactions without including the script in the transaction body. Dramatically reduces transaction size and fees for popular contracts. The reference script UTxO is not spent." ;
+  dcterms:description "CIP-33 feature allowing scripts to be stored on-chain in a UTxO and referenced by transactions without including the script in the transaction body. Dramatically reduces transaction size and fees for popular contracts. The reference script UTxO is not spent." ;
   gb:group gbgroup:smart-contracts ;
   rdfs:label "Reference Scripts" ;
   gb:nodeId "reference-scripts" ;
@@ -1384,7 +1384,7 @@ n:reference-scripts
 
 n:eutxo
   gbedge:enables n:plutus ;
-  gb:description "Extended UTxO — Cardano's transaction model that extends Bitcoin's UTxO with datum, redeemer, and script validation. Each UTxO can be locked by a validator script. Spending requires providing a redeemer that satisfies the validator. The model enables deterministic transaction validation — fees and outcomes are known before submission." ;
+  dcterms:description "Extended UTxO — Cardano's transaction model that extends Bitcoin's UTxO with datum, redeemer, and script validation. Each UTxO can be locked by a validator script. Spending requires providing a redeemer that satisfies the validator. The model enables deterministic transaction validation — fees and outcomes are known before submission." ;
   gb:group gbgroup:smart-contracts ;
   rdfs:label "EUTxO Model" ;
   gb:nodeId "eutxo" ;
@@ -1398,7 +1398,7 @@ n:eutxo
 
 n:script-context
   gbedge:provides n:eutxo ;
-  gb:description "The full transaction context passed to a Plutus validator. Includes all inputs, outputs, minting, certificates, withdrawals, validity range, signatories, and datum map. Scripts can inspect any part of the transaction to enforce arbitrary conditions." ;
+  dcterms:description "The full transaction context passed to a Plutus validator. Includes all inputs, outputs, minting, certificates, withdrawals, validity range, signatories, and datum map. Scripts can inspect any part of the transaction to enforce arbitrary conditions." ;
   gb:group gbgroup:smart-contracts ;
   rdfs:label "Script Context" ;
   gb:nodeId "script-context" ;
@@ -1411,7 +1411,7 @@ n:script-context
 
 n:redeemer
   gbedge:extends n:eutxo ;
-  gb:description "User-provided data included in a transaction to unlock a script-locked UTxO. The redeemer represents the action the user wants to perform. The validator script receives the datum, redeemer, and script context and decides whether to allow the spending." ;
+  dcterms:description "User-provided data included in a transaction to unlock a script-locked UTxO. The redeemer represents the action the user wants to perform. The validator script receives the datum, redeemer, and script context and decides whether to allow the spending." ;
   gb:group gbgroup:smart-contracts ;
   rdfs:label "Redeemer" ;
   gb:nodeId "redeemer" ;
@@ -1423,7 +1423,7 @@ n:redeemer
 
 n:datum
   gbedge:extends n:eutxo ;
-  gb:description "Data attached to a UTxO that is locked by a Plutus script. The datum represents the state of the contract. When spending the UTxO, the datum is passed to the validator script along with a redeemer and the transaction context. Can be stored inline (CIP-32) or as a hash with the full datum provided in the transaction." ;
+  dcterms:description "Data attached to a UTxO that is locked by a Plutus script. The datum represents the state of the contract. When spending the UTxO, the datum is passed to the validator script along with a redeemer and the transaction context. Can be stored inline (CIP-32) or as a hash with the full datum provided in the transaction." ;
   gb:group gbgroup:smart-contracts ;
   rdfs:label "Datum" ;
   gb:nodeId "datum" ;
@@ -1437,7 +1437,7 @@ n:datum
 n:cost-models
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#belongs%20to> n:param-group-technical ;
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#updated%20via> n:action-param-change ;
-  gb:description "Protocol parameters that assign abstract CPU and memory costs (ExUnits) to each Plutus builtin function. These are part of the Technical parameter group. Cost models are calibrated by benchmarking each builtin on a reference machine through the Haskell CEK machine, then fitting cost functions via R scripts. Coefficients are stored as 64-bit integers (picoseconds) for cross-platform reproducibility. The cost model ensures that maxBlockExUnits worth of abstract work fits within the real block validation time budget. Every node implementation (Haskell, Rust, etc.) must compute identical ExUnits — the abstract costs are consensus-critical. Updates go through the governance process as Protocol Parameter Changes." ;
+  dcterms:description "Protocol parameters that assign abstract CPU and memory costs (ExUnits) to each Plutus builtin function. These are part of the Technical parameter group. Cost models are calibrated by benchmarking each builtin on a reference machine through the Haskell CEK machine, then fitting cost functions via R scripts. Coefficients are stored as 64-bit integers (picoseconds) for cross-platform reproducibility. The cost model ensures that maxBlockExUnits worth of abstract work fits within the real block validation time budget. Every node implementation (Haskell, Rust, etc.) must compute identical ExUnits — the abstract costs are consensus-critical. Updates go through the governance process as Protocol Parameter Changes." ;
   gb:group gbgroup:parameters ;
   rdfs:label "Plutus Cost Models" ;
   gb:nodeId "cost-models" ;
@@ -1450,7 +1450,7 @@ n:cost-models
 
 n:exunits
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#priced%20by> n:cost-models ;
-  gb:description "Execution units — the two-dimensional resource budget for Plutus scripts. CPU steps measure computation time, memory units measure peak memory usage. Every transaction specifies ExUnits for each script it runs. Fees are computed from ExUnits using protocol parameters (prices per step/unit)." ;
+  dcterms:description "Execution units — the two-dimensional resource budget for Plutus scripts. CPU steps measure computation time, memory units measure peak memory usage. Every transaction specifies ExUnits for each script it runs. Fees are computed from ExUnits using protocol parameters (prices per step/unit)." ;
   gb:group gbgroup:smart-contracts ;
   rdfs:label "ExUnits" ;
   gb:nodeId "exunits" ;
@@ -1463,7 +1463,7 @@ n:exunits
 
 n:cek-machine
   gbedge:consumes n:exunits ;
-  gb:description "The abstract machine that evaluates Plutus Core on-chain. Tracks CPU and memory consumption using ExUnits budgets. If a script exceeds its budget, the transaction fails. The CEK machine is deterministic — same inputs always produce same outputs and same costs." ;
+  dcterms:description "The abstract machine that evaluates Plutus Core on-chain. Tracks CPU and memory consumption using ExUnits budgets. If a script exceeds its budget, the transaction fails. The CEK machine is deterministic — same inputs always produce same outputs and same costs." ;
   gb:group gbgroup:smart-contracts ;
   rdfs:label "CEK Machine" ;
   gb:nodeId "cek-machine" ;
@@ -1475,7 +1475,7 @@ n:cek-machine
 
 n:plutus-core
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluated%20by> n:cek-machine ;
-  gb:description "The low-level language that Plutus scripts compile to. An untyped lambda calculus with built-in functions for cryptography, arithmetic, and data manipulation. Executed by the CEK machine on-chain. Each built-in function has an associated cost in CPU and memory units defined by the cost model." ;
+  dcterms:description "The low-level language that Plutus scripts compile to. An untyped lambda calculus with built-in functions for cryptography, arithmetic, and data manipulation. Executed by the CEK machine on-chain. Each built-in function has an associated cost in CPU and memory units defined by the cost model." ;
   gb:group gbgroup:smart-contracts ;
   rdfs:label "Plutus Core" ;
   gb:nodeId "plutus-core" ;
@@ -1488,7 +1488,7 @@ n:plutus-core
 
 n:plutus
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#compiles%20to> n:plutus-core ;
-  gb:description "The native smart contract platform for Cardano. Plutus scripts are written in PureScript-like Haskell, compiled to Plutus Core (an untyped lambda calculus), and executed on-chain by the Plutus evaluator. Scripts validate transactions — they receive a datum, redeemer, and script context, returning true or false." ;
+  dcterms:description "The native smart contract platform for Cardano. Plutus scripts are written in PureScript-like Haskell, compiled to Plutus Core (an untyped lambda calculus), and executed on-chain by the Plutus evaluator. Scripts validate transactions — they receive a datum, redeemer, and script context, returning true or false." ;
   gb:group gbgroup:smart-contracts ;
   rdfs:label "Plutus" ;
   gb:nodeId "plutus" ;
@@ -1503,7 +1503,7 @@ n:plutus
 n:param-exceptions
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#modifies%20voting%20for> n:action-param-change ;
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#overrides%20thresholds%20from> n:param-group-governance ;
-  gb:description "Some protocol parameters have voting thresholds that differ from their group defaults, as defined in the Cardano Constitution and implemented in the Guardrails Script. For example: committeeMaxTermLength requires only DRep 67% with no CC vote; deposit parameters (dRepDeposit, stakePoolDeposit, stakeAddressDeposit, minPoolCost, committeeMinSize) use the Governance group threshold (DRep 75% + CC 2/3) rather than their native Economic/Technical group thresholds. These exceptions reflect the constitutional significance of these specific parameters." ;
+  dcterms:description "Some protocol parameters have voting thresholds that differ from their group defaults, as defined in the Cardano Constitution and implemented in the Guardrails Script. For example: committeeMaxTermLength requires only DRep 67% with no CC vote; deposit parameters (dRepDeposit, stakePoolDeposit, stakeAddressDeposit, minPoolCost, committeeMinSize) use the Governance group threshold (DRep 75% + CC 2/3) rather than their native Economic/Technical group thresholds. These exceptions reflect the constitutional significance of these specific parameters." ;
   gb:group gbgroup:parameters ;
   rdfs:label "Per-Parameter Threshold Exceptions" ;
   gb:nodeId "param-exceptions" ;
@@ -1516,7 +1516,7 @@ n:param-exceptions
 n:action-info
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#used%20for> n:treasury-budgeting ;
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> n:governance-action ;
-  gb:description "Has no on-chain effect — it's a mechanism for recording community sentiment on-chain. Requires 100% threshold from all three bodies (meaning it can never technically be 'ratified' in the normal sense, but serves as a signal). Info actions are useful for polling the community on proposals before committing to a binding governance action. They do not require chaining to previous actions." ;
+  dcterms:description "Has no on-chain effect — it's a mechanism for recording community sentiment on-chain. Requires 100% threshold from all three bodies (meaning it can never technically be 'ratified' in the normal sense, but serves as a signal). Info actions are useful for polling the community on proposals before committing to a binding governance action. They do not require chaining to previous actions." ;
   gb:group gbgroup:actions ;
   rdfs:label "7. Info Action" ;
   gb:nodeId "action-info" ;
@@ -1527,7 +1527,7 @@ n:action-info
 
 n:treasury-budgeting
   gbedge:gates n:action-treasury ;
-  gb:description "Treasury withdrawals follow a multi-step budgeting process defined by the Cardano Constitution. First, a Net Change Limit must be approved via an Info Action (DRep 50% + CC 2/3) to set the maximum amount that can be withdrawn in a period. Then, individual Budget proposals are approved (also Info Actions with DRep 50% + CC 2/3). Only after both are in place can Treasury Withdrawal governance actions be submitted against the approved budget. This layered process prevents unchecked treasury spending." ;
+  dcterms:description "Treasury withdrawals follow a multi-step budgeting process defined by the Cardano Constitution. First, a Net Change Limit must be approved via an Info Action (DRep 50% + CC 2/3) to set the maximum amount that can be withdrawn in a period. Then, individual Budget proposals are approved (also Info Actions with DRep 50% + CC 2/3). Only after both are in place can Treasury Withdrawal governance actions be submitted against the approved budget. This layered process prevents unchecked treasury spending." ;
   gb:group gbgroup:lifecycle ;
   rdfs:label "Treasury Budgeting Process" ;
   gb:nodeId "treasury-budgeting" ;
@@ -1539,7 +1539,7 @@ n:treasury-budgeting
 
 n:sanchonet
   gbedge:tested n:conway-era ;
-  gb:description "A dedicated governance testnet for experimenting with CIP-1694 features. Launched in 2023, it allowed the community to test DRep registration, voting, governance action submission, and the full lifecycle before Conway went live on mainnet. Named after Sancho Panza (Don Quixote's practical companion)." ;
+  dcterms:description "A dedicated governance testnet for experimenting with CIP-1694 features. Launched in 2023, it allowed the community to test DRep registration, voting, governance action submission, and the full lifecycle before Conway went live on mainnet. Named after Sancho Panza (Don Quixote's practical companion)." ;
   gb:group gbgroup:ecosystem ;
   rdfs:label "SanchoNet" ;
   gb:nodeId "sanchonet" ;
@@ -1551,7 +1551,7 @@ n:sanchonet
 n:cardano-foundation
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#evaluates%20and%20votes%20on> n:governance-action ;
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#registered%20as> n:drep ;
-  gb:description "One of the three founding entities of Cardano (alongside IOG and EMURGO). The CF is registered as a DRep on-chain and operates a Governance Advisory Team of subject-matter experts. It evaluates proposals on constitutional alignment and governance merit, publishing vote rationales with each governance action vote. The CF served on the interim Constitutional Committee during the bootstrap phase and created the Cardano Proposal Examiner tool. The founding entities relinquished their genesis keys, transitioning control to the community." ;
+  dcterms:description "One of the three founding entities of Cardano (alongside IOG and EMURGO). The CF is registered as a DRep on-chain and operates a Governance Advisory Team of subject-matter experts. It evaluates proposals on constitutional alignment and governance merit, publishing vote rationales with each governance action vote. The CF served on the interim Constitutional Committee during the bootstrap phase and created the Cardano Proposal Examiner tool. The founding entities relinquished their genesis keys, transitioning control to the community." ;
   gb:group gbgroup:ecosystem ;
   rdfs:label "Cardano Foundation" ;
   gb:nodeId "cardano-foundation" ;
@@ -1564,7 +1564,7 @@ n:cardano-foundation
 
 n:intersect
   gbedge:facilitates n:governance-model ;
-  gb:description "A not-for-profit organization (registered in Wyoming, USA) that facilitates off-chain governance processes. Intersect manages the Parameter Committee, organizes elections, runs working groups, and coordinates the governance tooling ecosystem. It is NOT a governance body — it does not vote or ratify. Its role is facilitation and coordination: hosting discussions, managing the CIP process, coordinating hard fork readiness, and providing infrastructure like GovTool." ;
+  dcterms:description "A not-for-profit organization (registered in Wyoming, USA) that facilitates off-chain governance processes. Intersect manages the Parameter Committee, organizes elections, runs working groups, and coordinates the governance tooling ecosystem. It is NOT a governance body — it does not vote or ratify. Its role is facilitation and coordination: hosting discussions, managing the CIP process, coordinating hard fork readiness, and providing infrastructure like GovTool." ;
   gb:group gbgroup:ecosystem ;
   rdfs:label "Intersect" ;
   gb:nodeId "intersect" ;
@@ -1575,7 +1575,7 @@ n:intersect
 
 n:cip-105
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#derives%20keys%20for> n:drep ;
-  gb:description "CIP-105 defines the Conway-era HD wallet key derivation paths for governance credentials. It specifies how wallets derive the key pairs used for DRep registration, vote delegation, and CC member credentials from a single master seed. This ensures that governance keys are deterministically recoverable from a wallet's mnemonic phrase, following the same BIP-32/BIP-44 patterns used for payment and staking keys." ;
+  dcterms:description "CIP-105 defines the Conway-era HD wallet key derivation paths for governance credentials. It specifies how wallets derive the key pairs used for DRep registration, vote delegation, and CC member credentials from a single master seed. This ensures that governance keys are deterministically recoverable from a wallet's mnemonic phrase, following the same BIP-32/BIP-44 patterns used for payment and staking keys." ;
   gb:group gbgroup:framework ;
   rdfs:label "CIP-105" ;
   gb:nodeId "cip-105" ;
@@ -1587,7 +1587,7 @@ n:cip-105
 n:cip-129
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#standardizes%20IDs%20for> n:governance-action ;
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#standardizes%20IDs%20for> n:drep ;
-  gb:description "CIP-129 standardizes governance identifiers across the ecosystem. It defines canonical string representations for governance credentials (DRep IDs, CC member IDs, governance action IDs) that work consistently across wallets, explorers, and governance tools. Without this standard, different tools might represent the same DRep or action differently, causing confusion when sharing links or referencing proposals." ;
+  dcterms:description "CIP-129 standardizes governance identifiers across the ecosystem. It defines canonical string representations for governance credentials (DRep IDs, CC member IDs, governance action IDs) that work consistently across wallets, explorers, and governance tools. Without this standard, different tools might represent the same DRep or action differently, causing confusion when sharing links or referencing proposals." ;
   gb:group gbgroup:framework ;
   rdfs:label "CIP-129" ;
   gb:nodeId "cip-129" ;
@@ -1606,7 +1606,7 @@ n:cc
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> n:action-param-change ;
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> n:action-hard-fork ;
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> n:action-new-constitution ;
-  gb:description "A community-elected oversight body responsible for ensuring that governance actions respect the Cardano Constitution. Each CC member holds exactly one vote (not stake-weighted). The CC does NOT create proposals and does NOT evaluate merit — it reviews constitutionality only. Members use a hot/cold key credential system (like genesis delegation). Each member has an individual term expiration epoch; expired members cannot vote. Members can resign early. The CC can enter a 'no-confidence' state via a Motion of No-Confidence, which blocks it from participating in ratification until a new committee is elected. The CC does not vote on No-Confidence motions or Committee updates (since those are about the CC itself)." ;
+  dcterms:description "A community-elected oversight body responsible for ensuring that governance actions respect the Cardano Constitution. Each CC member holds exactly one vote (not stake-weighted). The CC does NOT create proposals and does NOT evaluate merit — it reviews constitutionality only. Members use a hot/cold key credential system (like genesis delegation). Each member has an individual term expiration epoch; expired members cannot vote. Members can resign early. The CC can enter a 'no-confidence' state via a Motion of No-Confidence, which blocks it from participating in ratification until a new committee is elected. The CC does not vote on No-Confidence motions or Committee updates (since those are about the CC itself)." ;
   gb:group gbgroup:actors ;
   rdfs:label "Constitutional Committee (CC)" ;
   gb:nodeId "cc" ;
@@ -1618,7 +1618,7 @@ n:cc
 
 n:cip-108
   gbedge:extends n:cip-100 ;
-  gb:description "CIP-108 extends CIP-100 with a specific metadata format for governance actions. It defines required fields: title, abstract, motivation, rationale, and supporting references. This structured format ensures that voters have consistent, comparable information when evaluating proposals. GovTool and other governance interfaces render CIP-108 metadata to present proposals in a human-readable format." ;
+  dcterms:description "CIP-108 extends CIP-100 with a specific metadata format for governance actions. It defines required fields: title, abstract, motivation, rationale, and supporting references. This structured format ensures that voters have consistent, comparable information when evaluating proposals. GovTool and other governance interfaces render CIP-108 metadata to present proposals in a human-readable format." ;
   gb:group gbgroup:framework ;
   rdfs:label "CIP-108" ;
   gb:nodeId "cip-108" ;
@@ -1634,7 +1634,7 @@ n:governance-action
   gbedge:uses n:action-chaining ;
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#open%20for> n:voting ;
   gbedge:undergoes n:ratification ;
-  gb:description "An on-chain event triggered by a transaction. Any ada holder can submit a governance action by paying the govActionDeposit (currently 100,000 ada, refundable). Every action includes: the deposit amount, a reward address for deposit return, a metadata anchor (URL + hash, following CIP-100/CIP-108 standards), and — for most types — a hash reference to the most recently enacted action of the same type (to prevent collisions). Actions have a lifespan of govActionLifetime epochs (currently 6 epochs / ~30 days). There are 7 types of governance actions." ;
+  dcterms:description "An on-chain event triggered by a transaction. Any ada holder can submit a governance action by paying the govActionDeposit (currently 100,000 ada, refundable). Every action includes: the deposit amount, a reward address for deposit return, a metadata anchor (URL + hash, following CIP-100/CIP-108 standards), and — for most types — a hash reference to the most recently enacted action of the same type (to prevent collisions). Actions have a lifespan of govActionLifetime epochs (currently 6 epochs / ~30 days). There are 7 types of governance actions." ;
   gb:group gbgroup:actions ;
   rdfs:label "Governance Action" ;
   gb:nodeId "governance-action" ;
@@ -1652,7 +1652,7 @@ n:spo
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> n:action-hard-fork ;
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> n:action-update-committee ;
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#votes%20on> n:action-no-confidence ;
-  gb:description "Block producers who also participate in governance voting. SPOs vote on a specific subset of governance action types: No Confidence motions, Committee updates, Hard Fork Initiation, security-relevant protocol parameter changes, and Info actions. Their voting power is proportional to the total stake delegated to their pool. SPOs implement approved protocol upgrades (hard forks) on their infrastructure." ;
+  dcterms:description "Block producers who also participate in governance voting. SPOs vote on a specific subset of governance action types: No Confidence motions, Committee updates, Hard Fork Initiation, security-relevant protocol parameter changes, and Info actions. Their voting power is proportional to the total stake delegated to their pool. SPOs implement approved protocol upgrades (hard forks) on their infrastructure." ;
   gb:group gbgroup:actors ;
   rdfs:label "Stake Pool Operator (SPO)" ;
   gb:nodeId "spo" ;
@@ -1663,7 +1663,7 @@ n:spo
 
 n:conway-era
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#started%20with> n:bootstrap-phase ;
-  gb:description "The current Cardano ledger era that implements CIP-1694 governance. Named after mathematician John Horton Conway. Introduced via two hard forks: Chang #1 (August 2024) — bootstrap phase with limited governance (DRep registration, interim CC, parameter changes and hard forks only); and Plomin hard fork / Chang #2 (December 2024) — full governance activation with all 7 action types and treasury withdrawals. The bootstrap phase ended when the CC and SPOs ratified the Plomin hard fork." ;
+  dcterms:description "The current Cardano ledger era that implements CIP-1694 governance. Named after mathematician John Horton Conway. Introduced via two hard forks: Chang #1 (August 2024) — bootstrap phase with limited governance (DRep registration, interim CC, parameter changes and hard forks only); and Plomin hard fork / Chang #2 (December 2024) — full governance activation with all 7 action types and treasury withdrawals. The bootstrap phase ended when the CC and SPOs ratified the Plomin hard fork." ;
   gb:group gbgroup:framework ;
   rdfs:label "Conway Ledger Era" ;
   gb:nodeId "conway-era" ;
@@ -1675,7 +1675,7 @@ n:conway-era
 n:cip-1694
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#implemented%20in> n:conway-era ;
   gbedge:specifies n:governance-model ;
-  gb:description "The Cardano Improvement Proposal that specifies the on-chain governance mechanism. Authored by Jared Corduan and Andre Knispel, it defines the three governance bodies, seven action types, voting and ratification rules, the Constitutional Committee structure, DRep mechanics, and the full lifecycle of governance actions. CIP-1694 was implemented in the Conway ledger era (named after John Horton Conway)." ;
+  dcterms:description "The Cardano Improvement Proposal that specifies the on-chain governance mechanism. Authored by Jared Corduan and Andre Knispel, it defines the three governance bodies, seven action types, voting and ratification rules, the Constitutional Committee structure, DRep mechanics, and the full lifecycle of governance actions. CIP-1694 was implemented in the Conway ledger era (named after John Horton Conway)." ;
   gb:group gbgroup:framework ;
   rdfs:label "CIP-1694" ;
   gb:nodeId "cip-1694" ;
@@ -1689,7 +1689,7 @@ n:governance-model
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> n:spo ;
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#governance%20body> n:drep ;
   gbedge:implements n:liquid-democracy ;
-  gb:description "Cardano uses a tricameral (three-body) governance model implementing liquid democracy, introduced by CIP-1694 as part of the Voltaire phase. Ada holders can vote directly on every governance matter or delegate their voting power to Delegated Representatives (DReps). Three governance bodies — DReps, Stake Pool Operators (SPOs), and the Constitutional Committee (CC) — each play distinct roles in reviewing and ratifying governance actions. Every governance action requires approval from at least two of the three bodies." ;
+  dcterms:description "Cardano uses a tricameral (three-body) governance model implementing liquid democracy, introduced by CIP-1694 as part of the Voltaire phase. Ada holders can vote directly on every governance matter or delegate their voting power to Delegated Representatives (DReps). Three governance bodies — DReps, Stake Pool Operators (SPOs), and the Constitutional Committee (CC) — each play distinct roles in reviewing and ratifying governance actions. Every governance action requires approval from at least two of the three bodies." ;
   gb:group gbgroup:core ;
   rdfs:label "Cardano Governance" ;
   gb:nodeId "governance-model" ;
@@ -1703,7 +1703,7 @@ n:governance-model
 n:action-update-committee
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#changes%20membership%20of> n:cc ;
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> n:governance-action ;
-  gb:description "Changes the Constitutional Committee membership, its signature threshold, and/or member term limits. Can add new members (with term expiration epochs), remove existing members, and adjust the fraction of CC members required to approve actions. Thresholds differ depending on CC state: in normal state, requires DRep 67% + SPO 51%; in no-confidence state, DRep 60% + SPO 51% (lower DRep threshold to make it easier to replace a failed CC). The CC does not vote on this." ;
+  dcterms:description "Changes the Constitutional Committee membership, its signature threshold, and/or member term limits. Can add new members (with term expiration epochs), remove existing members, and adjust the fraction of CC members required to approve actions. Thresholds differ depending on CC state: in normal state, requires DRep 67% + SPO 51%; in no-confidence state, DRep 60% + SPO 51% (lower DRep threshold to make it easier to replace a failed CC). The CC does not vote on this." ;
   gb:group gbgroup:actions ;
   rdfs:label "2. Update Committee / Threshold" ;
   gb:nodeId "action-update-committee" ;
@@ -1715,7 +1715,7 @@ n:action-update-committee
 n:action-no-confidence
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#puts%20into%20no-confidence%20state> n:cc ;
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> n:governance-action ;
-  gb:description "Creates a state of no-confidence in the current Constitutional Committee. When ratified, the CC enters a no-confidence state and cannot participate in governance until a new committee is elected via an Update Committee action. This is the highest-priority governance action — if ratified in the same epoch as other actions, it is enacted first. Requires: DRep approval at 67% of active voting stake + SPO approval at 51% of active pool stake. The CC does not vote on this (since it's about them)." ;
+  dcterms:description "Creates a state of no-confidence in the current Constitutional Committee. When ratified, the CC enters a no-confidence state and cannot participate in governance until a new committee is elected via an Update Committee action. This is the highest-priority governance action — if ratified in the same epoch as other actions, it is enacted first. Requires: DRep approval at 67% of active voting stake + SPO approval at 51% of active pool stake. The CC does not vote on this (since it's about them)." ;
   gb:group gbgroup:actions ;
   rdfs:label "1. Motion of No-Confidence" ;
   gb:nodeId "action-no-confidence" ;
@@ -1728,7 +1728,7 @@ n:action-new-constitution
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20update> n:guardrails-script ;
   gbedge:modifies n:constitution ;
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> n:governance-action ;
-  gb:description "Modifies the Cardano Constitution and/or the on-chain Guardrails Script. The action includes an anchor to the new Constitution text and optionally a new script hash for the Guardrails Script. Requires: CC approval (2/3 majority) + DRep approval at 75% of active voting stake. SPOs do not vote on this. This is the action with the highest DRep threshold (alongside Governance group parameter changes), reflecting the significance of constitutional amendments." ;
+  dcterms:description "Modifies the Cardano Constitution and/or the on-chain Guardrails Script. The action includes an anchor to the new Constitution text and optionally a new script hash for the Guardrails Script. Requires: CC approval (2/3 majority) + DRep approval at 75% of active voting stake. SPOs do not vote on this. This is the action with the highest DRep threshold (alongside Governance group parameter changes), reflecting the significance of constitutional amendments." ;
   gb:group gbgroup:actions ;
   rdfs:label "3. New Constitution / Guardrails Script" ;
   gb:nodeId "action-new-constitution" ;
@@ -1739,7 +1739,7 @@ n:action-new-constitution
 
 n:constitution
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#codified%20in> n:guardrails-script ;
-  gb:description "An off-chain text document whose hash is recorded on-chain. It defines shared values and guiding principles for Cardano governance. The current Constitution was ratified at the Buenos Aires Constitutional Convention (December 4-6, 2024) with 95% delegate approval after 63 workshops across 51 countries, and became effective on-chain on January 24, 2026. It contains: a Preamble (not used for constitutionality assessments), 10 Tenets (core principles including transaction freedom, predictable costs, ada supply cap at 45 billion), Articles covering community participation, decentralized governance, CC responsibilities, and treasury provisions, plus Appendix I with permitted parameter ranges. The on-chain version (hash) prevails over the documented version in case of conflict." ;
+  dcterms:description "An off-chain text document whose hash is recorded on-chain. It defines shared values and guiding principles for Cardano governance. The current Constitution was ratified at the Buenos Aires Constitutional Convention (December 4-6, 2024) with 95% delegate approval after 63 workshops across 51 countries, and became effective on-chain on January 24, 2026. It contains: a Preamble (not used for constitutionality assessments), 10 Tenets (core principles including transaction freedom, predictable costs, ada supply cap at 45 billion), Articles covering community participation, decentralized governance, CC responsibilities, and treasury provisions, plus Appendix I with permitted parameter ranges. The on-chain version (hash) prevails over the documented version in case of conflict." ;
   gb:group gbgroup:framework ;
   rdfs:label "Cardano Constitution" ;
   gb:nodeId "constitution" ;
@@ -1751,7 +1751,7 @@ n:constitution
 
 n:param-group-governance
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#some%20params%20are> n:security-params ;
-  gb:description "Protocol parameters that govern governance itself. DRep voting threshold: 75% (P5d) — the highest threshold for parameter changes, reflecting the self-referential nature of changing governance rules. Includes: all 15 voting thresholds (P1–P6 for DReps, Q1–Q5 for SPOs), govActionLifetime (1–15 epochs), govActionDeposit (1M–10T lovelace), dRepDeposit (1M–100B lovelace), dRepActivity (13–37 epochs), committeeMinSize (3–10), committeeMaxTermLength (18–293 epochs)." ;
+  dcterms:description "Protocol parameters that govern governance itself. DRep voting threshold: 75% (P5d) — the highest threshold for parameter changes, reflecting the self-referential nature of changing governance rules. Includes: all 15 voting thresholds (P1–P6 for DReps, Q1–Q5 for SPOs), govActionLifetime (1–15 epochs), govActionDeposit (1M–10T lovelace), dRepDeposit (1M–100B lovelace), dRepActivity (13–37 epochs), committeeMinSize (3–10), committeeMaxTermLength (18–293 epochs)." ;
   gb:group gbgroup:parameters ;
   rdfs:label "Governance Parameter Group" ;
   gb:nodeId "param-group-governance" ;
@@ -1762,7 +1762,7 @@ n:param-group-governance
 
 n:param-group-economic
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#some%20params%20are> n:security-params ;
-  gb:description "Protocol parameters related to transaction fees, deposits, and monetary policy. DRep voting threshold: 67% (P5b). Includes: txFeePerByte (30–1,000 lovelace), txFeeFixed (100,000–10,000,000 lovelace), stakeAddressDeposit, stakePoolDeposit, monetaryExpansion (0.001–0.005), treasuryCut (10%–30%), minPoolCost, utxoCostPerByte (3,000–6,500), executionUnitPrices (priceMemory and priceSteps), minFeeRefScriptCostPerByte." ;
+  dcterms:description "Protocol parameters related to transaction fees, deposits, and monetary policy. DRep voting threshold: 67% (P5b). Includes: txFeePerByte (30–1,000 lovelace), txFeeFixed (100,000–10,000,000 lovelace), stakeAddressDeposit, stakePoolDeposit, monetaryExpansion (0.001–0.005), treasuryCut (10%–30%), minPoolCost, utxoCostPerByte (3,000–6,500), executionUnitPrices (priceMemory and priceSteps), minFeeRefScriptCostPerByte." ;
   gb:group gbgroup:parameters ;
   rdfs:label "Economic Parameter Group" ;
   gb:nodeId "param-group-economic" ;
@@ -1773,7 +1773,7 @@ n:param-group-economic
 
 n:param-group-network
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#some%20params%20are> n:security-params ;
-  gb:description "Protocol parameters related to network capacity and transaction limits. DRep voting threshold: 67% (P5a). Includes: maxBlockBodySize (24,576–122,880 bytes), maxTxSize (up to 32,768 bytes), maxBlockHeaderSize (up to 5,000 bytes), maxValueSize (up to 12,288 bytes), maxTxExecutionUnits (memory and steps), maxBlockExecutionUnits (memory and steps), maxCollateralInputs (minimum 1). Guardrail NETWORK-01: should not change more than once per 2 epochs. NETWORK-02: only one parameter should change per epoch unless correlated." ;
+  dcterms:description "Protocol parameters related to network capacity and transaction limits. DRep voting threshold: 67% (P5a). Includes: maxBlockBodySize (24,576–122,880 bytes), maxTxSize (up to 32,768 bytes), maxBlockHeaderSize (up to 5,000 bytes), maxValueSize (up to 12,288 bytes), maxTxExecutionUnits (memory and steps), maxBlockExecutionUnits (memory and steps), maxCollateralInputs (minimum 1). Guardrail NETWORK-01: should not change more than once per 2 epochs. NETWORK-02: only one parameter should change per epoch unless correlated." ;
   gb:group gbgroup:parameters ;
   rdfs:label "Network Parameter Group" ;
   gb:nodeId "param-group-network" ;
@@ -1784,7 +1784,7 @@ n:param-group-network
 
 n:param-group-technical
   gbedge:contains n:cost-models ;
-  gb:description "Protocol parameters related to stake pool mechanics, Plutus execution, and script validation. DRep voting threshold: 67% (P5c). Includes: poolPledgeInfluence (0.1–1.0), poolRetireMaxEpoch, stakePoolTargetNum (250–2,000), costModels (the Plutus cost model parameters — benchmarked values for each builtin function), collateralPercentage (100–200). The costModels parameter is what gets updated when the Plutus team reprices builtins based on new benchmarks." ;
+  dcterms:description "Protocol parameters related to stake pool mechanics, Plutus execution, and script validation. DRep voting threshold: 67% (P5c). Includes: poolPledgeInfluence (0.1–1.0), poolRetireMaxEpoch, stakePoolTargetNum (250–2,000), costModels (the Plutus cost model parameters — benchmarked values for each builtin function), collateralPercentage (100–200). The costModels parameter is what gets updated when the Plutus team reprices builtins based on new benchmarks." ;
   gb:group gbgroup:parameters ;
   rdfs:label "Technical Parameter Group" ;
   gb:nodeId "param-group-technical" ;
@@ -1796,7 +1796,7 @@ n:param-group-technical
 
 n:action-treasury
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> n:governance-action ;
-  gb:description "Withdraws ada from the Cardano treasury. The action specifies a map from stake credentials to positive lovelace amounts. Requires: CC approval (2/3 majority) + DRep approval at 67%. SPOs do not vote on this. The Guardrails Script enforces withdrawal limits (TREASURY-01a through TREASURY-04a). Treasury withdrawals must specify purpose, expected costs, and provide for auditable accounts. This action type does NOT require chaining to previous actions of the same type (unlike most other types)." ;
+  dcterms:description "Withdraws ada from the Cardano treasury. The action specifies a map from stake credentials to positive lovelace amounts. Requires: CC approval (2/3 majority) + DRep approval at 67%. SPOs do not vote on this. The Guardrails Script enforces withdrawal limits (TREASURY-01a through TREASURY-04a). Treasury withdrawals must specify purpose, expected costs, and provide for auditable accounts. This action type does NOT require chaining to previous actions of the same type (unlike most other types)." ;
   gb:group gbgroup:actions ;
   rdfs:label "6. Treasury Withdrawal" ;
   gb:nodeId "action-treasury" ;
@@ -1807,7 +1807,7 @@ n:action-treasury
 
 n:action-hard-fork
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#is%20a%20type%20of> n:governance-action ;
-  gb:description "Triggers a non-backwards-compatible protocol upgrade. The action specifies a new major protocol version (must be exactly +1 from current). This is the only governance action that requires approval from ALL THREE bodies: CC (2/3 majority), DReps (60%), and SPOs (51%). Guardrail HARDFORK-04a requires at least 85% of stake pools by active stake to have upgraded their node software before enactment. A ratified hard fork delays ratification of all other pending actions until after enactment." ;
+  dcterms:description "Triggers a non-backwards-compatible protocol upgrade. The action specifies a new major protocol version (must be exactly +1 from current). This is the only governance action that requires approval from ALL THREE bodies: CC (2/3 majority), DReps (60%), and SPOs (51%). Guardrail HARDFORK-04a requires at least 85% of stake pools by active stake to have upgraded their node software before enactment. A ratified hard fork delays ratification of all other pending actions until after enactment." ;
   gb:group gbgroup:actions ;
   rdfs:label "4. Hard Fork Initiation" ;
   gb:nodeId "action-hard-fork" ;
@@ -1819,7 +1819,7 @@ n:action-hard-fork
 
 n:voting
   gbedge:determines n:ratification ;
-  gb:description "Each governance body votes Yes, No, or Abstain on applicable governance actions. Votes are recorded on-chain via transactions. DRep and SPO votes are weighted by delegated stake; CC votes are one-member-one-vote. Votes can be changed at any time before the action is ratified. The voting period lasts up to govActionLifetime epochs (currently 6 epochs / ~30 days). Abstain votes are NOT counted in the active voting stake denominator. Post-bootstrap: ada holders must delegate to a DRep (or Abstain/No Confidence) to withdraw staking rewards." ;
+  dcterms:description "Each governance body votes Yes, No, or Abstain on applicable governance actions. Votes are recorded on-chain via transactions. DRep and SPO votes are weighted by delegated stake; CC votes are one-member-one-vote. Votes can be changed at any time before the action is ratified. The voting period lasts up to govActionLifetime epochs (currently 6 epochs / ~30 days). Abstain votes are NOT counted in the active voting stake denominator. Post-bootstrap: ada holders must delegate to a DRep (or Abstain/No Confidence) to withdraw staking rewards." ;
   gb:group gbgroup:lifecycle ;
   rdfs:label "Voting" ;
   gb:nodeId "voting" ;
@@ -1831,7 +1831,7 @@ n:voting
 
 n:ratification
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#leads%20to> n:enactment ;
-  gb:description "The process by which a governance action accumulates enough votes to be approved. Ratification is checked ONLY at epoch boundaries — a new tally is calculated each epoch using the current stake snapshot. An action can become ratified even without new votes if delegation changes shift the stake distribution. Votes can be changed at any time before ratification. Registered stake that did not vote counts as 'No'. Unregistered stake counts as 'Abstain'. Each action type has specific thresholds for each governance body. A successful No-Confidence, Committee Update, New Constitution, or Hard Fork delays ratification of ALL other pending actions until after enactment." ;
+  dcterms:description "The process by which a governance action accumulates enough votes to be approved. Ratification is checked ONLY at epoch boundaries — a new tally is calculated each epoch using the current stake snapshot. An action can become ratified even without new votes if delegation changes shift the stake distribution. Votes can be changed at any time before ratification. Registered stake that did not vote counts as 'No'. Unregistered stake counts as 'Abstain'. Each action type has specific thresholds for each governance body. A successful No-Confidence, Committee Update, New Constitution, or Hard Fork delays ratification of ALL other pending actions until after enactment." ;
   gb:group gbgroup:lifecycle ;
   rdfs:label "Ratification" ;
   gb:nodeId "ratification" ;
@@ -1847,7 +1847,7 @@ n:ada-holder
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20delegate%20to> n:no-confidence-option ;
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#can%20delegate%20to> n:abstain-option ;
   <https://lambdasistemi.github.io/graph-browser/vocab/edges#delegates%20voting%20power%20to> n:drep ;
-  gb:description "Any holder of ada. Ada holders are the foundation of Cardano governance — they have 'skin in the game' and can participate in governance in multiple ways: vote directly by registering as a DRep, delegate their voting power to a DRep (or to the pre-defined Abstain/No Confidence options), submit governance actions (with a deposit), and delegate stake to SPOs for block production. Voting power is proportional: one lovelace = one vote." ;
+  dcterms:description "Any holder of ada. Ada holders are the foundation of Cardano governance — they have 'skin in the game' and can participate in governance in multiple ways: vote directly by registering as a DRep, delegate their voting power to a DRep (or to the pre-defined Abstain/No Confidence options), submit governance actions (with a deposit), and delegate stake to SPOs for block production. Voting power is proportional: one lovelace = one vote." ;
   gb:group gbgroup:actors ;
   rdfs:label "Ada Holder" ;
   gb:nodeId "ada-holder" ;
@@ -1858,7 +1858,7 @@ n:ada-holder
   rdfs:seeAlso <https://gov.tools> .
 
 n:spo-thresholds
-  gb:description "SPO thresholds are expressed as a fraction of active pool stake. SPOs only vote on specific action types. Current mainnet values: No-Confidence (Q1) = 51%, Committee Update normal (Q2a) = 51%, Committee Update no-confidence (Q2b) = 51%, Hard Fork (Q4) = 51%, Security-relevant params (Q5) = 51%, Info = 100% (fixed). SPOs do NOT vote on: New Constitution, non-security parameter changes, or Treasury Withdrawals." ;
+  dcterms:description "SPO thresholds are expressed as a fraction of active pool stake. SPOs only vote on specific action types. Current mainnet values: No-Confidence (Q1) = 51%, Committee Update normal (Q2a) = 51%, Committee Update no-confidence (Q2b) = 51%, Hard Fork (Q4) = 51%, Security-relevant params (Q5) = 51%, Info = 100% (fixed). SPOs do NOT vote on: New Constitution, non-security parameter changes, or Treasury Withdrawals." ;
   gb:group gbgroup:thresholds ;
   rdfs:label "SPO Voting Thresholds" ;
   gb:nodeId "spo-thresholds" ;
@@ -1868,7 +1868,7 @@ n:spo-thresholds
   foaf:page <https://cips.cardano.org/cip/CIP-1694#ratification> .
 
 n:security-params
-  gb:description "A subset of protocol parameters that additionally require SPO approval (at Q5 = 51% threshold) when changed. These parameters directly affect network security and node operator costs. The list: maxBlockBodySize, maxTxSize, maxBlockHeaderSize, maxValueSize, maxBlockExecutionUnits, txFeePerByte, txFeeFixed, utxoCostPerByte, govActionDeposit, minFeeRefScriptCostPerByte. This gives SPOs a veto over changes that could destabilize the network or make block production uneconomical." ;
+  dcterms:description "A subset of protocol parameters that additionally require SPO approval (at Q5 = 51% threshold) when changed. These parameters directly affect network security and node operator costs. The list: maxBlockBodySize, maxTxSize, maxBlockHeaderSize, maxValueSize, maxBlockExecutionUnits, txFeePerByte, txFeeFixed, utxoCostPerByte, govActionDeposit, minFeeRefScriptCostPerByte. This gives SPOs a veto over changes that could destabilize the network or make block production uneconomical." ;
   gb:group gbgroup:parameters ;
   rdfs:label "Security-Relevant Parameters" ;
   gb:nodeId "security-params" ;
@@ -1878,7 +1878,7 @@ n:security-params
   foaf:page <https://cips.cardano.org/cip/CIP-1694> .
 
 n:no-confidence-option
-  gb:description "A pre-defined voting option for ada holders. When delegating to No Confidence, the holder's stake automatically votes 'Yes' on every Motion of No-Confidence and 'No' on every other governance action. Unlike Abstain, this stake IS counted in the active voting stake — it actively opposes all governance actions except no-confidence motions. This is a signal of dissatisfaction with the current governance state." ;
+  dcterms:description "A pre-defined voting option for ada holders. When delegating to No Confidence, the holder's stake automatically votes 'Yes' on every Motion of No-Confidence and 'No' on every other governance action. Unlike Abstain, this stake IS counted in the active voting stake — it actively opposes all governance actions except no-confidence motions. This is a signal of dissatisfaction with the current governance state." ;
   gb:group gbgroup:actors ;
   rdfs:label "No Confidence (Pre-defined DRep)" ;
   gb:nodeId "no-confidence-option" ;
@@ -1888,7 +1888,7 @@ n:no-confidence-option
   foaf:page <https://cips.cardano.org/cip/CIP-1694#pre-defined-voting-options> .
 
 n:liquid-democracy
-  gb:description "The democratic model used by Cardano governance. Ada holders can vote directly on every governance matter (by registering as their own DRep) OR delegate their voting power to any registered DRep. Delegation can be changed at any time and takes effect immediately. This combines the benefits of direct democracy (anyone can participate) with representative democracy (expertise can be delegated to). DRep delegation is SEPARATE from stake pool delegation — you choose who produces blocks and who votes on your behalf independently." ;
+  dcterms:description "The democratic model used by Cardano governance. Ada holders can vote directly on every governance matter (by registering as their own DRep) OR delegate their voting power to any registered DRep. Delegation can be changed at any time and takes effect immediately. This combines the benefits of direct democracy (anyone can participate) with representative democracy (expertise can be delegated to). DRep delegation is SEPARATE from stake pool delegation — you choose who produces blocks and who votes on your behalf independently." ;
   gb:group gbgroup:core ;
   rdfs:label "Liquid Democracy" ;
   gb:nodeId "liquid-democracy" ;
@@ -1898,7 +1898,7 @@ n:liquid-democracy
   foaf:page <https://docs.cardano.org/about-cardano/governance-overview> .
 
 n:hot-cold-keys
-  gb:description "The credential system used by Constitutional Committee members. Similar to genesis delegation certificates. The cold key is the CC member's identity — kept offline for security. The hot key is authorized by the cold key for day-to-day voting. If a hot key is compromised, it can be rotated without changing the CC member's identity. This separation protects against key compromise while allowing active participation. CC members can also use native or Plutus script credentials instead of key pairs." ;
+  dcterms:description "The credential system used by Constitutional Committee members. Similar to genesis delegation certificates. The cold key is the CC member's identity — kept offline for security. The hot key is authorized by the cold key for day-to-day voting. If a hot key is compromised, it can be rotated without changing the CC member's identity. This separation protects against key compromise while allowing active participation. CC members can also use native or Plutus script credentials instead of key pairs." ;
   gb:group gbgroup:framework ;
   rdfs:label "Hot/Cold Key System" ;
   gb:nodeId "hot-cold-keys" ;
@@ -1908,7 +1908,7 @@ n:hot-cold-keys
   foaf:page <https://developers.cardano.org/docs/governance/cardano-governance/constitutional-committee-guide/> .
 
 n:enactment
-  gb:description "Ratified governance actions are enacted on the epoch boundary FOLLOWING ratification. When multiple actions are ratified in the same epoch, they are enacted in a fixed priority order: (1) No-Confidence, (2) Committee Update, (3) New Constitution, (4) Hard Fork, (5) Parameter Changes, (6) Treasury Withdrawals, (7) Info. Within the same type, actions are enacted in the order they were accepted to the chain. After enactment, the governance action deposit is returned to the specified reward address." ;
+  dcterms:description "Ratified governance actions are enacted on the epoch boundary FOLLOWING ratification. When multiple actions are ratified in the same epoch, they are enacted in a fixed priority order: (1) No-Confidence, (2) Committee Update, (3) New Constitution, (4) Hard Fork, (5) Parameter Changes, (6) Treasury Withdrawals, (7) Info. Within the same type, actions are enacted in the order they were accepted to the chain. After enactment, the governance action deposit is returned to the specified reward address." ;
   gb:group gbgroup:lifecycle ;
   rdfs:label "Enactment" ;
   gb:nodeId "enactment" ;
@@ -1918,7 +1918,7 @@ n:enactment
   foaf:page <https://cips.cardano.org/cip/CIP-1694#enactment> .
 
 n:drep-thresholds
-  gb:description "DRep thresholds are expressed as a fraction of active DRep voting stake. Active voting stake = all stake delegated to registered, active DReps (excluding Abstain delegations). Current mainnet values: No-Confidence (P1) = 67%, Committee Update normal (P2a) = 67%, Committee Update no-confidence (P2b) = 60%, New Constitution (P3) = 75%, Hard Fork (P4) = 60%, Network params (P5a) = 67%, Economic params (P5b) = 67%, Technical params (P5c) = 67%, Governance params (P5d) = 75%, Treasury Withdrawal (P6) = 67%, Info = 100% (fixed)." ;
+  dcterms:description "DRep thresholds are expressed as a fraction of active DRep voting stake. Active voting stake = all stake delegated to registered, active DReps (excluding Abstain delegations). Current mainnet values: No-Confidence (P1) = 67%, Committee Update normal (P2a) = 67%, Committee Update no-confidence (P2b) = 60%, New Constitution (P3) = 75%, Hard Fork (P4) = 60%, Network params (P5a) = 67%, Economic params (P5b) = 67%, Technical params (P5c) = 67%, Governance params (P5d) = 75%, Treasury Withdrawal (P6) = 67%, Info = 100% (fixed)." ;
   gb:group gbgroup:thresholds ;
   rdfs:label "DRep Voting Thresholds" ;
   gb:nodeId "drep-thresholds" ;
@@ -1928,7 +1928,7 @@ n:drep-thresholds
   foaf:page <https://cips.cardano.org/cip/CIP-1694#ratification> .
 
 n:deposit-mechanism
-  gb:description "Several governance actions require refundable deposits to prevent spam. govActionDeposit (currently 100,000 ada) is required to submit any governance action — returned when the action is ratified or expires. dRepDeposit (currently 500 ada) is required to register as a DRep — returned on retirement. These deposits are protocol parameters in the Governance group, changeable via governance actions with a 75% DRep threshold." ;
+  dcterms:description "Several governance actions require refundable deposits to prevent spam. govActionDeposit (currently 100,000 ada) is required to submit any governance action — returned when the action is ratified or expires. dRepDeposit (currently 500 ada) is required to register as a DRep — returned on retirement. These deposits are protocol parameters in the Governance group, changeable via governance actions with a 75% DRep threshold." ;
   gb:group gbgroup:lifecycle ;
   rdfs:label "Deposit Mechanism" ;
   gb:nodeId "deposit-mechanism" ;
@@ -1938,7 +1938,7 @@ n:deposit-mechanism
   foaf:page <https://developers.cardano.org/docs/governance/cardano-governance/governance-model/> .
 
 n:cip-30
-  gb:description "Cardano dApp-Wallet Web Bridge — the original standard for connecting browser-based dApps to Cardano wallets. Defines a JavaScript API injected into window.cardano that lets dApps discover wallets, request access, query balances, submit transactions, and sign data. Nearly every Cardano dApp uses CIP-30 for wallet interaction. CIP-95 extends it with governance capabilities." ;
+  dcterms:description "Cardano dApp-Wallet Web Bridge — the original standard for connecting browser-based dApps to Cardano wallets. Defines a JavaScript API injected into window.cardano that lets dApps discover wallets, request access, query balances, submit transactions, and sign data. Nearly every Cardano dApp uses CIP-30 for wallet interaction. CIP-95 extends it with governance capabilities." ;
   gb:group gbgroup:standards ;
   rdfs:label "CIP-30" ;
   gb:nodeId "cip-30" ;
@@ -1948,7 +1948,7 @@ n:cip-30
   foaf:page <https://cips.cardano.org/cip/CIP-0030> .
 
 n:cip-136
-  gb:description "CIP-136 defines the metadata standard for Constitutional Committee vote rationales. When CC members vote on governance actions, they are expected to explain their constitutional reasoning. CIP-136 provides a structured format for these rationales, including which constitutional articles were considered and why the action was deemed constitutional or not. This creates a public record of constitutional interpretation — effectively building governance case law over time." ;
+  dcterms:description "CIP-136 defines the metadata standard for Constitutional Committee vote rationales. When CC members vote on governance actions, they are expected to explain their constitutional reasoning. CIP-136 provides a structured format for these rationales, including which constitutional articles were considered and why the action was deemed constitutional or not. This creates a public record of constitutional interpretation — effectively building governance case law over time." ;
   gb:group gbgroup:framework ;
   rdfs:label "CIP-136" ;
   gb:nodeId "cip-136" ;
@@ -1958,7 +1958,7 @@ n:cip-136
   foaf:page <https://cips.cardano.org/cip/CIP-0136> .
 
 n:cip-100
-  gb:description "CIP-100 defines the general governance metadata standard. Every governance action includes a metadata anchor — a URL pointing to a JSON document plus its hash for integrity. CIP-100 specifies the base format for this metadata, ensuring all governance tools can parse and display proposal information consistently. The metadata is stored off-chain (to avoid blockchain bloat) but its hash is recorded on-chain, making it tamper-proof." ;
+  dcterms:description "CIP-100 defines the general governance metadata standard. Every governance action includes a metadata anchor — a URL pointing to a JSON document plus its hash for integrity. CIP-100 specifies the base format for this metadata, ensuring all governance tools can parse and display proposal information consistently. The metadata is stored off-chain (to avoid blockchain bloat) but its hash is recorded on-chain, making it tamper-proof." ;
   gb:group gbgroup:framework ;
   rdfs:label "CIP-100" ;
   gb:nodeId "cip-100" ;
@@ -1968,7 +1968,7 @@ n:cip-100
   foaf:page <https://cips.cardano.org/cip/CIP-0100> .
 
 n:cc-threshold
-  gb:description "The CC uses one-member-one-vote (not stake-weighted). The required fraction of CC members who must approve is a configurable threshold (currently 2/3 on mainnet). The CC votes on: New Constitution, Hard Fork, all Protocol Parameter Changes, Treasury Withdrawals, and Info actions. The CC does NOT vote on: No-Confidence motions or Committee Updates (since those are about the CC itself). Expired members cannot vote. The committee has a minimum size (committeeMinSize = 7 on mainnet)." ;
+  dcterms:description "The CC uses one-member-one-vote (not stake-weighted). The required fraction of CC members who must approve is a configurable threshold (currently 2/3 on mainnet). The CC votes on: New Constitution, Hard Fork, all Protocol Parameter Changes, Treasury Withdrawals, and Info actions. The CC does NOT vote on: No-Confidence motions or Committee Updates (since those are about the CC itself). Expired members cannot vote. The committee has a minimum size (committeeMinSize = 7 on mainnet)." ;
   gb:group gbgroup:thresholds ;
   rdfs:label "CC Voting Threshold" ;
   gb:nodeId "cc-threshold" ;
@@ -1978,7 +1978,7 @@ n:cc-threshold
   foaf:page <https://developers.cardano.org/docs/governance/cardano-governance/constitutional-committee-guide/> .
 
 n:bootstrap-phase
-  gb:description "The initial governance phase after Chang #1 (August 2024) and before the Plomin hard fork (December 2024). During bootstrap: CC vote alone was sufficient for protocol parameter changes; CC + SPO vote was sufficient for hard fork initiation; Info actions were available; no other governance actions were possible; DRep participation was not required. The bootstrap phase ended when CC and SPOs ratified the Plomin hard fork, transitioning to full governance." ;
+  dcterms:description "The initial governance phase after Chang #1 (August 2024) and before the Plomin hard fork (December 2024). During bootstrap: CC vote alone was sufficient for protocol parameter changes; CC + SPO vote was sufficient for hard fork initiation; Info actions were available; no other governance actions were possible; DRep participation was not required. The bootstrap phase ended when CC and SPOs ratified the Plomin hard fork, transitioning to full governance." ;
   gb:group gbgroup:lifecycle ;
   rdfs:label "Bootstrap Phase" ;
   gb:nodeId "bootstrap-phase" ;
@@ -1988,7 +1988,7 @@ n:bootstrap-phase
   foaf:page <https://docs.cardano.org/about-cardano/evolution/upgrades/chang> .
 
 n:action-chaining
-  gb:description "A collision-prevention mechanism. Each governance action (except Treasury Withdrawals and Info) must include the governance action ID of the most recently enacted action of its same type. This forms a chain that prevents two competing same-type actions from both being ratified when they assume incompatible starting states. For example, two parameter change proposals that both assume the current parameter values cannot both be valid after one of them changes those values." ;
+  dcterms:description "A collision-prevention mechanism. Each governance action (except Treasury Withdrawals and Info) must include the governance action ID of the most recently enacted action of its same type. This forms a chain that prevents two competing same-type actions from both being ratified when they assume incompatible starting states. For example, two parameter change proposals that both assume the current parameter values cannot both be valid after one of them changes those values." ;
   gb:group gbgroup:lifecycle ;
   rdfs:label "Action Chaining" ;
   gb:nodeId "action-chaining" ;
@@ -1998,7 +1998,7 @@ n:action-chaining
   foaf:page <https://cips.cardano.org/cip/CIP-1694#governance-actions> .
 
 n:abstain-option
-  gb:description "A pre-defined voting option for ada holders. When delegating to Abstain, the holder's stake is marked as not participating — it is NOT counted in the active voting stake denominator. This means it neither helps nor hinders ratification of any action. The holder still counts as registered for staking reward incentives." ;
+  dcterms:description "A pre-defined voting option for ada holders. When delegating to Abstain, the holder's stake is marked as not participating — it is NOT counted in the active voting stake denominator. This means it neither helps nor hinders ratification of any action. The holder still counts as registered for staking reward incentives." ;
   gb:group gbgroup:actors ;
   rdfs:label "Abstain (Pre-defined DRep)" ;
   gb:nodeId "abstain-option" ;


### PR DESCRIPTION
Closes #35

## Summary

Migrates graph.ttl from legacy graph-browser predicates to standard RDF/OWL:

**Edges:** 129 total
- 98 edges now use `cardano:` ObjectProperties directly (e.g. `n:drep cardano:votesOn n:info-action`)
- 31 edges without a `cardano:` equivalent kept as `gbedge:` 
- Edge descriptions preserved via `rdf:Statement` reification instead of `gb:EdgeAssertion`

**Links:** 166 total
- All converted from `gb:ExternalLink` reification to direct `foaf:page` (primary) / `rdfs:seeAlso` (additional) triples

**Node descriptions:**
- Switched from `gb:description` to `dcterms:description` — the importer reads `dcterms:description`, so node descriptions were previously empty in the sidebar

**cardano.ttl:**
- Removed 48 `owl:equivalentProperty` mappings (no longer needed — same predicates used directly)

## Preview

https://ckm-standard-predicates.surge.sh

## Verified via Playwright

- SPARQL queries return results ("Who Votes on What", "Delegation Paths")
- Edge labels render from cardano: property rdfs:label ("votes on", "delegates voting power to")
- Node links work (foaf:page / rdfs:seeAlso)
- Node descriptions now visible in sidebar
- Ontology term links resolve to published namespace