### PR TITLE
Add Cardano Budget 2026 proposals as composed graphs

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -78,7 +78,7 @@
     "proposal": {
       "label": "Budget Proposal",
       "color": "#ffa657",
-      "shape": "tag"
+      "shape": "star"
     }
   }
 }

--- a/data/config.json
+++ b/data/config.json
@@ -4,7 +4,10 @@
   "sourceUrl": "https://github.com/lambdasistemi/cardano-knowledge-maps",
   "graphSources": [
     { "format": "text/turtle", "path": "data/rdf/graph.ttl" },
-    { "format": "text/turtle", "path": "data/rdf/cardano.ttl" }
+    { "format": "text/turtle", "path": "data/rdf/cardano.ttl" },
+    { "format": "text/turtle", "path": "data/rdf/budget-2026/partner-chain-factory.ttl" },
+    { "format": "text/turtle", "path": "data/rdf/budget-2026/indigo-v2030rs.ttl" },
+    { "format": "text/turtle", "path": "data/rdf/budget-2026/serviceplan-demand-engine.ttl" }
   ],
   "kinds": {
     "actor": {
@@ -71,6 +74,11 @@
       "label": "Standard",
       "color": "#e3b341",
       "shape": "round-pentagon"
+    },
+    "proposal": {
+      "label": "Budget Proposal",
+      "color": "#ffa657",
+      "shape": "tag"
     }
   }
 }

