### PR TITLE
Expand Hydra ecosystem graph

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -2,7 +2,10 @@
   "title": "Cardano Knowledge Maps",
   "description": "Interactive knowledge maps of the Cardano ecosystem — governance, smart contracts, and more.",
   "sourceUrl": "https://github.com/lambdasistemi/cardano-knowledge-maps",
-  "graphSource": { "format": "text/turtle", "path": "data/rdf/graph.ttl" },
+  "graphSources": [
+    { "format": "text/turtle", "path": "data/rdf/graph.ttl" },
+    { "format": "text/turtle", "path": "data/rdf/cardano.ttl" }
+  ],
   "kinds": {
     "actor": {
       "label": "Actor",

--- a/data/config.json
+++ b/data/config.json
@@ -2,10 +2,7 @@
   "title": "Cardano Knowledge Maps",
   "description": "Interactive knowledge maps of the Cardano ecosystem — governance, smart contracts, and more.",
   "sourceUrl": "https://github.com/lambdasistemi/cardano-knowledge-maps",
-  "graphSources": [
-    { "format": "text/turtle", "path": "data/rdf/graph.ttl" },
-    { "format": "text/turtle", "path": "data/rdf/cardano.ttl" }
-  ],
+  "graphSource": { "format": "text/turtle", "path": "data/rdf/graph.ttl" },
   "kinds": {
     "actor": {
       "label": "Actor",

--- a/data/queries.json
+++ b/data/queries.json
@@ -225,6 +225,22 @@
     "tags": ["view", "ontology"]
   },
   {
+    "id": "hydra-ecosystem",
+    "name": "Hydra L2 Ecosystem",
+    "description": "Hydra Head protocol — components, lifecycle phases, consensus, and connections to L1.",
+    "sparql": "PREFIX cardano: <https://lambdasistemi.github.io/cardano-knowledge-maps/vocab/cardano#>\nPREFIX n: <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/>\nSELECT DISTINCT ?node WHERE {\n  { ?node a cardano:L2Protocol }\n  UNION { ?node a cardano:L2Component }\n  UNION { ?node a cardano:L2Lifecycle }\n  UNION { ?node cardano:componentOf n:hydra }\n  UNION { ?node cardano:lifecyclePhaseOf n:hydra }\n  UNION { ?node cardano:maintainedBy ?org }\n  UNION { VALUES ?node { n:hydra n:eutxo n:plutus n:state-machine n:reference-inputs n:cardano-scaling n:isomorphic-state-channel n:unanimous-consensus } }\n}",
+    "tags": [
+      "view"
+    ]
+  },
+  {
+    "id": "hydra-lifecycle",
+    "name": "Hydra Head Lifecycle",
+    "description": "The five phases of a Hydra head: Init → Commit → Open → Close → Fan-out.",
+    "sparql": "PREFIX cardano: <https://lambdasistemi.github.io/cardano-knowledge-maps/vocab/cardano#>\nPREFIX n: <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/>\nSELECT DISTINCT ?node WHERE {\n  { ?node a cardano:L2Lifecycle }\n  UNION { VALUES ?node { n:hydra n:hydra-contestation n:hydra-snapshot n:hydra-participation-token } }\n}",
+    "tags": []
+  },
+  {
     "id": "ontology-alignments",
     "name": "Ontology Alignments",
     "description": "Classes touched by equivalentClass or equivalentProperty mappings.",

--- a/data/rdf/cardano.ttl
+++ b/data/rdf/cardano.ttl
@@ -266,6 +266,23 @@ cardano:VasilFeature a owl:Class ;
   rdfs:subClassOf cardano:GovernanceMechanism ;
   dcterms:description "A ledger feature introduced in the Vasil/Babbage hard fork." .
 
+# -- Layer 2 / Scaling ---------------------------------------------------------
+
+cardano:L2Protocol a owl:Class ;
+  rdfs:label "Layer 2 Protocol" ;
+  rdfs:subClassOf cardano:DApp ;
+  dcterms:description "A scaling protocol that processes transactions off-chain while inheriting L1 security." .
+
+cardano:L2Component a owl:Class ;
+  rdfs:label "Layer 2 Component" ;
+  rdfs:subClassOf cardano:SmartContractConcept ;
+  dcterms:description "A component of a Layer 2 scaling protocol." .
+
+cardano:L2Lifecycle a owl:Class ;
+  rdfs:label "Layer 2 Lifecycle Phase" ;
+  rdfs:subClassOf cardano:SmartContractConcept ;
+  dcterms:description "A phase in the lifecycle of a Layer 2 head or channel." .
+
 # ==============================================================================
 # Properties — Governance
 # ==============================================================================
@@ -483,8 +500,30 @@ cardano:optimizes a owl:ObjectProperty ;
 cardano:registersMetadataFor a owl:ObjectProperty ;
   rdfs:label "registers metadata for" ;
   rdfs:domain cardano:CIP ;
+  rdfs:range cardano:SmartContractConcept .
+
+cardano:settlesOn a owl:ObjectProperty ;
+  rdfs:label "settles on" ;
+  rdfs:domain cardano:L2Protocol ;
   rdfs:range cardano:SmartContractConcept ;
-  dcterms:description "A CIP that standardizes metadata registration for a concept." .
+  dcterms:description "An L2 protocol that settles state transitions on an L1 ledger." .
+
+cardano:lifecyclePhaseOf a owl:ObjectProperty ;
+  rdfs:label "lifecycle phase of" ;
+  rdfs:domain cardano:L2Lifecycle ;
+  rdfs:range cardano:L2Protocol ;
+  dcterms:description "A lifecycle phase belonging to an L2 protocol." .
+
+cardano:componentOf a owl:ObjectProperty ;
+  rdfs:label "component of" ;
+  rdfs:domain cardano:L2Component ;
+  rdfs:range cardano:L2Protocol ;
+  dcterms:description "A component belonging to an L2 protocol." .
+
+cardano:maintainedBy a owl:ObjectProperty ;
+  rdfs:label "maintained by" ;
+  rdfs:range foaf:Agent ;
+  dcterms:description "An entity that maintains a project or tool." .
 
 # ==============================================================================
 # Alignment — bridge gbkind: classes to cardano: classes
@@ -614,9 +653,30 @@ n:cek-machine  a cardano:SmartContractRuntime .
 
 # -- DApps / Protocols ---------------------------------------------------------
 n:djed     a cardano:DApp .
-n:hydra    a cardano:DApp .
+n:hydra    a cardano:L2Protocol .
 n:liqwid   a cardano:DApp .
 n:minswap  a cardano:DApp .
+
+# -- Hydra components ---------------------------------------------------------
+n:hydra-head                a cardano:L2Component .
+n:hydra-node                a cardano:DeveloperTool .
+n:hydra-snapshot            a cardano:L2Component .
+n:hydra-head-validator      a cardano:L2Component .
+n:hydra-participation-token a cardano:L2Component .
+n:hydra-websocket-api       a cardano:L2Component .
+n:hydra-contestation        a cardano:L2Component .
+n:isomorphic-state-channel  a cardano:SmartContractConcept .
+n:unanimous-consensus       a cardano:SmartContractConcept .
+
+# -- Hydra lifecycle -----------------------------------------------------------
+n:hydra-init    a cardano:L2Lifecycle .
+n:hydra-commit  a cardano:L2Lifecycle .
+n:hydra-open    a cardano:L2Lifecycle .
+n:hydra-close   a cardano:L2Lifecycle .
+n:hydra-fan-out a cardano:L2Lifecycle .
+
+# -- Hydra organization -------------------------------------------------------
+n:cardano-scaling a cardano:GovernanceOrganization .
 
 # -- Tools ---------------------------------------------------------------------
 n:blockfrost       a cardano:DeveloperTool .

--- a/data/rdf/graph.ttl
+++ b/data/rdf/graph.ttl
@@ -134,6 +134,176 @@ n:hydra gbedge:replicates n:eutxo .
   rdf:object n:eutxo ;
   dcterms:description "Hydra L2 heads replicate the full EUTxO model off-chain with the same smart contract semantics." .
 
+# -- Hydra ecosystem edges -----------------------------------------------------
+
+n:hydra cardano:settlesOn n:eutxo .
+[] a rdf:Statement ;
+  rdf:subject n:hydra ;
+  rdf:predicate cardano:settlesOn ;
+  rdf:object n:eutxo ;
+  dcterms:description "Hydra heads settle their final state back to the Cardano L1 EUTxO ledger via fan-out transactions." .
+
+n:hydra-head cardano:componentOf n:hydra .
+[] a rdf:Statement ;
+  rdf:subject n:hydra-head ;
+  rdf:predicate cardano:componentOf ;
+  rdf:object n:hydra ;
+  dcterms:description "A Hydra head is an individual state channel instance managed by a fixed set of participants." .
+
+n:hydra-node cardano:componentOf n:hydra .
+[] a rdf:Statement ;
+  rdf:subject n:hydra-node ;
+  rdf:predicate cardano:componentOf ;
+  rdf:object n:hydra ;
+  dcterms:description "The hydra-node binary is the off-chain software that runs the Head protocol, manages consensus, and exposes the WebSocket API." .
+
+n:hydra-snapshot cardano:componentOf n:hydra .
+[] a rdf:Statement ;
+  rdf:subject n:hydra-snapshot ;
+  rdf:predicate cardano:componentOf ;
+  rdf:object n:hydra ;
+  dcterms:description "Snapshots capture agreed-upon UTxO state inside a head. All participants must multi-sign each snapshot." .
+
+n:hydra-head-validator cardano:componentOf n:hydra .
+[] a rdf:Statement ;
+  rdf:subject n:hydra-head-validator ;
+  rdf:predicate cardano:componentOf ;
+  rdf:object n:hydra ;
+  dcterms:description "The on-chain Head validator is a Plutus state machine that governs the lifecycle: Init, Open, Closed, Final." .
+
+n:hydra-participation-token cardano:componentOf n:hydra .
+[] a rdf:Statement ;
+  rdf:subject n:hydra-participation-token ;
+  rdf:predicate cardano:componentOf ;
+  rdf:object n:hydra ;
+  dcterms:description "Participation tokens (PTs) are minted during head initialization. Each participant holds one PT, proving membership." .
+
+n:hydra-websocket-api cardano:componentOf n:hydra .
+[] a rdf:Statement ;
+  rdf:subject n:hydra-websocket-api ;
+  rdf:predicate cardano:componentOf ;
+  rdf:object n:hydra ;
+  dcterms:description "The WebSocket API is the primary interface for submitting transactions to a head and observing state changes." .
+
+n:hydra-contestation cardano:componentOf n:hydra .
+[] a rdf:Statement ;
+  rdf:subject n:hydra-contestation ;
+  rdf:predicate cardano:componentOf ;
+  rdf:object n:hydra ;
+  dcterms:description "Contestation is the dispute resolution mechanism: after a head closes, participants can contest with a more recent snapshot during the contestation period." .
+
+n:hydra-init cardano:lifecyclePhaseOf n:hydra .
+[] a rdf:Statement ;
+  rdf:subject n:hydra-init ;
+  rdf:predicate cardano:lifecyclePhaseOf ;
+  rdf:object n:hydra ;
+  dcterms:description "Initialization posts the head parameters and mints participation tokens on L1. Each participant commits UTxOs." .
+
+n:hydra-commit cardano:lifecyclePhaseOf n:hydra .
+[] a rdf:Statement ;
+  rdf:subject n:hydra-commit ;
+  rdf:predicate cardano:lifecyclePhaseOf ;
+  rdf:object n:hydra ;
+  dcterms:description "Commit locks UTxOs from L1 into the head. All participants must commit before the head opens. Incremental commits allow adding UTxOs to an already-open head." .
+
+n:hydra-open cardano:lifecyclePhaseOf n:hydra .
+[] a rdf:Statement ;
+  rdf:subject n:hydra-open ;
+  rdf:predicate cardano:lifecyclePhaseOf ;
+  rdf:object n:hydra ;
+  dcterms:description "Open phase: the head processes transactions off-chain with sub-second finality. Transactions are confirmed when all participants sign the resulting snapshot." .
+
+n:hydra-close cardano:lifecyclePhaseOf n:hydra .
+[] a rdf:Statement ;
+  rdf:subject n:hydra-close ;
+  rdf:predicate cardano:lifecyclePhaseOf ;
+  rdf:object n:hydra ;
+  dcterms:description "Close posts the latest snapshot to L1 and starts the contestation period. Any participant can close unilaterally." .
+
+n:hydra-fan-out cardano:lifecyclePhaseOf n:hydra .
+[] a rdf:Statement ;
+  rdf:subject n:hydra-fan-out ;
+  rdf:predicate cardano:lifecyclePhaseOf ;
+  rdf:object n:hydra ;
+  dcterms:description "Fan-out distributes the head's final UTxO set back to L1 after the contestation period expires. Each committed UTxO becomes a real L1 UTxO." .
+
+n:hydra-head-validator gbedge:implements n:state-machine .
+[] a rdf:Statement ;
+  rdf:subject n:hydra-head-validator ;
+  rdf:predicate gbedge:implements ;
+  rdf:object n:state-machine ;
+  dcterms:description "The Head validator is a Plutus state machine with states: Initial, Open, Closed. Transitions are governed by multi-signed snapshots." .
+
+n:hydra-head gbedge:uses n:reference-inputs .
+[] a rdf:Statement ;
+  rdf:subject n:hydra-head ;
+  rdf:predicate gbedge:uses ;
+  rdf:object n:reference-inputs ;
+  dcterms:description "Hydra heads use CIP-31 reference inputs to read L1 state (e.g. script references, protocol parameters) without consuming UTxOs." .
+
+n:hydra gbedge:uses n:plutus .
+[] a rdf:Statement ;
+  rdf:subject n:hydra ;
+  rdf:predicate gbedge:uses ;
+  rdf:object n:plutus ;
+  dcterms:description "Hydra's isomorphic design means the same Plutus scripts run identically on L1 and inside a head. No script modification needed." .
+
+n:isomorphic-state-channel gbedge:enables n:hydra-head .
+[] a rdf:Statement ;
+  rdf:subject n:isomorphic-state-channel ;
+  rdf:predicate gbedge:enables ;
+  rdf:object n:hydra-head ;
+  dcterms:description "Isomorphic state channels are the theoretical foundation: L2 replicates L1's ledger rules exactly, so any L1 validator works unmodified in a head." .
+
+n:unanimous-consensus gbedge:enables n:hydra-snapshot .
+[] a rdf:Statement ;
+  rdf:subject n:unanimous-consensus ;
+  rdf:predicate gbedge:enables ;
+  rdf:object n:hydra-snapshot ;
+  dcterms:description "All head participants must sign every snapshot. This gives instant finality within the head but means any single party can block progress." .
+
+n:hydra-contestation gbedge:requires n:hydra-snapshot .
+[] a rdf:Statement ;
+  rdf:subject n:hydra-contestation ;
+  rdf:predicate gbedge:requires ;
+  rdf:object n:hydra-snapshot ;
+  dcterms:description "Contestation requires presenting a more recent multi-signed snapshot than the one used to close the head." .
+
+n:hydra-init gbedge:generates n:hydra-participation-token .
+[] a rdf:Statement ;
+  rdf:subject n:hydra-init ;
+  rdf:predicate gbedge:generates ;
+  rdf:object n:hydra-participation-token ;
+  dcterms:description "Head initialization mints one participation token per participant, locked in the head validator." .
+
+n:hydra-fan-out gbedge:consumes n:hydra-participation-token .
+[] a rdf:Statement ;
+  rdf:subject n:hydra-fan-out ;
+  rdf:predicate gbedge:consumes ;
+  rdf:object n:hydra-participation-token ;
+  dcterms:description "Fan-out burns participation tokens and distributes the final UTxO set to L1." .
+
+n:hydra cardano:maintainedBy n:cardano-scaling .
+[] a rdf:Statement ;
+  rdf:subject n:hydra ;
+  rdf:predicate cardano:maintainedBy ;
+  rdf:object n:cardano-scaling ;
+  dcterms:description "Hydra is developed and maintained by the Cardano Scaling team (formerly IOG Hydra team)." .
+
+n:hydra-close gbedge:enables n:hydra-contestation .
+[] a rdf:Statement ;
+  rdf:subject n:hydra-close ;
+  rdf:predicate gbedge:enables ;
+  rdf:object n:hydra-contestation ;
+  dcterms:description "Closing a head starts the contestation period, during which any participant can contest with a newer snapshot." .
+
+n:hydra-node gbedge:provides n:hydra-websocket-api .
+[] a rdf:Statement ;
+  rdf:subject n:hydra-node ;
+  rdf:predicate gbedge:provides ;
+  rdf:object n:hydra-websocket-api ;
+  dcterms:description "The hydra-node process exposes a WebSocket API for clients to submit transactions and receive state updates." .
+
 n:liqwid cardano:writtenIn n:plutarch .
 [] a rdf:Statement ;
   rdf:subject n:liqwid ;
@@ -1086,6 +1256,160 @@ n:hydra
   rdfs:seeAlso <https://docs.cardano.org/developer-resources/scalability-solutions/hydra> ;
   rdfs:seeAlso <https://hydra.family/head-protocol/> ;
   rdfs:seeAlso <https://github.com/cardano-scaling/hydra> .
+
+n:hydra-head
+  dcterms:description "An individual Hydra head — an off-chain mini-ledger shared by a fixed set of participants. Each head maintains its own UTxO set, processes transactions with sub-second finality, and settles back to L1 via fan-out. Multiple heads can run concurrently and independently." ;
+  gb:group gbgroup:protocols ;
+  rdfs:label "Hydra Head" ;
+  gb:nodeId "hydra-head" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node ;
+  foaf:page <https://hydra.family/head-protocol/core-concepts/> ;
+  rdfs:seeAlso <https://hydra.family/head-protocol/topologies/> .
+
+n:hydra-node
+  dcterms:description "The hydra-node is the off-chain Haskell process that each participant runs. It manages the Head protocol state machine, communicates with peers via an authenticated network layer, and exposes a WebSocket API for client applications. Connects to a cardano-node for L1 chain following." ;
+  gb:group gbgroup:tooling ;
+  rdfs:label "Hydra Node" ;
+  gb:nodeId "hydra-node" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:tool ;
+  a gb:Node ;
+  foaf:page <https://hydra.family/head-protocol/getting-started/> ;
+  rdfs:seeAlso <https://github.com/cardano-scaling/hydra/tree/master/hydra-node> .
+
+n:hydra-snapshot
+  dcterms:description "A snapshot captures the agreed-upon UTxO state inside an open head at a point in time. Every snapshot must be multi-signed by all participants (unanimous consensus). Confirmed snapshots are irrevocable — they cannot be rolled back. The latest confirmed snapshot is used to close and contest." ;
+  gb:group gbgroup:protocols ;
+  rdfs:label "Hydra Snapshot" ;
+  gb:nodeId "hydra-snapshot" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node ;
+  foaf:page <https://hydra.family/head-protocol/core-concepts/> .
+
+n:hydra-head-validator
+  dcterms:description "The on-chain Plutus validator that governs the Hydra head lifecycle. Implements a state machine with states Initial, Open, and Closed. Validates multi-signatures, snapshot hashes, and contestation logic. Originally written in Plutus-Tx, commit validator migrated to Aiken for 20-50% cost reduction." ;
+  gb:group gbgroup:smart-contracts ;
+  rdfs:label "Head Validator" ;
+  gb:nodeId "hydra-head-validator" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node ;
+  foaf:page <https://github.com/cardano-scaling/hydra/tree/master/hydra-plutus> ;
+  rdfs:seeAlso <https://github.com/cardano-scaling/hydra/blob/master/hydra-plutus/src/Hydra/Contract/Head.hs> .
+
+n:hydra-participation-token
+  dcterms:description "Participation tokens (PTs) are NFTs minted during head initialization, one per participant. They prove membership in the head and are locked in the head validator. PTs are burned during fan-out, ensuring the head can only be finalized once." ;
+  gb:group gbgroup:protocols ;
+  rdfs:label "Participation Token" ;
+  gb:nodeId "hydra-participation-token" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node ;
+  foaf:page <https://hydra.family/head-protocol/core-concepts/> .
+
+n:hydra-websocket-api
+  dcterms:description "The primary client interface to a hydra-node. Clients connect via WebSocket to submit NewTx commands, receive transaction confirmations (SnapshotConfirmed), and observe head lifecycle events (HeadIsOpen, HeadIsClosed, ReadyToFanout). Supports the same transaction format as L1." ;
+  gb:group gbgroup:tooling ;
+  rdfs:label "Hydra WebSocket API" ;
+  gb:nodeId "hydra-websocket-api" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node ;
+  foaf:page <https://hydra.family/head-protocol/api-reference/> .
+
+n:hydra-contestation
+  dcterms:description "Dispute resolution mechanism for Hydra heads. After a head is closed on L1, a contestation period begins (configurable duration). During this window, any participant can contest by presenting a more recent multi-signed snapshot. After the period expires with no successful contest, fan-out becomes available." ;
+  gb:group gbgroup:protocols ;
+  rdfs:label "Contestation" ;
+  gb:nodeId "hydra-contestation" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:mechanism ;
+  a gb:Node ;
+  foaf:page <https://hydra.family/head-protocol/core-concepts/> .
+
+n:hydra-init
+  dcterms:description "Head initialization phase. A participant posts an init transaction on L1, declaring head parameters (participants, contestation period). The head validator mints participation tokens. Each participant then commits UTxOs from L1 into the head." ;
+  gb:group gbgroup:lifecycle ;
+  rdfs:label "Init" ;
+  gb:nodeId "hydra-init" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:process ;
+  a gb:Node ;
+  foaf:page <https://hydra.family/head-protocol/core-concepts/> .
+
+n:hydra-commit
+  dcterms:description "Commit phase locks L1 UTxOs into the head. Each participant selects which UTxOs to commit. All participants must commit before the head opens. Incremental commits (added later) allow committing additional UTxOs to an already-open head, and incremental decommits allow withdrawing." ;
+  gb:group gbgroup:lifecycle ;
+  rdfs:label "Commit" ;
+  gb:nodeId "hydra-commit" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:process ;
+  a gb:Node ;
+  foaf:page <https://hydra.family/head-protocol/core-concepts/> ;
+  rdfs:seeAlso <https://github.com/cardano-scaling/hydra/blob/master/hydra-plutus/src/Hydra/Contract/Commit.hs> .
+
+n:hydra-open
+  dcterms:description "Open phase: the head is live and processing transactions off-chain. Any participant can submit transactions via the WebSocket API. Transactions are validated against the head's local UTxO set using the same Plutus rules as L1. Confirmed via unanimous multi-signature on snapshots." ;
+  gb:group gbgroup:lifecycle ;
+  rdfs:label "Open" ;
+  gb:nodeId "hydra-open" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:process ;
+  a gb:Node ;
+  foaf:page <https://hydra.family/head-protocol/core-concepts/> .
+
+n:hydra-close
+  dcterms:description "Close phase: any participant can unilaterally close the head by posting the latest confirmed snapshot to L1. This starts the contestation period. The on-chain validator verifies the snapshot's multi-signature before accepting the close." ;
+  gb:group gbgroup:lifecycle ;
+  rdfs:label "Close" ;
+  gb:nodeId "hydra-close" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:process ;
+  a gb:Node ;
+  foaf:page <https://hydra.family/head-protocol/core-concepts/> .
+
+n:hydra-fan-out
+  dcterms:description "Fan-out is the final settlement: after the contestation period expires, any participant can post a fan-out transaction that distributes the head's UTxOs back to L1. Participation tokens are burned. The head ceases to exist." ;
+  gb:group gbgroup:lifecycle ;
+  rdfs:label "Fan-out" ;
+  gb:nodeId "hydra-fan-out" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:process ;
+  a gb:Node ;
+  foaf:page <https://hydra.family/head-protocol/core-concepts/> .
+
+n:isomorphic-state-channel
+  dcterms:description "The core theoretical property of Hydra: the L2 channel replicates the L1 ledger rules exactly. Any Plutus script, any transaction structure, any validator that works on L1 works identically inside a head with no modifications. This is in contrast to rollup-style L2s that require adapted contracts." ;
+  gb:group gbgroup:core ;
+  rdfs:label "Isomorphic State Channel" ;
+  gb:nodeId "isomorphic-state-channel" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node ;
+  foaf:page <https://iohk.io/en/research/library/papers/hydra-fast-isomorphic-state-channels/> .
+
+n:unanimous-consensus
+  dcterms:description "Hydra's consensus model: every snapshot and every transaction must be signed by all head participants. This gives instant finality (no confirmation delay) but means a single unresponsive party blocks the entire head. The trade-off is mitigated by the ability to close unilaterally." ;
+  gb:group gbgroup:core ;
+  rdfs:label "Unanimous Consensus" ;
+  gb:nodeId "unanimous-consensus" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node ;
+  foaf:page <https://hydra.family/head-protocol/core-concepts/> .
+
+n:cardano-scaling
+  dcterms:description "The team responsible for developing and maintaining the Hydra Head protocol implementation. Formerly part of IOG, now operating under the Cardano Scaling umbrella. Maintains the hydra repository, documentation, and related tooling." ;
+  gb:group gbgroup:ecosystem ;
+  rdfs:label "Cardano Scaling" ;
+  gb:nodeId "cardano-scaling" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:actor ;
+  a gb:Node ;
+  foaf:page <https://github.com/cardano-scaling> .
 
 n:liqwid
   dcterms:description "Leading lending/borrowing protocol on Cardano. Non-custodial, supports liquid staking. DAO-governed via LQ token. Uses Plutarch for performance-critical validators. Demonstrates complex multi-contract DeFi on EUTxO." ;
@@ -2503,8 +2827,8 @@ gbkind:action-type
 
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf>
   gb:sourceRepository "https://github.com/lambdasistemi/cardano-knowledge-maps"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-  gb:edgeCount 129 ;
-  gb:nodeCount 88 ;
+  gb:edgeCount 153 ;
+  gb:nodeCount 103 ;
   dcterms:description "Interactive knowledge maps of the Cardano ecosystem — governance, smart contracts, and more." ;
   dcterms:title "Cardano Knowledge Maps" ;
   a gb:Dataset .

--- a/data/rdf/graph.ttl
+++ b/data/rdf/graph.ttl
@@ -304,6 +304,41 @@ n:hydra-node gbedge:provides n:hydra-websocket-api .
   rdf:object n:hydra-websocket-api ;
   dcterms:description "The hydra-node process exposes a WebSocket API for clients to submit transactions and receive state updates." .
 
+n:hydra-head-validator cardano:writtenIn n:aiken .
+[] a rdf:Statement ;
+  rdf:subject n:hydra-head-validator ;
+  rdf:predicate cardano:writtenIn ;
+  rdf:object n:aiken ;
+  dcterms:description "The commit validator was migrated from Plutus-Tx to Aiken (PlutusV3), reducing head-opening cost by 20% and abort cost by 50%. Other validators remain in Plutus-Tx." .
+
+n:hydra-snapshot gbedge:enables n:hydra-close .
+[] a rdf:Statement ;
+  rdf:subject n:hydra-snapshot ;
+  rdf:predicate gbedge:enables ;
+  rdf:object n:hydra-close ;
+  dcterms:description "Closing a head requires submitting the latest confirmed multi-signed snapshot to L1. The snapshot hash is verified by the head validator." .
+
+n:hydra-commit gbedge:enables n:hydra-open .
+[] a rdf:Statement ;
+  rdf:subject n:hydra-commit ;
+  rdf:predicate gbedge:enables ;
+  rdf:object n:hydra-open ;
+  dcterms:description "All participants must commit their UTxOs before the head can transition from Initial to Open via collectComTx." .
+
+n:hydra-open gbedge:enables n:hydra-close .
+[] a rdf:Statement ;
+  rdf:subject n:hydra-open ;
+  rdf:predicate gbedge:enables ;
+  rdf:object n:hydra-close ;
+  dcterms:description "Any participant can unilaterally close an open head by posting the latest snapshot to L1." .
+
+n:hydra-contestation gbedge:enables n:hydra-fan-out .
+[] a rdf:Statement ;
+  rdf:subject n:hydra-contestation ;
+  rdf:predicate gbedge:enables ;
+  rdf:object n:hydra-fan-out ;
+  dcterms:description "Fan-out becomes available only after the contestation period expires with no successful contest." .
+
 n:liqwid cardano:writtenIn n:plutarch .
 [] a rdf:Statement ;
   rdf:subject n:liqwid ;
@@ -2827,7 +2862,7 @@ gbkind:action-type
 
 <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf>
   gb:sourceRepository "https://github.com/lambdasistemi/cardano-knowledge-maps"^^<http://www.w3.org/2001/XMLSchema#anyURI> ;
-  gb:edgeCount 153 ;
+  gb:edgeCount 158 ;
   gb:nodeCount 103 ;
   dcterms:description "Interactive knowledge maps of the Cardano ecosystem — governance, smart contracts, and more." ;
   dcterms:title "Cardano Knowledge Maps" ;

--- a/data/tutorials/hydra-lifecycle.json
+++ b/data/tutorials/hydra-lifecycle.json
@@ -1,0 +1,49 @@
+{
+  "id": "hydra-lifecycle",
+  "title": "Life of a Hydra Head",
+  "description": "Follow a head from initialization through fan-out: the five phases, the on-chain state machine, and what happens when things go wrong.",
+  "stops": [
+    {
+      "node": "hydra-init",
+      "depth": 2,
+      "title": "1. Initialization",
+      "narrative": "A head begins with [Init](node:hydra-init). A participant posts an init transaction on L1, declaring the head parameters: who the participants are, and how long the [contestation](node:hydra-contestation) period lasts.\n\nThe [Head validator](node:hydra-head-validator) — a Plutus [state machine](node:state-machine) — mints [participation tokens](node:hydra-participation-token): one per participant plus one state token. These NFTs prove membership and track the head's on-chain state."
+    },
+    {
+      "node": "hydra-commit",
+      "depth": 2,
+      "title": "2. Committing UTxOs",
+      "narrative": "During [Commit](node:hydra-commit), each participant selects which L1 UTxOs to lock into the head. These are moved to the commit validator — they leave L1 and will only return at [fan-out](node:hydra-fan-out).\n\nAll participants must commit before the head can [open](node:hydra-open). If someone doesn't commit, the head can be aborted and UTxOs returned.\n\nIncremental commits allow adding UTxOs to an already-open head. Incremental decommits allow withdrawing — both without closing."
+    },
+    {
+      "node": "hydra-open",
+      "depth": 2,
+      "title": "3. Open: The Fast Lane",
+      "narrative": "Once all commits are collected, the head transitions to [Open](node:hydra-open). This is where the magic happens.\n\nTransactions are submitted via the [WebSocket API](node:hydra-websocket-api), validated against the head's local UTxO set using the same [Plutus](node:plutus) rules as L1, and confirmed via [unanimous multi-signature](node:unanimous-consensus) on [snapshots](node:hydra-snapshot). Finality is immediate — sub-second latency, bounded only by network round-trip time between participants."
+    },
+    {
+      "node": "hydra-close",
+      "depth": 2,
+      "title": "4. Closing: Back to L1",
+      "narrative": "Any participant can unilaterally [close](node:hydra-close) the head at any time by posting the latest confirmed [snapshot](node:hydra-snapshot) to L1. This is the safety guarantee: you never need the other parties' cooperation to exit.\n\nThe [Head validator](node:hydra-head-validator) verifies the snapshot's multi-signature before accepting the close. The on-chain state transitions from Open to Closed, and the [contestation](node:hydra-contestation) period begins."
+    },
+    {
+      "node": "hydra-contestation",
+      "depth": 2,
+      "title": "Contestation: The Dispute Window",
+      "narrative": "[Contestation](node:hydra-contestation) is Hydra's dispute resolution mechanism. After a head is closed, a timer starts (configurable, minimum 12 hours on mainnet). During this window, any participant can *contest* by presenting a more recent multi-signed [snapshot](node:hydra-snapshot).\n\nThis prevents a malicious party from closing with an outdated snapshot to steal funds. The contestation deadline extends with each successful contest (at worst `(1+n) * period` where n = participants), ensuring everyone gets a fair chance to respond.\n\nIf no one contests, the posted snapshot stands as final."
+    },
+    {
+      "node": "hydra-fan-out",
+      "depth": 2,
+      "title": "5. Fan-Out: Settlement",
+      "narrative": "After the contestation period expires, any participant can post a [fan-out](node:hydra-fan-out) transaction. This distributes the head's final UTxO set back to L1 — each UTxO inside the head becomes a real L1 UTxO.\n\n[Participation tokens](node:hydra-participation-token) are burned, ensuring the head can only be finalized once. The head ceases to exist. The full cycle is complete: L1 → head → L1, with all intermediate transactions processed off-chain at L2 speed.\n\nThe on-chain [state machine](node:state-machine) transitions through Initial → Open → Closed → Final, enforced by the [Head validator](node:hydra-head-validator) at every step."
+    },
+    {
+      "node": "hydra-head-validator",
+      "depth": 2,
+      "title": "The On-Chain Guardian",
+      "narrative": "The [Head validator](node:hydra-head-validator) is the Plutus smart contract that governs the entire lifecycle on L1. It [implements a state machine](node:state-machine) with states Initial, Open, and Closed.\n\nAt each transition it verifies multi-signatures, snapshot hashes, and contestation logic. Originally written entirely in Plutus-Tx, the commit validator was migrated to [Aiken](node:aiken) (PlutusV3), reducing head-opening cost by 20% and abort cost by 50%.\n\nThe validator uses [reference inputs](node:reference-inputs) to read L1 state without consuming UTxOs, keeping contention low."
+    }
+  ]
+}

--- a/data/tutorials/hydra-overview.json
+++ b/data/tutorials/hydra-overview.json
@@ -1,0 +1,43 @@
+{
+  "id": "hydra-overview",
+  "title": "Hydra: Cardano's Layer 2",
+  "description": "What Hydra is, how it scales Cardano, and why isomorphic state channels matter.",
+  "stops": [
+    {
+      "node": "hydra",
+      "depth": 2,
+      "title": "What Is Hydra?",
+      "narrative": "[Hydra](node:hydra) is Cardano's Layer 2 scaling solution — a protocol for creating off-chain mini-ledgers called \"heads.\" Each head [replicates the full EUTxO model](node:eutxo) with sub-second finality and near-zero fees. Multiple heads run independently and scale linearly.\n\nUnlike rollups that require adapted contracts, Hydra is *isomorphic*: the same [Plutus](node:plutus) scripts, the same transaction format, the same ledger rules work identically on L1 and inside a head. No modifications needed."
+    },
+    {
+      "node": "isomorphic-state-channel",
+      "depth": 2,
+      "title": "The Isomorphic Property",
+      "narrative": "The [isomorphic state channel](node:isomorphic-state-channel) concept is Hydra's theoretical foundation, introduced in the original [academic paper](https://iohk.io/en/research/library/papers/hydra-fast-isomorphic-state-channels/) by Chakravarty et al. (FC'21).\n\nIsomorphic means \"same shape\" — the L2 channel replicates L1's ledger rules *exactly*. Any validator, any transaction structure, any script that works on L1 works unmodified inside a [Hydra head](node:hydra-head). This is a fundamental design choice that sets Hydra apart from rollup-style L2s where contracts must be rewritten or adapted."
+    },
+    {
+      "node": "unanimous-consensus",
+      "depth": 2,
+      "title": "Unanimous Consensus",
+      "narrative": "[Unanimous consensus](node:unanimous-consensus) is the trade-off at the heart of Hydra. Every [snapshot](node:hydra-snapshot) — every state update inside a head — must be signed by *all* participants.\n\nThe upside: instant finality. Once all parties sign, the state is irrevocable — no confirmation delay, no rollback risk. The downside: a single unresponsive party blocks the entire head. This is mitigated by the ability to [close](node:hydra-close) unilaterally at any time."
+    },
+    {
+      "node": "hydra-head",
+      "depth": 2,
+      "title": "Inside a Head",
+      "narrative": "A [Hydra head](node:hydra-head) is an individual off-chain mini-ledger shared by a fixed set of participants. It maintains its own UTxO set and processes transactions locally with the same [Plutus](node:plutus) validation rules as L1.\n\nEach participant runs a [hydra-node](node:hydra-node), which manages the off-chain protocol, communicates with peers, and exposes a [WebSocket API](node:hydra-websocket-api) for client applications. Clients submit transactions using the exact same Cardano transaction format."
+    },
+    {
+      "node": "hydra-snapshot",
+      "depth": 2,
+      "title": "Snapshots: The State Record",
+      "narrative": "A [snapshot](node:hydra-snapshot) captures the agreed-upon UTxO state inside an open head at a point in time. It contains the full UTxO set and the transactions that produced it.\n\nSnapshots are the currency of consensus: they must be multi-signed by all participants. A confirmed snapshot is irrevocable — it cannot be rolled back. The latest confirmed snapshot is what gets posted to L1 when a head is [closed](node:hydra-close), and what [contestation](node:hydra-contestation) is judged against."
+    },
+    {
+      "node": "cardano-scaling",
+      "depth": 1,
+      "title": "Who Builds It",
+      "narrative": "[Cardano Scaling](node:cardano-scaling) is the team that develops and maintains the Hydra Head protocol. Formerly part of IOG, they maintain the [hydra repository](https://github.com/cardano-scaling/hydra), the documentation at [hydra.family](https://hydra.family/head-protocol/), and related tooling.\n\nThe on-chain validators are written in Plutus-Tx, with the commit validator recently [migrated to Aiken](node:aiken) for a 20-50% cost reduction."
+    }
+  ]
+}

--- a/data/tutorials/index.json
+++ b/data/tutorials/index.json
@@ -70,5 +70,17 @@
     "title": "Plutus V3 Upgrades",
     "description": "CIP-69, CIP-85, CIP-381 — smaller scripts, unified interfaces, and on-chain cryptography.",
     "file": "data/tutorials/plutus-v3-cips.json"
+  },
+  {
+    "id": "hydra-overview",
+    "title": "Hydra: Cardano's Layer 2",
+    "description": "What Hydra is, how it scales Cardano, and why isomorphic state channels matter.",
+    "file": "data/tutorials/hydra-overview.json"
+  },
+  {
+    "id": "hydra-lifecycle",
+    "title": "Life of a Hydra Head",
+    "description": "Follow a head from initialization through fan-out: the five phases, the on-chain state machine, and what happens when things go wrong.",
+    "file": "data/tutorials/hydra-lifecycle.json"
   }
 ]

--- a/flake.lock
+++ b/flake.lock
@@ -55,11 +55,11 @@
         "purescript-overlay": "purescript-overlay"
       },
       "locked": {
-        "lastModified": 1775739065,
-        "narHash": "sha256-gRddug5YmHmNIkUwlY+7fP3M7dJoc088qM5amrxfbY8=",
+        "lastModified": 1775904642,
+        "narHash": "sha256-nKxRD27tck0LKWX4u5ovlkuKGc5ziNScTg3cuNYxUeQ=",
         "owner": "lambdasistemi",
         "repo": "graph-browser",
-        "rev": "7d33b9f583a160624d67e3983a33466d8e4df374",
+        "rev": "f050e07ffcf3098d81716537dc30e7db64effc67",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- 15 new nodes covering the full Hydra Head protocol: components (head, node, snapshot, validator, participation token, WebSocket API, contestation), lifecycle phases (init, commit, open, close, fan-out), core concepts (isomorphic state channel, unanimous consensus), and the Cardano Scaling org
- 29 new edges connecting Hydra nodes to each other and to existing EUTxO, Plutus, state-machine, reference-inputs, Aiken nodes
- Lifecycle sequencing edges: commit→open, open→close, snapshot→close, contestation→fan-out
- Head validator writtenIn Aiken (commit validator migrated to PlutusV3)
- Ontology extensions: `L2Protocol`, `L2Component`, `L2Lifecycle` classes; `settlesOn`, `lifecyclePhaseOf`, `componentOf`, `maintainedBy` predicates
- 2 new SPARQL queries: "Hydra L2 Ecosystem" view and "Hydra Head Lifecycle" view
- 2 guided tours: "Hydra: Cardano's Layer 2" (6 stops) and "Life of a Hydra Head" (7 stops)
- Updated graph-browser flake input to f050e07 (graphSources plural support)

## Preview

https://cardano-knowledge-maps-hydra.surge.sh

## Test plan

- [x] `nix build` passes
- [x] Surge preview deployed and verified
- [x] Hydra Ecosystem query renders correctly
- [x] Tours render correctly