--- a/data/queries.json
+++ b/data/queries.json
@@ -102,6 +102,13 @@
     "tags": []
   },
   {
+    "id": "budget-2026",
+    "name": "Budget 2026 Proposals",
+    "description": "Cardano Budget 2026 — all submitted proposals with their proposers, deliverables, and treasury links.",
+    "sparql": "PREFIX gbkind: <https://lambdasistemi.github.io/graph-browser/vocab/kinds#>\nPREFIX cardano: <https://lambdasistemi.github.io/cardano-knowledge-maps/vocab/cardano#>\nSELECT DISTINCT ?node WHERE {\n  { ?node a gbkind:proposal }\n  UNION { ?proposal a gbkind:proposal ; cardano:submittedBy ?node }\n  UNION { ?proposal a gbkind:proposal ; cardano:deliversArtifact ?node }\n  UNION { ?proposal a gbkind:proposal ; cardano:fundingFrom ?node }\n  UNION { ?proposal a gbkind:proposal ; cardano:runsIn ?node }\n}",
+    "tags": ["view", "budget-2026"]
+  },
+  {
     "id": "treasury-and-budgeting",
     "name": "Treasury & Budgeting",
     "description": "Treasury withdrawals, budgeting mechanism, and economic parameters.",

--- a/data/rdf/budget-2026/indigo-v2030rs.ttl
+++ b/data/rdf/budget-2026/indigo-v2030rs.ttl
@@ -1,0 +1,172 @@
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+@prefix gb:      <https://lambdasistemi.github.io/graph-browser/vocab/terms#> .
+@prefix gbkind:  <https://lambdasistemi.github.io/graph-browser/vocab/kinds#> .
+@prefix gbgroup: <https://lambdasistemi.github.io/graph-browser/vocab/groups#> .
+@prefix gbedge:  <https://lambdasistemi.github.io/graph-browser/vocab/edges#> .
+@prefix cardano: <https://lambdasistemi.github.io/cardano-knowledge-maps/vocab/cardano#> .
+@prefix n:       <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/> .
+
+# =========================================================================
+#  Cardano Budget 2026 — Proposal: Indigo — V2030RS, Tokenized RWA, BTC-Fi & Privacy
+#  Proposer: Indigo Foundation  |  Request: 3,965,500 ADA
+#  https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026/69e63a4ed6a29288536b11fc
+# =========================================================================
+
+# -- Edges ----------------------------------------------------------------
+
+n:bp-indigo-v2030rs cardano:submittedBy n:org-indigo-foundation .
+[] a rdf:Statement ;
+  rdf:subject n:bp-indigo-v2030rs ;
+  rdf:predicate cardano:submittedBy ;
+  rdf:object n:org-indigo-foundation ;
+  dcterms:description "Indigo Foundation submitted the V2030RS / iUSDt / BTC-Fi / privacy proposal to Cardano Budget 2026 on 2026-04-20." .
+
+n:bp-indigo-v2030rs cardano:fundingFrom n:treasury-budgeting .
+[] a rdf:Statement ;
+  rdf:subject n:bp-indigo-v2030rs ;
+  rdf:predicate cardano:fundingFrom ;
+  rdf:object n:treasury-budgeting ;
+  dcterms:description "The proposal requests 3,965,500 ADA (~USD 1.19M at 0.30) from the Cardano Treasury via the Budget 2026 process." .
+
+n:bp-indigo-v2030rs cardano:deliversArtifact n:iusdt .
+[] a rdf:Statement ;
+  rdf:subject n:bp-indigo-v2030rs ;
+  rdf:predicate cardano:deliversArtifact ;
+  rdf:object n:iusdt ;
+  dcterms:description "Central deliverable: iUSDt — an institutional-grade, tokenized real-world-asset stablecoin bridging Cardano with institutional liquidity funds." .
+
+n:bp-indigo-v2030rs cardano:deliversArtifact n:v2030rs-revenue-share .
+[] a rdf:Statement ;
+  rdf:subject n:bp-indigo-v2030rs ;
+  rdf:predicate cardano:deliversArtifact ;
+  rdf:object n:v2030rs-revenue-share ;
+  dcterms:description "V2030RS — a treasury revenue-sharing mechanism that returns a portion of Indigo protocol revenues to the Cardano Treasury." .
+
+n:bp-indigo-v2030rs cardano:deliversArtifact n:shielded-iasset .
+[] a rdf:Statement ;
+  rdf:subject n:bp-indigo-v2030rs ;
+  rdf:predicate cardano:deliversArtifact ;
+  rdf:object n:shielded-iasset ;
+  dcterms:description "Privacy deliverable: shielded iAssets — confidential synthetic assets issued on partner-chain ecosystems." .
+
+n:bp-indigo-v2030rs cardano:deliversArtifact n:btc-fi-market .
+[] a rdf:Statement ;
+  rdf:subject n:bp-indigo-v2030rs ;
+  rdf:predicate cardano:deliversArtifact ;
+  rdf:object n:btc-fi-market ;
+  dcterms:description "Bitcoin DeFi market: an Indigo-hosted venue for Bitcoin-denominated positions, bringing BTC liquidity into the Cardano DeFi stack." .
+
+n:iusdt cardano:backedBy n:rwa .
+[] a rdf:Statement ;
+  rdf:subject n:iusdt ;
+  rdf:predicate cardano:backedBy ;
+  rdf:object n:rwa ;
+  dcterms:description "iUSDt is collateralised by tokenized real-world assets held through institutional liquidity funds, rather than by on-chain crypto collateral alone." .
+
+n:iusdt cardano:comparableTo n:djed .
+[] a rdf:Statement ;
+  rdf:subject n:iusdt ;
+  rdf:predicate cardano:comparableTo ;
+  rdf:object n:djed ;
+  dcterms:description "iUSDt is positioned in the same product category as Djed (Cardano-native stablecoin) but uses RWA-backed institutional collateral rather than an overcollateralized algorithmic peg." .
+
+n:v2030rs-revenue-share gbedge:returnsTo n:treasury-budgeting .
+[] a rdf:Statement ;
+  rdf:subject n:v2030rs-revenue-share ;
+  rdf:predicate gbedge:returnsTo ;
+  rdf:object n:treasury-budgeting ;
+  dcterms:description "V2030RS directs a share of Indigo protocol revenue back to the Cardano Treasury — reframing the proposal's ADA ask as a revenue-sharing partnership rather than a one-way grant." .
+
+n:shielded-iasset cardano:deployedOn n:partner-chain .
+[] a rdf:Statement ;
+  rdf:subject n:shielded-iasset ;
+  rdf:predicate cardano:deployedOn ;
+  rdf:object n:partner-chain ;
+  dcterms:description "Shielded iAssets are deployed on partner-chain ecosystems — a cross-proposal dependency on the Partner Chain Factory track (bp-partner-chain-factory)." .
+
+n:btc-fi-market cardano:denominatedIn n:btc .
+[] a rdf:Statement ;
+  rdf:subject n:btc-fi-market ;
+  rdf:predicate cardano:denominatedIn ;
+  rdf:object n:btc ;
+  dcterms:description "The BTC-Fi market component uses Bitcoin as the denominating asset, bringing external BTC liquidity into Indigo on Cardano." .
+
+# -- Nodes ----------------------------------------------------------------
+
+n:bp-indigo-v2030rs
+  dcterms:description "Cardano Budget 2026 proposal requesting 3,965,500 ADA (USD ~1.19M @ 0.30). Four-track scope: (1) iUSDt — institutional-grade tokenized RWA stablecoin linking Cardano with institutional liquidity funds; (2) Bitcoin DeFi markets on Indigo; (3) shielded iAssets on partner-chain ecosystems; (4) V2030RS — a landmark revenue-sharing model with the Cardano Treasury. Submitted on 20/04/2026. Read Proposal: https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026/69e63a4ed6a29288536b11fc" ;
+  gb:group gbgroup:proposals ;
+  rdfs:label "Budget 2026 Proposal — Indigo V2030RS / iUSDt" ;
+  gb:nodeId "bp-indigo-v2030rs" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:proposal ;
+  a gb:Node ;
+  foaf:page <https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026/69e63a4ed6a29288536b11fc> .
+
+n:org-indigo-foundation
+  dcterms:description "Indigo Foundation — proposer of the V2030RS / iUSDt / BTC-Fi / shielded-iAsset package to Cardano Budget 2026." ;
+  gb:group gbgroup:organizations ;
+  rdfs:label "Indigo Foundation" ;
+  gb:nodeId "org-indigo-foundation" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:actor ;
+  a gb:Node ;
+  foaf:page <https://indigoprotocol.io/> .
+
+n:iusdt
+  dcterms:description "iUSDt — institutional-grade tokenized RWA stablecoin proposed by Indigo. Collateralised through institutional liquidity funds rather than on-chain overcollateralisation. Positioned as Cardano's first bridge into institutional RWA liquidity." ;
+  gb:group gbgroup:protocols ;
+  rdfs:label "iUSDt" ;
+  gb:nodeId "iusdt" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:protocol ;
+  a gb:Node .
+
+n:rwa
+  dcterms:description "Real-World Asset — off-chain assets (e.g. short-term treasuries, institutional liquidity fund shares) represented on-chain as tokens. Referenced by the Indigo proposal as the collateral base for iUSDt and as a pathway connecting Cardano DeFi to traditional-finance liquidity." ;
+  gb:group gbgroup:concepts ;
+  rdfs:label "Real-World Asset (RWA)" ;
+  gb:nodeId "rwa" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node .
+
+n:v2030rs-revenue-share
+  dcterms:description "V2030RS — the revenue-sharing mechanism the Indigo proposal introduces as a structural alternative to one-way treasury grants. A portion of protocol revenue flows back to the Cardano Treasury, making the ADA ask a partnership rather than a grant." ;
+  gb:group gbgroup:mechanisms ;
+  rdfs:label "V2030RS Revenue-Share" ;
+  gb:nodeId "v2030rs-revenue-share" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:mechanism ;
+  a gb:Node .
+
+n:shielded-iasset
+  dcterms:description "Shielded iAsset — a privacy-preserving synthetic asset issued on partner-chain ecosystems, so that iAsset holdings and flows are confidential while still settling against Cardano via the partner-chain path." ;
+  gb:group gbgroup:concepts ;
+  rdfs:label "Shielded iAsset" ;
+  gb:nodeId "shielded-iasset" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node .
+
+n:btc-fi-market
+  dcterms:description "Indigo's Bitcoin DeFi market — a venue for BTC-denominated positions that routes external Bitcoin liquidity into the Cardano DeFi stack via Indigo." ;
+  gb:group gbgroup:protocols ;
+  rdfs:label "BTC-Fi Market" ;
+  gb:nodeId "btc-fi-market" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:protocol ;
+  a gb:Node .
+
+n:btc
+  dcterms:description "Bitcoin — the external asset the Indigo BTC-Fi market builds around. Not native to Cardano; brought in via bridging / wrapping primitives referenced by the proposal." ;
+  gb:group gbgroup:concepts ;
+  rdfs:label "BTC" ;
+  gb:nodeId "btc" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node ;
+  foaf:page <https://bitcoin.org/> .

--- a/data/rdf/budget-2026/partner-chain-factory.ttl
+++ b/data/rdf/budget-2026/partner-chain-factory.ttl
@@ -1,0 +1,190 @@
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+@prefix gb:      <https://lambdasistemi.github.io/graph-browser/vocab/terms#> .
+@prefix gbkind:  <https://lambdasistemi.github.io/graph-browser/vocab/kinds#> .
+@prefix gbgroup: <https://lambdasistemi.github.io/graph-browser/vocab/groups#> .
+@prefix gbedge:  <https://lambdasistemi.github.io/graph-browser/vocab/edges#> .
+@prefix cardano: <https://lambdasistemi.github.io/cardano-knowledge-maps/vocab/cardano#> .
+@prefix n:       <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/> .
+
+# =========================================================================
+#  Cardano Budget 2026 — Proposal: Partner Chain Factory (Ouroboros Tachýs)
+#  Proposer: Ensurable Systems Ltd  |  Request: 13,150,479 ADA
+#  https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026/69e8c0e2ae91c89d305701f5
+# =========================================================================
+
+# -- Edges ----------------------------------------------------------------
+
+n:bp-partner-chain-factory cardano:submittedBy n:org-ensurable-systems .
+[] a rdf:Statement ;
+  rdf:subject n:bp-partner-chain-factory ;
+  rdf:predicate cardano:submittedBy ;
+  rdf:object n:org-ensurable-systems ;
+  dcterms:description "Ensurable Systems Ltd submitted the Partner Chain Factory proposal to Cardano Budget 2026 on 2026-04-22." .
+
+n:bp-partner-chain-factory cardano:fundingFrom n:treasury-budgeting .
+[] a rdf:Statement ;
+  rdf:subject n:bp-partner-chain-factory ;
+  rdf:predicate cardano:fundingFrom ;
+  rdf:object n:treasury-budgeting ;
+  dcterms:description "The proposal requests 13,150,479 ADA (~USD 3.29M at 0.25) from the Cardano Treasury via the Budget 2026 process." .
+
+n:bp-partner-chain-factory cardano:deliversArtifact n:partner-chain-factory-toolkit .
+[] a rdf:Statement ;
+  rdf:subject n:bp-partner-chain-factory ;
+  rdf:predicate cardano:deliversArtifact ;
+  rdf:object n:partner-chain-factory-toolkit ;
+  dcterms:description "Deliverable is an open-source, Intersect-governed toolkit that lets builders deploy new Cardano-derived partner chains in hours rather than months." .
+
+n:partner-chain-factory-toolkit cardano:builtOn n:ouroboros-tachys .
+[] a rdf:Statement ;
+  rdf:subject n:partner-chain-factory-toolkit ;
+  rdf:predicate cardano:builtOn ;
+  rdf:object n:ouroboros-tachys ;
+  dcterms:description "The toolkit produces chains running Ouroboros Tachýs — a high-performance variant delivering 1–2 second block confirmation and ~40× mainnet throughput." .
+
+n:ouroboros-tachys cardano:variantOf n:ouroboros-praos .
+[] a rdf:Statement ;
+  rdf:subject n:ouroboros-tachys ;
+  rdf:predicate cardano:variantOf ;
+  rdf:object n:ouroboros-praos ;
+  dcterms:description "Ouroboros Tachýs is a performance-oriented variant of Ouroboros Praos, retaining Praos-equivalent security properties while increasing throughput and reducing confirmation latency." .
+
+n:vector-chain cardano:builtOn n:ouroboros-tachys .
+[] a rdf:Statement ;
+  rdf:subject n:vector-chain ;
+  rdf:predicate cardano:builtOn ;
+  rdf:object n:ouroboros-tachys ;
+  dcterms:description "Vector, launched late 2025 as the first Cardano-derived partner chain in production, is the reference validation of the Ouroboros Tachýs design the factory industrialises." .
+
+n:partner-chain-factory-toolkit cardano:produces n:partner-chain .
+[] a rdf:Statement ;
+  rdf:subject n:partner-chain-factory-toolkit ;
+  rdf:predicate cardano:produces ;
+  rdf:object n:partner-chain ;
+  dcterms:description "The factory emits partner-chain instances: application-specific chains that settle to Cardano mainnet and connect via production-grade bridging infrastructure." .
+
+n:partner-chain cardano:settlesOn n:cardano-mainnet .
+[] a rdf:Statement ;
+  rdf:subject n:partner-chain ;
+  rdf:predicate cardano:settlesOn ;
+  rdf:object n:cardano-mainnet ;
+  dcterms:description "Partner chains use Cardano mainnet as their settlement layer; their security is ultimately anchored to Cardano's consensus." .
+
+n:partner-chain cardano:requiresStakeIn n:ada .
+[] a rdf:Statement ;
+  rdf:subject n:partner-chain ;
+  rdf:predicate cardano:requiresStakeIn ;
+  rdf:object n:ada ;
+  dcterms:description "Partner chains built by the factory require ADA for stake, generating structural ADA demand independent of L1 transaction volume." .
+
+n:partner-chain cardano:connectsVia n:cardano-bridge .
+[] a rdf:Statement ;
+  rdf:subject n:partner-chain ;
+  rdf:predicate cardano:connectsVia ;
+  rdf:object n:cardano-bridge ;
+  dcterms:description "Partner chains produced by the factory ship with production-grade bridging infrastructure to move assets and messages between the partner chain and Cardano mainnet." .
+
+n:cardano-bridge gbedge:generates n:treasury-budgeting .
+[] a rdf:Statement ;
+  rdf:subject n:cardano-bridge ;
+  rdf:predicate gbedge:generates ;
+  rdf:object n:treasury-budgeting ;
+  dcterms:description "Bridging activity between partner chains and mainnet generates fees, contributing to treasury sustainability — part of the proposal's treasury-return argument." .
+
+# -- Nodes ----------------------------------------------------------------
+
+n:bp-partner-chain-factory
+  dcterms:description "Cardano Budget 2026 proposal requesting 13,150,479 ADA (USD ~3.29M @ 0.25) to build a reusable, open-source Partner Chain Factory. The factory bundles the Ouroboros Tachýs consensus variant, chain-bootstrapping tooling, and production-grade bridging so new partner chains can be deployed in hours rather than months, and started directly in the current Cardano era. The deliverable is to be open-source and maintained inside the Intersect-governed Cardano codebase. Submitted on 22/04/2026. Read Proposal: https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026/69e8c0e2ae91c89d305701f5" ;
+  gb:group gbgroup:proposals ;
+  rdfs:label "Budget 2026 Proposal — Partner Chain Factory" ;
+  gb:nodeId "bp-partner-chain-factory" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:proposal ;
+  a gb:Node ;
+  foaf:page <https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026/69e8c0e2ae91c89d305701f5> .
+
+n:org-ensurable-systems
+  dcterms:description "Ensurable Systems Ltd — proposer of the Partner Chain Factory proposal (Budget 2026). The team states it built the Cardano node, implemented Ouroboros, and delivered every hard fork from Byron through Plomin." ;
+  gb:group gbgroup:organizations ;
+  rdfs:label "Ensurable Systems Ltd" ;
+  gb:nodeId "org-ensurable-systems" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:actor ;
+  a gb:Node .
+
+n:partner-chain-factory-toolkit
+  dcterms:description "Open-source toolkit delivered by the proposal: chain-bootstrapping templates, the Ouroboros Tachýs consensus implementation, and bridging infrastructure. Maintained within the Intersect-governed Cardano codebase; available to any builder without licence fee." ;
+  gb:group gbgroup:tools ;
+  rdfs:label "Partner Chain Factory Toolkit" ;
+  gb:nodeId "partner-chain-factory-toolkit" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:tool ;
+  a gb:Node .
+
+n:ouroboros-tachys
+  dcterms:description "A high-performance Ouroboros consensus variant targeting 1–2 second confirmation latency and ~40× Cardano mainnet throughput, while retaining Ouroboros security properties. Intended as the consensus engine for Cardano-derived partner chains produced by the factory." ;
+  gb:group gbgroup:protocols ;
+  rdfs:label "Ouroboros Tachýs" ;
+  gb:nodeId "ouroboros-tachys" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:protocol ;
+  a gb:Node .
+
+n:ouroboros-praos
+  dcterms:description "The production Cardano consensus protocol. Proof-of-stake protocol in the Ouroboros family with provable security under semi-synchronous network assumptions. Used by Cardano mainnet; the baseline against which Ouroboros Tachýs is described as a performance-oriented variant." ;
+  gb:group gbgroup:protocols ;
+  rdfs:label "Ouroboros Praos" ;
+  gb:nodeId "ouroboros-praos" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:protocol ;
+  a gb:Node ;
+  foaf:page <https://iohk.io/en/research/library/papers/ouroboros-praos-an-adaptively-secure-semi-synchronous-proof-of-stake-protocol/> .
+
+n:partner-chain
+  dcterms:description "A Cardano-derived application chain that settles to Cardano mainnet, requires ADA stake, and connects to mainnet through bridging infrastructure. Distinct from Layer 2 constructions (e.g. Hydra heads): partner chains are sovereign chains that inherit Cardano tooling and security anchoring rather than running inside a Cardano state channel." ;
+  gb:group gbgroup:concepts ;
+  rdfs:label "Partner Chain" ;
+  gb:nodeId "partner-chain" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node .
+
+n:vector-chain
+  dcterms:description "Vector — launched in late 2025 as the first Cardano-derived partner chain in production. Cited in the Partner Chain Factory proposal as the existence proof for the Ouroboros Tachýs design the factory industrialises." ;
+  gb:group gbgroup:protocols ;
+  rdfs:label "Vector Chain" ;
+  gb:nodeId "vector-chain" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:protocol ;
+  a gb:Node .
+
+n:cardano-bridge
+  dcterms:description "Production-grade bridging infrastructure between Cardano mainnet and partner chains produced by the factory: asset transfers, message passing, and the fee flow that supports the treasury-return argument of the proposal." ;
+  gb:group gbgroup:concepts ;
+  rdfs:label "Cardano Bridge" ;
+  gb:nodeId "cardano-bridge" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node .
+
+n:cardano-mainnet
+  dcterms:description "The Cardano layer-1 settlement chain running Ouroboros Praos. Referenced as the settlement layer for partner chains produced by the factory." ;
+  gb:group gbgroup:protocols ;
+  rdfs:label "Cardano Mainnet" ;
+  gb:nodeId "cardano-mainnet" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:protocol ;
+  a gb:Node ;
+  foaf:page <https://cardano.org/> .
+
+n:ada
+  dcterms:description "The native asset of Cardano. Used for transaction fees, staking (Ouroboros Praos), deposits, and treasury denomination. Partner chains built by the factory require ADA for stake, which is the core structural-demand argument of the proposal." ;
+  gb:group gbgroup:concepts ;
+  rdfs:label "ADA" ;
+  gb:nodeId "ada" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node .

--- a/data/rdf/budget-2026/serviceplan-demand-engine.ttl
+++ b/data/rdf/budget-2026/serviceplan-demand-engine.ttl
@@ -1,0 +1,198 @@
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+@prefix gb:      <https://lambdasistemi.github.io/graph-browser/vocab/terms#> .
+@prefix gbkind:  <https://lambdasistemi.github.io/graph-browser/vocab/kinds#> .
+@prefix gbgroup: <https://lambdasistemi.github.io/graph-browser/vocab/groups#> .
+@prefix gbedge:  <https://lambdasistemi.github.io/graph-browser/vocab/edges#> .
+@prefix cardano: <https://lambdasistemi.github.io/cardano-knowledge-maps/vocab/cardano#> .
+@prefix n:       <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/> .
+
+# =========================================================================
+#  Cardano Budget 2026 — Proposal: The Marketing Powered Demand Engine for Cardano
+#  Proposer: Serviceplan Group  |  Request: 20,871,418 ADA
+#  https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026/69e21a177a2045bdd2281d1a
+# =========================================================================
+
+# -- Edges ----------------------------------------------------------------
+
+n:bp-serviceplan-demand-engine cardano:submittedBy n:org-serviceplan-group .
+[] a rdf:Statement ;
+  rdf:subject n:bp-serviceplan-demand-engine ;
+  rdf:predicate cardano:submittedBy ;
+  rdf:object n:org-serviceplan-group ;
+  dcterms:description "Serviceplan Group submitted the Marketing Powered Demand Engine proposal to Cardano Budget 2026 on 2026-04-20." .
+
+n:bp-serviceplan-demand-engine cardano:fundingFrom n:treasury-budgeting .
+[] a rdf:Statement ;
+  rdf:subject n:bp-serviceplan-demand-engine ;
+  rdf:predicate cardano:fundingFrom ;
+  rdf:object n:treasury-budgeting ;
+  dcterms:description "The proposal requests 20,871,418 ADA (~USD 3.55M at 0.17) from the Cardano Treasury via the Budget 2026 process." .
+
+n:bp-serviceplan-demand-engine cardano:deliversArtifact n:demand-engine .
+[] a rdf:Statement ;
+  rdf:subject n:bp-serviceplan-demand-engine ;
+  rdf:predicate cardano:deliversArtifact ;
+  rdf:object n:demand-engine ;
+  dcterms:description "Top-level deliverable is an enterprise demand-generation system positioning Cardano as 'The Blockchain for Serious Business'." .
+
+n:bp-serviceplan-demand-engine cardano:deliversArtifact n:cardano-hub .
+[] a rdf:Statement ;
+  rdf:subject n:bp-serviceplan-demand-engine ;
+  rdf:predicate cardano:deliversArtifact ;
+  rdf:object n:cardano-hub ;
+  dcterms:description "The proposal delivers the Cardano Hub — a central evidence-and-engagement environment for enterprise leads." .
+
+n:demand-engine cardano:targets n:enterprise-adoption .
+[] a rdf:Statement ;
+  rdf:subject n:demand-engine ;
+  rdf:predicate cardano:targets ;
+  rdf:object n:enterprise-adoption ;
+  dcterms:description "The demand engine is aimed at enterprise decision-makers — the segment the proposal argues is currently underserved by Cardano's go-to-market." .
+
+n:demand-engine cardano:implementsProcess n:demand-funnel .
+[] a rdf:Statement ;
+  rdf:subject n:demand-engine ;
+  rdf:predicate cardano:implementsProcess ;
+  rdf:object n:demand-funnel ;
+  dcterms:description "The demand engine operates through a three-stage Attention → Proof → Qualified Leads funnel." .
+
+n:demand-funnel cardano:validatesIn n:pilot-vertical-institutional-defi .
+[] a rdf:Statement ;
+  rdf:subject n:demand-funnel ;
+  rdf:predicate cardano:validatesIn ;
+  rdf:object n:pilot-vertical-institutional-defi ;
+  dcterms:description "Institutional DeFi is the V1 pilot vertical — first enterprise use case tested through the funnel." .
+
+n:demand-funnel cardano:validatesIn n:pilot-vertical-supply-chain .
+[] a rdf:Statement ;
+  rdf:subject n:demand-funnel ;
+  rdf:predicate cardano:validatesIn ;
+  rdf:object n:pilot-vertical-supply-chain ;
+  dcterms:description "Supply Chain Traceability is the V2 pilot vertical — activated after V1 KPI validation, subject to GMC / community alignment." .
+
+n:bp-serviceplan-demand-engine cardano:runsIn n:pilot-market-uk .
+[] a rdf:Statement ;
+  rdf:subject n:bp-serviceplan-demand-engine ;
+  rdf:predicate cardano:runsIn ;
+  rdf:object n:pilot-market-uk ;
+  dcterms:description "UK is one of three pilot markets for the 12-month campaign." .
+
+n:bp-serviceplan-demand-engine cardano:runsIn n:pilot-market-germany .
+[] a rdf:Statement ;
+  rdf:subject n:bp-serviceplan-demand-engine ;
+  rdf:predicate cardano:runsIn ;
+  rdf:object n:pilot-market-germany ;
+  dcterms:description "Germany is one of three pilot markets for the 12-month campaign." .
+
+n:bp-serviceplan-demand-engine cardano:runsIn n:pilot-market-switzerland .
+[] a rdf:Statement ;
+  rdf:subject n:bp-serviceplan-demand-engine ;
+  rdf:predicate cardano:runsIn ;
+  rdf:object n:pilot-market-switzerland ;
+  dcterms:description "Switzerland is one of three pilot markets for the 12-month campaign." .
+
+# -- Nodes ----------------------------------------------------------------
+
+n:bp-serviceplan-demand-engine
+  dcterms:description "Cardano Budget 2026 proposal requesting 20,871,418 ADA (USD ~3.55M @ 0.17). 12-month enterprise marketing pilot positioning Cardano as 'The Blockchain for Serious Business' through a three-stage funnel (Attention → Proof → Qualified Leads). Pilot verticals: Institutional DeFi (V1) and Supply Chain Traceability (V2). Pilot markets: UK, Germany, Switzerland. Targets 45M paid impressions, 320K native views, 300K Hub clicks. Budget €2,978,738, split 53% media / 47% agency. Submitted on 20/04/2026. Read Proposal: https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026/69e21a177a2045bdd2281d1a" ;
+  gb:group gbgroup:proposals ;
+  rdfs:label "Budget 2026 Proposal — Serviceplan Demand Engine" ;
+  gb:nodeId "bp-serviceplan-demand-engine" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:proposal ;
+  a gb:Node ;
+  foaf:page <https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026/69e21a177a2045bdd2281d1a> .
+
+n:org-serviceplan-group
+  dcterms:description "Serviceplan Group — proposer of the Marketing Powered Demand Engine. A marketing-and-agency group delivering the enterprise demand-generation pilot." ;
+  gb:group gbgroup:organizations ;
+  rdfs:label "Serviceplan Group" ;
+  gb:nodeId "org-serviceplan-group" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:actor ;
+  a gb:Node ;
+  foaf:page <https://www.serviceplan.com/> .
+
+n:demand-engine
+  dcterms:description "Enterprise demand-generation system: the top-level artifact of the Serviceplan proposal. Positions Cardano as 'The Blockchain for Serious Business' and drives the three-stage Attention → Proof → Qualified Leads funnel across pilot verticals and markets." ;
+  gb:group gbgroup:tools ;
+  rdfs:label "Cardano Enterprise Demand Engine" ;
+  gb:nodeId "demand-engine" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:tool ;
+  a gb:Node .
+
+n:cardano-hub
+  dcterms:description "Cardano Hub — central evidence and engagement environment proposed by Serviceplan. Destination for paid media, native advertising, and event-to-digital funnels; the Hub is where qualified enterprise leads convert after exposure." ;
+  gb:group gbgroup:tools ;
+  rdfs:label "Cardano Hub" ;
+  gb:nodeId "cardano-hub" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:artifact ;
+  a gb:Node .
+
+n:demand-funnel
+  dcterms:description "Three-stage demand-generation process: Attention (paid media, events, Out of Home), Proof (Cardano Hub evidence environment), Qualified Leads (enterprise sales hand-off). Structured in four work packages: Enable, Kick-off, Scale, V2." ;
+  gb:group gbgroup:processes ;
+  rdfs:label "Attention → Proof → Qualified Leads Funnel" ;
+  gb:nodeId "demand-funnel" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:process ;
+  a gb:Node .
+
+n:enterprise-adoption
+  dcterms:description "Enterprise adoption — the concept the Serviceplan proposal treats as the missing demand signal for Cardano. The proposal argues enterprise leaders currently lack three things: use-case clarity, reliable proof, and engagement paths." ;
+  gb:group gbgroup:concepts ;
+  rdfs:label "Enterprise Adoption" ;
+  gb:nodeId "enterprise-adoption" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node .
+
+n:pilot-vertical-institutional-defi
+  dcterms:description "V1 pilot vertical: Institutional DeFi. First enterprise use case tested through the three-stage demand funnel." ;
+  gb:group gbgroup:concepts ;
+  rdfs:label "Pilot Vertical — Institutional DeFi" ;
+  gb:nodeId "pilot-vertical-institutional-defi" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node .
+
+n:pilot-vertical-supply-chain
+  dcterms:description "V2 pilot vertical: Supply Chain Traceability. Activated after V1 KPI validation; subject to GMC / community alignment." ;
+  gb:group gbgroup:concepts ;
+  rdfs:label "Pilot Vertical — Supply Chain Traceability" ;
+  gb:nodeId "pilot-vertical-supply-chain" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node .
+
+n:pilot-market-uk
+  dcterms:description "Pilot market: United Kingdom. One of three launch markets for the 12-month enterprise demand-generation campaign." ;
+  gb:group gbgroup:concepts ;
+  rdfs:label "Pilot Market — UK" ;
+  gb:nodeId "pilot-market-uk" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node .
+
+n:pilot-market-germany
+  dcterms:description "Pilot market: Germany. One of three launch markets for the 12-month enterprise demand-generation campaign." ;
+  gb:group gbgroup:concepts ;
+  rdfs:label "Pilot Market — Germany" ;
+  gb:nodeId "pilot-market-germany" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node .
+
+n:pilot-market-switzerland
+  dcterms:description "Pilot market: Switzerland. One of three launch markets for the 12-month enterprise demand-generation campaign." ;
+  gb:group gbgroup:concepts ;
+  rdfs:label "Pilot Market — Switzerland" ;
+  gb:nodeId "pilot-market-switzerland" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  a gbkind:concept ;
+  a gb:Node .

--- a/flake.lock
+++ b/flake.lock
@@ -55,11 +55,11 @@
         "purescript-overlay": "purescript-overlay"
       },
       "locked": {
-        "lastModified": 1775739065,
-        "narHash": "sha256-gRddug5YmHmNIkUwlY+7fP3M7dJoc088qM5amrxfbY8=",
+        "lastModified": 1775904642,
+        "narHash": "sha256-nKxRD27tck0LKWX4u5ovlkuKGc5ziNScTg3cuNYxUeQ=",
         "owner": "lambdasistemi",
         "repo": "graph-browser",
-        "rev": "7d33b9f583a160624d67e3983a33466d8e4df374",
+        "rev": "f050e07ffcf3098d81716537dc30e7db64effc67",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Brings the three Cardano Budget 2026 proposals from https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026 into the knowledge maps as **per-proposal TTL files loaded as independent graph sources**, rather than expanding \`graph.ttl\`.

### Added proposals

| # | Title | Proposer | Request |
|---|---|---|---|
| 1 | Partner Chain Factory (Ouroboros Tachýs) | Ensurable Systems Ltd | 13,150,479 ADA |
| 2 | Indigo — V2030RS / iUSDt / BTC-Fi / Privacy | Indigo Foundation | 3,965,500 ADA |
| 3 | Marketing Powered Demand Engine | Serviceplan Group | 20,871,418 ADA |

### Cross-graph composition

The three new TTLs merge with \`graph.ttl\` in the Oxigraph store, so the proposals link into the existing ontology and into each other:

- all three → existing \`n:treasury-budgeting\`
- Indigo \`n:iusdt\` → existing \`n:djed\` (comparable stablecoin)
- Indigo \`n:shielded-iasset\` → new \`n:partner-chain\` from proposal #1 (cross-proposal dependency)
- new \`n:ouroboros-tachys\` → new \`n:ouroboros-praos\` (variantOf)

### Files

- \`data/rdf/budget-2026/partner-chain-factory.ttl\` (+139 triples)
- \`data/rdf/budget-2026/indigo-v2030rs.ttl\` (+125 triples)
- \`data/rdf/budget-2026/serviceplan-demand-engine.ttl\` (+145 triples)
- \`data/config.json\` — 3 new \`graphSources\`, new \`proposal\` node kind
- \`data/queries.json\` — new \"Budget 2026 Proposals\" SPARQL view

### Validation

- Oxigraph parses all 5 TTLs cleanly (2843 total triples)
- \`nix build\` succeeds; built output exposes the new sources in \`data/config.json\`
- Local \`serve\` renders the landing page and the new query appears in the sidebar

### Follow-up

A graph-browser feature issue will be filed for **per-source toggle / collapse** (composed-graphs UI) so readers can hide/show individual proposals without editing \`config.json\`. Today all sources merge into one flat store with no provenance.

## Test plan

- [ ] CI builds green
- [ ] Live Pages preview loads without console errors
- [ ] \"Budget 2026 Proposals\" query shows 3 proposal nodes with their proposers, deliverables and treasury links
- [ ] Cross-proposal edge \`shielded-iasset → partner-chain\` renders