### PR TITLE
Budget proposal ontology + deep enrichment of all three Budget 2026 proposals

### DIFF
--- a/data/queries.json
+++ b/data/queries.json
@@ -105,7 +105,28 @@
     "id": "budget-2026",
     "name": "Budget 2026 Proposals",
     "description": "Cardano Budget 2026 — all submitted proposals with their proposers, deliverables, and treasury links.",
-    "sparql": "PREFIX gbkind: <https://lambdasistemi.github.io/graph-browser/vocab/kinds#>\nPREFIX cardano: <https://lambdasistemi.github.io/cardano-knowledge-maps/vocab/cardano#>\nSELECT DISTINCT ?node WHERE {\n  { ?node a gbkind:proposal }\n  UNION { ?proposal a gbkind:proposal ; cardano:submittedBy ?node }\n  UNION { ?proposal a gbkind:proposal ; cardano:deliversArtifact ?node }\n  UNION { ?proposal a gbkind:proposal ; cardano:fundingFrom ?node }\n  UNION { ?proposal a gbkind:proposal ; cardano:runsIn ?node }\n}",
+    "sparql": "PREFIX gbkind: <https://lambdasistemi.github.io/graph-browser/vocab/kinds#>\nPREFIX cardano: <https://lambdasistemi.github.io/cardano-knowledge-maps/vocab/cardano#>\nSELECT DISTINCT ?node WHERE {\n  { ?node a gbkind:proposal }\n  UNION { ?proposal a gbkind:proposal ; cardano:proposedBy ?node }\n  UNION { ?proposal a gbkind:proposal ; cardano:administeredBy ?node }\n  UNION { ?proposal a gbkind:proposal ; cardano:deliversArtifact ?node }\n  UNION { ?proposal a gbkind:proposal ; cardano:partOfBudgetProcess ?node }\n  UNION { ?proposal a gbkind:proposal ; cardano:runsIn ?node }\n}",
+    "tags": ["view", "budget-2026"]
+  },
+  {
+    "id": "budget-2026-work-packages",
+    "name": "Budget 2026 — Work Packages",
+    "description": "Every Budget 2026 work package with its parent proposal, milestones, line items, cost categories, and the partner/role each line item is performed by.",
+    "sparql": "PREFIX cardano: <https://lambdasistemi.github.io/cardano-knowledge-maps/vocab/cardano#>\nSELECT DISTINCT ?node WHERE {\n  { ?node a cardano:WorkPackage }\n  UNION { ?proposal cardano:hasWorkPackage ?node . FILTER(STR(?proposal) != '') }\n  UNION { ?node a cardano:BudgetProposal }\n  UNION { ?wp a cardano:WorkPackage ; cardano:hasWorkPackageMilestone ?node }\n  UNION { ?wp a cardano:WorkPackage ; cardano:hasBudgetLineItem ?node }\n  UNION { ?bli a cardano:BudgetLineItem ; cardano:lineItemCategory ?node }\n  UNION { ?bli a cardano:BudgetLineItem ; cardano:lineItemPerformedBy ?node }\n}",
+    "tags": ["view", "budget-2026"]
+  },
+  {
+    "id": "budget-2026-strategy-alignment",
+    "name": "Budget 2026 — Strategy & KPIs",
+    "description": "How Budget 2026 proposals align with the Cardano 2030 Strategy Framework: pillars, supported KPIs, and proposed new KPIs.",
+    "sparql": "PREFIX cardano: <https://lambdasistemi.github.io/cardano-knowledge-maps/vocab/cardano#>\nSELECT DISTINCT ?node WHERE {\n  { ?node a cardano:BudgetProposal }\n  UNION { ?node a cardano:StrategicPillar }\n  UNION { ?node a cardano:StrategyKPI }\n}",
+    "tags": ["view", "budget-2026"]
+  },
+  {
+    "id": "budget-2026-treasury-flow",
+    "name": "Budget 2026 — Treasury Flow",
+    "description": "How money moves through the Budget 2026 process: the budget process node, every proposal, every repayment clause and the treasury they return to.",
+    "sparql": "PREFIX cardano: <https://lambdasistemi.github.io/cardano-knowledge-maps/vocab/cardano#>\nSELECT DISTINCT ?node WHERE {\n  { ?node a cardano:BudgetProcess }\n  UNION { ?node a cardano:BudgetProposal }\n  UNION { ?node a cardano:RepaymentClause }\n  UNION { ?node a cardano:TreasuryBudgeting }\n  UNION { ?node a cardano:TreasuryWithdrawal }\n}",
     "tags": ["view", "budget-2026"]
   },
   {

--- a/data/rdf/budget-2026/indigo-v2030rs.ttl
+++ b/data/rdf/budget-2026/indigo-v2030rs.ttl
@@ -1,5 +1,6 @@
 @prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix foaf:    <http://xmlns.com/foaf/0.1/> .
 @prefix gb:      <https://lambdasistemi.github.io/graph-browser/vocab/terms#> .
@@ -15,21 +16,144 @@
 #  https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026/69e63a4ed6a29288536b11fc
 # =========================================================================
 
-# -- Edges ----------------------------------------------------------------
+# -- Proposal-level facts --------------------------------------------------
 
-n:bp-indigo-v2030rs cardano:submittedBy n:org-indigo-foundation .
+n:bp-indigo-v2030rs a cardano:BudgetProposal ;
+  a gb:Node ;
+  a gbkind:proposal ;
+  gb:nodeId "bp-indigo-v2030rs" ;
+  rdfs:label "Budget 2026 Proposal — Indigo V2030RS / iUSDt" ;
+  gb:group gbgroup:proposals ;
+  cardano:proposalIdentifier "69e63a4ed6a29288536b11fc" ;
+  cardano:requestedAdaAmount "3965500"^^xsd:decimal ;
+  cardano:requestedUsdAmount "1189650"^^xsd:decimal ;
+  cardano:adaUsdRate "0.30"^^xsd:decimal ;
+  cardano:estimatedDurationMonths "12"^^xsd:integer ;
+  cardano:submittedOn "2026-04-20T16:44:00Z"^^xsd:dateTime ;
+  cardano:applicantType "Company" ;
+  dcterms:description "Cardano Budget 2026 proposal requesting 3,965,500 ADA (USD ~1.19M @ 0.30). Four-track scope: (1) iUSDt — institutional-grade tokenized RWA stablecoin linking Cardano with institutional liquidity funds; (2) Bitcoin DeFi markets on Indigo; (3) shielded iAssets on partner-chain ecosystems; (4) V2030RS — a landmark revenue-sharing model with the Cardano Treasury. Submitted on 2026-04-20." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026/69e63a4ed6a29288536b11fc> .
+
+n:bp-indigo-v2030rs cardano:partOfBudgetProcess n:cardano-budget-2026 .
+n:bp-indigo-v2030rs cardano:proposedBy n:org-indigo-foundation .
+n:bp-indigo-v2030rs cardano:administeredBy n:org-intersect .
+
+n:bp-indigo-v2030rs cardano:alignsWithPillar n:pillar-2-adoption .
+n:bp-indigo-v2030rs cardano:alignsWithPillar n:pillar-4-community .
+n:bp-indigo-v2030rs cardano:alignsWithPillar n:pillar-5-sustainability .
+
+n:bp-indigo-v2030rs cardano:supportsKPI n:kpi-annual-protocol-revenue .
 [] a rdf:Statement ;
   rdf:subject n:bp-indigo-v2030rs ;
-  rdf:predicate cardano:submittedBy ;
-  rdf:object n:org-indigo-foundation ;
-  dcterms:description "Indigo Foundation submitted the V2030RS / iUSDt / BTC-Fi / privacy proposal to Cardano Budget 2026 on 2026-04-20." .
+  rdf:predicate cardano:supportsKPI ;
+  rdf:object n:kpi-annual-protocol-revenue ;
+  dcterms:description "Indigo's V2030RS routes 10% of net revenue from RWAs, BTC DeFi and shielded iAssets to the Treasury perpetually. Builds on Indigo's proven ~4.66M ADA average annual revenue." .
 
-n:bp-indigo-v2030rs cardano:fundingFrom n:treasury-budgeting .
+n:bp-indigo-v2030rs cardano:supportsKPI n:kpi-tvl .
 [] a rdf:Statement ;
   rdf:subject n:bp-indigo-v2030rs ;
-  rdf:predicate cardano:fundingFrom ;
-  rdf:object n:treasury-budgeting ;
-  dcterms:description "The proposal requests 3,965,500 ADA (~USD 1.19M at 0.30) from the Cardano Treasury via the Budget 2026 process." .
+  rdf:predicate cardano:supportsKPI ;
+  rdf:object n:kpi-tvl ;
+  dcterms:description "Targets 10× TVL growth via iUSDt (tokenized Treasuries), xBTC collateral, and Midnight shielded liquidity." .
+
+n:bp-indigo-v2030rs cardano:supportsKPI n:kpi-monthly-transactions .
+[] a rdf:Statement ;
+  rdf:subject n:bp-indigo-v2030rs ;
+  rdf:predicate cardano:supportsKPI ;
+  rdf:object n:kpi-monthly-transactions ;
+  dcterms:description "Driven by mint/burn, loan, redemption, and shielded activity from the three MVPs." .
+
+n:bp-indigo-v2030rs cardano:supportsKPI n:kpi-mau .
+[] a rdf:Statement ;
+  rdf:subject n:bp-indigo-v2030rs ;
+  rdf:predicate cardano:supportsKPI ;
+  rdf:object n:kpi-mau ;
+  dcterms:description "Expanded by onboarding corporate treasuries, Bitcoin holders, and privacy-seeking institutions." .
+
+# -- Work package and budget ----------------------------------------------
+
+n:bp-indigo-v2030rs cardano:hasWorkPackage n:wp-indigo-rwa-compliance .
+
+n:wp-indigo-rwa-compliance a cardano:WorkPackage ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "wp-indigo-rwa-compliance" ;
+  rdfs:label "WP1 — RWA Compliance: Legal, Compliance & Entity Setup" ;
+  gb:group gbgroup:concepts ;
+  cardano:wpAdaAmount "3850000"^^xsd:decimal ;
+  cardano:proposalNature "Non-technical" ;
+  cardano:initiativeStatus "New Initiative" ;
+  dcterms:description "Establishment of Indigo Finance Corp and any wholly-owned subsidiaries, the legal/regulatory framework, jurisdictional licensing, and mission-critical service provider relationships (including custody) required for institutional tokenized RWA issuance (iUSDt). Total work-package budget: 3,850,000 ADA / $1,155,000 (ADA/USD 0.30)." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:wp-indigo-rwa-compliance cardano:hasBudgetLineItem n:bli-indigo-legal-compliance .
+n:wp-indigo-rwa-compliance cardano:hasBudgetLineItem n:bli-indigo-development .
+
+n:bli-indigo-legal-compliance a cardano:BudgetLineItem ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "bli-indigo-legal-compliance" ;
+  rdfs:label "Indigo line — Legal & Compliance" ;
+  gb:group gbgroup:concepts ;
+  cardano:lineItemAdaAmount "2300000"^^xsd:decimal ;
+  dcterms:description "Legal & Compliance for RWA Compliance: 2,300,000 ADA / $690,000 (ADA/USD 0.30)." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+n:bli-indigo-legal-compliance cardano:lineItemCategory n:cost-category-legal-compliance .
+
+n:bli-indigo-development a cardano:BudgetLineItem ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "bli-indigo-development" ;
+  rdfs:label "Indigo line — Development (RWA Core, BTC DeFi, Midnight, Audits & Open Tooling)" ;
+  gb:group gbgroup:concepts ;
+  cardano:lineItemAdaAmount "1550000"^^xsd:decimal ;
+  dcterms:description "Development for RWA Core, BTC DeFi, Midnight, Audits & Open Tooling: 1,550,000 ADA / $465,000 (ADA/USD 0.30)." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+n:bli-indigo-development cardano:lineItemCategory n:cost-category-development .
+
+n:bp-indigo-v2030rs cardano:hasBudgetLineItem n:bli-indigo-intersect-fee .
+n:bli-indigo-intersect-fee a cardano:BudgetLineItem ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "bli-indigo-intersect-fee" ;
+  rdfs:label "Indigo line — Intersect Budget Administration fee" ;
+  gb:group gbgroup:concepts ;
+  cardano:lineItemAdaAmount "115500"^^xsd:decimal ;
+  dcterms:description "Intersect Budget Administration fee: 115,500 ADA / $34,650 (ADA/USD 0.30)." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+n:bli-indigo-intersect-fee cardano:lineItemPerformedBy n:org-intersect .
+
+# -- Repayment clause -----------------------------------------------------
+
+n:bp-indigo-v2030rs cardano:hasRepaymentClause n:repay-indigo-v2030rs .
+
+n:repay-indigo-v2030rs a cardano:RepaymentClause ;
+  a gb:Node ;
+  a gbkind:mechanism ;
+  gb:nodeId "repay-indigo-v2030rs" ;
+  rdfs:label "Indigo V2030RS — 10% perpetual revenue share" ;
+  gb:group gbgroup:mechanisms ;
+  dcterms:description "10% of all net new protocol revenue generated from the products developed through this proposal (Institutional Tokenized RWAs / iUSDt, BTC DeFi Primitives, Shielded iAssets on Midnight) flows back to the Cardano Treasury perpetually from day one of each product go-live, executed via the V2030RS framework through quarterly auditable on-chain transfers, with no sunset clause or cap." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+n:repay-indigo-v2030rs cardano:repaysToTreasury n:treasury-budgeting .
+
+# -- Comment thread -------------------------------------------------------
+
+n:bp-indigo-v2030rs cardano:hasComment n:comment-indigo-1 .
+
+n:comment-indigo-1 a cardano:ProposalComment ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "comment-indigo-1" ;
+  rdfs:label "Comment — '-256' on Indigo (timing concern)" ;
+  gb:group gbgroup:concepts ;
+  cardano:commentBy "-256 (stake1...4nqmkm)" ;
+  cardano:commentPostedOn "2026-04-21T02:18:00Z"^^xsd:dateTime ;
+  dcterms:description "The proposal is much needed for Cardano ecosystem as we are not able to attract new users. Integrating with Bitcoin DeFi might bring new liquidity. But timing is wrong: ADA is at multi-year low and selling ADA at these levels to fund development would be throwing away money. Suggests waiting at least a year." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+# -- Domain anchors and deliverables (existing structure preserved) -------
 
 n:bp-indigo-v2030rs cardano:deliversArtifact n:iusdt .
 [] a rdf:Statement ;
@@ -94,30 +218,20 @@ n:btc-fi-market cardano:denominatedIn n:btc .
   rdf:object n:btc ;
   dcterms:description "The BTC-Fi market component uses Bitcoin as the denominating asset, bringing external BTC liquidity into Indigo on Cardano." .
 
-# -- Nodes ----------------------------------------------------------------
+# -- Domain nodes (proposer org + deliverables) ---------------------------
 
-n:bp-indigo-v2030rs
-  dcterms:description "Cardano Budget 2026 proposal requesting 3,965,500 ADA (USD ~1.19M @ 0.30). Four-track scope: (1) iUSDt — institutional-grade tokenized RWA stablecoin linking Cardano with institutional liquidity funds; (2) Bitcoin DeFi markets on Indigo; (3) shielded iAssets on partner-chain ecosystems; (4) V2030RS — a landmark revenue-sharing model with the Cardano Treasury. Submitted on 20/04/2026. Read Proposal: https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026/69e63a4ed6a29288536b11fc" ;
-  gb:group gbgroup:proposals ;
-  rdfs:label "Budget 2026 Proposal — Indigo V2030RS / iUSDt" ;
-  gb:nodeId "bp-indigo-v2030rs" ;
-  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-  a gbkind:proposal ;
+n:org-indigo-foundation a cardano:Proposer ;
   a gb:Node ;
-  foaf:page <https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026/69e63a4ed6a29288536b11fc> .
-
-n:org-indigo-foundation
-  dcterms:description "Indigo Foundation — proposer of the V2030RS / iUSDt / BTC-Fi / shielded-iAsset package to Cardano Budget 2026." ;
-  gb:group gbgroup:organizations ;
-  rdfs:label "Indigo Foundation" ;
-  gb:nodeId "org-indigo-foundation" ;
-  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
   a gbkind:actor ;
-  a gb:Node ;
+  gb:nodeId "org-indigo-foundation" ;
+  rdfs:label "Indigo Foundation" ;
+  gb:group gbgroup:organizations ;
+  dcterms:description "Indigo Foundation — proposer of the V2030RS / iUSDt / BTC-Fi / shielded-iAsset package to Cardano Budget 2026. Operator of Indigo Protocol on Cardano: cumulative protocol revenue >$8.55M USD since Indigo Protocol 2.0 launched in 04/2024 (mint/burn fees, redemptions, interest payments). Prior funding: multiple rounds through Cardano Catalyst." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
   foaf:page <https://indigoprotocol.io/> .
 
 n:iusdt
-  dcterms:description "iUSDt — institutional-grade tokenized RWA stablecoin proposed by Indigo. Collateralised through institutional liquidity funds rather than on-chain overcollateralisation. Positioned as Cardano's first bridge into institutional RWA liquidity." ;
+  dcterms:description "iUSDt — institutional-grade tokenized RWA stablecoin proposed by Indigo. Collateralised through institutional liquidity funds rather than on-chain overcollateralisation. Positioned as Cardano's first bridge into institutional RWA liquidity. Backed by short-duration U.S. Treasuries per Section 2.1 of the proposal." ;
   gb:group gbgroup:protocols ;
   rdfs:label "iUSDt" ;
   gb:nodeId "iusdt" ;
@@ -135,7 +249,7 @@ n:rwa
   a gb:Node .
 
 n:v2030rs-revenue-share
-  dcterms:description "V2030RS — the revenue-sharing mechanism the Indigo proposal introduces as a structural alternative to one-way treasury grants. A portion of protocol revenue flows back to the Cardano Treasury, making the ADA ask a partnership rather than a grant." ;
+  dcterms:description "V2030RS — the revenue-sharing mechanism the Indigo proposal introduces as a structural alternative to one-way treasury grants. Up to 10% of net protocol revenue from the funded products flows back to the Cardano Treasury perpetually from day one, with quarterly on-chain transfers and no sunset clause." ;
   gb:group gbgroup:mechanisms ;
   rdfs:label "V2030RS Revenue-Share" ;
   gb:nodeId "v2030rs-revenue-share" ;
@@ -144,7 +258,7 @@ n:v2030rs-revenue-share
   a gb:Node .
 
 n:shielded-iasset
-  dcterms:description "Shielded iAsset — a privacy-preserving synthetic asset issued on partner-chain ecosystems, so that iAsset holdings and flows are confidential while still settling against Cardano via the partner-chain path." ;
+  dcterms:description "Shielded iAsset — a privacy-preserving synthetic asset issued on Midnight (Cardano's confidentiality partner chain), so that iAsset holdings and flows are confidential while still settling against Cardano via the partner-chain path." ;
   gb:group gbgroup:concepts ;
   rdfs:label "Shielded iAsset" ;
   gb:nodeId "shielded-iasset" ;
@@ -153,7 +267,7 @@ n:shielded-iasset
   a gb:Node .
 
 n:btc-fi-market
-  dcterms:description "Indigo's Bitcoin DeFi market — a venue for BTC-denominated positions that routes external Bitcoin liquidity into the Cardano DeFi stack via Indigo." ;
+  dcterms:description "Indigo's Bitcoin DeFi market — a venue for BTC-denominated positions that routes external Bitcoin liquidity into the Cardano DeFi stack via Indigo, using xBTC collateral per Section 2.2 of the proposal." ;
   gb:group gbgroup:protocols ;
   rdfs:label "BTC-Fi Market" ;
   gb:nodeId "btc-fi-market" ;

--- a/data/rdf/budget-2026/partner-chain-factory.ttl
+++ b/data/rdf/budget-2026/partner-chain-factory.ttl
@@ -1,5 +1,6 @@
 @prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix foaf:    <http://xmlns.com/foaf/0.1/> .
 @prefix gb:      <https://lambdasistemi.github.io/graph-browser/vocab/terms#> .
@@ -11,109 +12,458 @@
 
 # =========================================================================
 #  Cardano Budget 2026 — Proposal: Partner Chain Factory (Ouroboros Tachýs)
-#  Proposer: Ensurable Systems Ltd  |  Request: 13,150,479 ADA
+#  Proposer: Ensurable Systems Ltd (lead, six-partner consortium)
+#  Request: 13,150,479 ADA
 #  https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026/69e8c0e2ae91c89d305701f5
 # =========================================================================
 
-# -- Edges ----------------------------------------------------------------
+# -- Proposal-level facts --------------------------------------------------
 
-n:bp-partner-chain-factory cardano:submittedBy n:org-ensurable-systems .
+n:bp-partner-chain-factory a cardano:BudgetProposal ;
+  a gb:Node ;
+  a gbkind:proposal ;
+  gb:nodeId "bp-partner-chain-factory" ;
+  rdfs:label "Budget 2026 Proposal — Partner Chain Factory (Ouroboros Tachýs)" ;
+  gb:group gbgroup:proposals ;
+  cardano:proposalIdentifier "69e8c0e2ae91c89d305701f5" ;
+  cardano:requestedAdaAmount "13150479"^^xsd:decimal ;
+  cardano:requestedUsdAmount "3287620"^^xsd:decimal ;
+  cardano:adaUsdRate "0.25"^^xsd:decimal ;
+  cardano:estimatedDurationMonths "15"^^xsd:integer ;
+  cardano:submittedOn "2026-04-22T12:36:00Z"^^xsd:dateTime ;
+  cardano:applicantType "Company" ;
+  dcterms:description "15-month, six-partner consortium delivering an open-source Partner Chain Factory built on the Ouroboros Tachýs consensus variant: 1-2s confirmation, ~40× mainnet throughput, formal security analysis, automated deployment ≤4h, Cardano⇄partner-chain bridge with independent security audit, complete tooling and documentation, and two demonstrators (Vector internal testnet then Vector mainnet). Toolkit handed over to Intersect-maintained Cardano repositories at project close. Surplus ADA from FX above $0.25 returned to treasury." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026/69e8c0e2ae91c89d305701f5> ;
+  rdfs:seeAlso <https://github.com/cardano-foundation/CIPs/pull/1149> .
+
+n:bp-partner-chain-factory cardano:partOfBudgetProcess n:cardano-budget-2026 .
+n:bp-partner-chain-factory cardano:proposedBy n:org-ensurable-systems .
+n:bp-partner-chain-factory cardano:administeredBy n:org-intersect .
+
+n:bp-partner-chain-factory cardano:alignsWithPillar n:pillar-1-infrastructure .
+n:bp-partner-chain-factory cardano:alignsWithPillar n:pillar-2-adoption .
+n:bp-partner-chain-factory cardano:alignsWithPillar n:pillar-4-community .
+n:bp-partner-chain-factory cardano:alignsWithPillar n:pillar-5-sustainability .
+
+n:bp-partner-chain-factory cardano:supportsKPI n:kpi-tvl .
+n:bp-partner-chain-factory cardano:supportsKPI n:kpi-monthly-transactions .
+n:bp-partner-chain-factory cardano:supportsKPI n:kpi-mau .
+n:bp-partner-chain-factory cardano:supportsKPI n:kpi-annual-protocol-revenue .
 [] a rdf:Statement ;
   rdf:subject n:bp-partner-chain-factory ;
-  rdf:predicate cardano:submittedBy ;
-  rdf:object n:org-ensurable-systems ;
-  dcterms:description "Ensurable Systems Ltd submitted the Partner Chain Factory proposal to Cardano Budget 2026 on 2026-04-22." .
+  rdf:predicate cardano:supportsKPI ;
+  rdf:object n:kpi-annual-protocol-revenue ;
+  dcterms:description "Five active partner chains at base estimate would contribute 150,000-250,000 ADA annually in direct mainnet fee revenue (4-7% of the current 3.5M ADA baseline). Bridge transactions, settlement anchoring and SPO registration are the three structural channels." .
 
-n:bp-partner-chain-factory cardano:fundingFrom n:treasury-budgeting .
-[] a rdf:Statement ;
-  rdf:subject n:bp-partner-chain-factory ;
-  rdf:predicate cardano:fundingFrom ;
-  rdf:object n:treasury-budgeting ;
-  dcterms:description "The proposal requests 13,150,479 ADA (~USD 3.29M at 0.25) from the Cardano Treasury via the Budget 2026 process." .
+# -- New KPIs proposed by this proposal -----------------------------------
+
+n:bp-partner-chain-factory cardano:proposesNewKPI n:kpi-active-partner-chains .
+n:bp-partner-chain-factory cardano:proposesNewKPI n:kpi-cross-chain-bridge-volume .
+n:bp-partner-chain-factory cardano:proposesNewKPI n:kpi-ecosystem-builder-pipeline .
+
+n:kpi-active-partner-chains a cardano:StrategyKPI ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "kpi-active-partner-chains" ;
+  rdfs:label "KPI — Active Partner Chains" ;
+  gb:group gbgroup:concepts ;
+  cardano:kpiCurrentValue "2 (Vector and Midnight)" ;
+  cardano:kpiTargetValue "10 by 2030" ;
+  dcterms:description "Number of monthly active Cardano-derived partner chains. Proposed by the Partner Chain Factory proposal as a missing framework KPI." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:kpi-cross-chain-bridge-volume a cardano:StrategyKPI ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "kpi-cross-chain-bridge-volume" ;
+  rdfs:label "KPI — Cross-chain Bridge Volume (monthly)" ;
+  gb:group gbgroup:concepts ;
+  cardano:kpiCurrentValue "Not systematically tracked" ;
+  cardano:kpiTargetValue "≥$50M monthly by 2030" ;
+  dcterms:description "Total ADA-equivalent value bridged between Cardano mainnet and partner chains or external chains per month. Required so the framework can distinguish a thriving partner-chain ecosystem from a fragmented one where value leaks rather than recirculates." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:kpi-ecosystem-builder-pipeline a cardano:StrategyKPI ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "kpi-ecosystem-builder-pipeline" ;
+  rdfs:label "KPI — Ecosystem Builder Pipeline" ;
+  gb:group gbgroup:concepts ;
+  cardano:kpiCurrentValue "1 (AFF/Vector)" ;
+  cardano:kpiTargetValue "20 by 2030" ;
+  dcterms:description "Number of distinct partner-chain builder teams in active engagement with the Cardano partner-chain ecosystem." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+# -- Six-partner consortium ------------------------------------------------
+
+n:org-ensurable-systems a cardano:Proposer ;
+  a gb:Node ;
+  a gbkind:actor ;
+  gb:nodeId "org-ensurable-systems" ;
+  rdfs:label "Ensurable Systems (ES)" ;
+  gb:group gbgroup:organizations ;
+  dcterms:description "Lead entity for the Partner Chain Factory consortium. Founders: Kevin Hammond PhD (Technical Delivery Lead) and Philipp Kant PhD. Team experience: built the Cardano node, implemented Ouroboros, delivered every hard fork from Byron through Plomin." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://ensurable.systems> .
+
+n:org-well-typed a cardano:Proposer ;
+  a gb:Node ;
+  a gbkind:actor ;
+  gb:nodeId "org-well-typed" ;
+  rdfs:label "Well Typed (WT)" ;
+  gb:group gbgroup:organizations ;
+  dcterms:description "Consortium partner. Lead: Duncan Coutts. Long-standing Haskell consultancy with deep IOG codebase familiarity; leads WP2 (Tachýs design and implementation)." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://well-typed.com/> .
+
+n:org-pnsol a cardano:Proposer ;
+  a gb:Node ;
+  a gbkind:actor ;
+  gb:nodeId "org-pnsol" ;
+  rdfs:label "Predictable Network Solutions (PNSol)" ;
+  gb:group gbgroup:organizations ;
+  dcterms:description "Consortium partner. Network performance and adversarial-robustness specialists; leads WP3 (system integration, deployment automation, DDoS validation)." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://www.pnsol.com/> .
+
+n:org-apex-fusion-foundation a cardano:Proposer ;
+  a gb:Node ;
+  a gbkind:actor ;
+  gb:nodeId "org-apex-fusion-foundation" ;
+  rdfs:label "Apex Fusion Foundation (AFF)" ;
+  gb:group gbgroup:organizations ;
+  dcterms:description "Consortium partner. Christopher Greenwood (Programme Delivery Lead, COO). Operator of the Vector chain — launched late 2025 as the first Cardano-derived partner chain in production. Has previously received Cardano ecosystem funding for Vector." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://foundation.apexfusion.org/> .
+
+n:org-hal8 a cardano:Proposer ;
+  a gb:Node ;
+  a gbkind:actor ;
+  gb:nodeId "org-hal8" ;
+  rdfs:label "HAL8" ;
+  gb:group gbgroup:organizations ;
+  dcterms:description "Consortium partner. Leads WP5 (tooling standards), WP6 (documentation/knowledge management), WP7 (demonstrators) and WP8 (dissemination)." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://hal8.io/> .
+
+n:org-ethernal a cardano:Proposer ;
+  a gb:Node ;
+  a gbkind:actor ;
+  gb:nodeId "org-ethernal" ;
+  rdfs:label "Ethernal (ETNL)" ;
+  gb:group gbgroup:organizations ;
+  dcterms:description "Consortium partner. Leads WP4 (Cardano ⇄ Tachýs ⇄ EVM bridge). Existing relationships across Polygon, Avail and Cosmos for EVM-side ecosystem outreach." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://ethernal.tech/> .
+
+# -- Programme milestones MS1-MS9 (month markers) -------------------------
+
+n:pcf-ms1 a cardano:WorkPackageMilestone ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "pcf-ms1" ;
+  rdfs:label "PCF Programme Milestone MS1 (M1)" ;
+  gb:group gbgroup:concepts ;
+  cardano:milestoneMonth "1"^^xsd:integer ;
+  dcterms:description "Project kickoff: integrated delivery plan, partner support environment, dissemination website live." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:pcf-ms2 a cardano:WorkPackageMilestone ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "pcf-ms2" ;
+  rdfs:label "PCF Programme Milestone MS2 (M3)" ;
+  gb:group gbgroup:concepts ;
+  cardano:milestoneMonth "3"^^xsd:integer ;
+  dcterms:description "Tachýs CIP accepted; cardano-ledger spec PR submitted; bridge architecture D4.1 published." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:pcf-ms3 a cardano:WorkPackageMilestone ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "pcf-ms3" ;
+  rdfs:label "PCF Programme Milestone MS3 (M5)" ;
+  gb:group gbgroup:concepts ;
+  cardano:milestoneMonth "5"^^xsd:integer ;
+  dcterms:description "Tooling-incompatibilities CPS published (D5.1); first CF outreach session for wallet/explorer teams." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:pcf-ms4 a cardano:WorkPackageMilestone ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "pcf-ms4" ;
+  rdfs:label "PCF Programme Milestone MS4 (M6)" ;
+  gb:group gbgroup:concepts ;
+  cardano:milestoneMonth "6"^^xsd:integer ;
+  dcterms:description "First builder workshop; UTXO-to-UTXO bridge operational; PNSol no-Praos-regression report." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:pcf-ms5 a cardano:WorkPackageMilestone ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "pcf-ms5" ;
+  rdfs:label "PCF Programme Milestone MS5 (M8)" ;
+  gb:group gbgroup:concepts ;
+  cardano:milestoneMonth "8"^^xsd:integer ;
+  dcterms:description "Genesis quick-start ≤4h: end-to-end automated deployment of a new Tachýs partner chain in the current Cardano era." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:pcf-ms6 a cardano:WorkPackageMilestone ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "pcf-ms6" ;
+  rdfs:label "PCF Programme Milestone MS6 (M9)" ;
+  gb:group gbgroup:concepts ;
+  cardano:milestoneMonth "9"^^xsd:integer ;
+  dcterms:description "Mid-programme review (D1.2 quarterly DRep report); UTXO-to-EVM bridge for EVM builder access." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:pcf-ms7 a cardano:WorkPackageMilestone ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "pcf-ms7" ;
+  rdfs:label "PCF Programme Milestone MS7 (M12)" ;
+  gb:group gbgroup:concepts ;
+  cardano:milestoneMonth "12"^^xsd:integer ;
+  dcterms:description "Implementation merged with no Praos regressions; bridge audited (all critical/high resolved); Tachýs formal security analysis published; tooling CIP accepted." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:pcf-ms8 a cardano:WorkPackageMilestone ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "pcf-ms8" ;
+  rdfs:label "PCF Programme Milestone MS8 (M13)" ;
+  gb:group gbgroup:concepts ;
+  cardano:milestoneMonth "13"^^xsd:integer ;
+  dcterms:description "Vector internal testnet running Tachýs: deployment ≤4h; throughput ≥10× mainnet; finality ≤5s; slot fill rate ≥95%; second builder workshop." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:pcf-ms9 a cardano:WorkPackageMilestone ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "pcf-ms9" ;
+  rdfs:label "PCF Programme Milestone MS9 (M15)" ;
+  gb:group gbgroup:concepts ;
+  cardano:milestoneMonth "15"^^xsd:integer ;
+  dcterms:description "Project close: Tachýs deployed to Vector mainnet (no unplanned downtime); upstream PR submitted to Intersect-maintained node repo; institutional reference configuration reviewed; documentation portal handed over to Intersect; ≥3 external builder teams engaged; surplus ADA from FX returned to treasury." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+# -- Work packages and budget --------------------------------------------
+
+n:bp-partner-chain-factory cardano:hasWorkPackage n:wp-pcf-1-management .
+n:bp-partner-chain-factory cardano:hasWorkPackage n:wp-pcf-2-tachys-design .
+n:bp-partner-chain-factory cardano:hasWorkPackage n:wp-pcf-3-system-integration .
+n:bp-partner-chain-factory cardano:hasWorkPackage n:wp-pcf-4-bridging .
+n:bp-partner-chain-factory cardano:hasWorkPackage n:wp-pcf-5-tooling-standards .
+n:bp-partner-chain-factory cardano:hasWorkPackage n:wp-pcf-6-documentation .
+n:bp-partner-chain-factory cardano:hasWorkPackage n:wp-pcf-7-demonstrators .
+n:bp-partner-chain-factory cardano:hasWorkPackage n:wp-pcf-8-dissemination .
+
+n:wp-pcf-1-management a cardano:WorkPackage ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "wp-pcf-1-management" ;
+  rdfs:label "PCF WP1 — Project Management and Evaluation" ;
+  gb:group gbgroup:concepts ;
+  cardano:wpAdaAmount "2105828.9"^^xsd:decimal ;
+  cardano:proposalNature "Non-technical" ;
+  cardano:initiativeStatus "New Initiative" ;
+  dcterms:description "Delivery coordination across six partners and 15 months: integrated delivery plan, RAID log, monthly Cardano Forum updates, quarterly DRep reports, Intersect upstream contribution management, builder ecosystem engagement, final evaluation. 28.30 person-months — 16% of total project effort, framed as the insurance premium on a 12.7M ADA technical investment." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+n:wp-pcf-1-management cardano:hasWorkPackageMilestone n:pcf-ms1 .
+n:wp-pcf-1-management cardano:hasWorkPackageMilestone n:pcf-ms2 .
+n:wp-pcf-1-management cardano:hasWorkPackageMilestone n:pcf-ms6 .
+n:wp-pcf-1-management cardano:hasWorkPackageMilestone n:pcf-ms9 .
+
+n:wp-pcf-2-tachys-design a cardano:WorkPackage ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "wp-pcf-2-tachys-design" ;
+  rdfs:label "PCF WP2 — Ouroboros Tachýs Design and Implementation" ;
+  gb:group gbgroup:concepts ;
+  cardano:wpAdaAmount "1333328"^^xsd:decimal ;
+  cardano:proposalNature "Technical" ;
+  cardano:initiativeStatus "New Initiative" ;
+  dcterms:description "CIP accepted by M3; production-quality implementation; consensus selection mechanism (Praos/Tachýs toggle) with no Praos regressions; stabilised parameter surface; genesis quick-start in current era; formal security analysis. Led by Well Typed." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+n:wp-pcf-2-tachys-design cardano:hasWorkPackageMilestone n:pcf-ms1 .
+n:wp-pcf-2-tachys-design cardano:hasWorkPackageMilestone n:pcf-ms2 .
+n:wp-pcf-2-tachys-design cardano:hasWorkPackageMilestone n:pcf-ms4 .
+n:wp-pcf-2-tachys-design cardano:hasWorkPackageMilestone n:pcf-ms5 .
+n:wp-pcf-2-tachys-design cardano:hasWorkPackageMilestone n:pcf-ms7 .
+
+n:wp-pcf-3-system-integration a cardano:WorkPackage ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "wp-pcf-3-system-integration" ;
+  rdfs:label "PCF WP3 — System Integration" ;
+  gb:group gbgroup:concepts ;
+  cardano:wpAdaAmount "1569994"^^xsd:decimal ;
+  cardano:proposalNature "Technical" ;
+  cardano:initiativeStatus "New Initiative" ;
+  dcterms:description "Automated deployment tooling (local + AWS) in <4h; clean integration into Cardano node; Intersect CI/CD conformance; integration test suite; performance validation; empirical validation of DDoS mitigations; production-readiness knowledge base. Led by PNSol." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+n:wp-pcf-3-system-integration cardano:hasWorkPackageMilestone n:pcf-ms4 .
+n:wp-pcf-3-system-integration cardano:hasWorkPackageMilestone n:pcf-ms5 .
+n:wp-pcf-3-system-integration cardano:hasWorkPackageMilestone n:pcf-ms7 .
+
+n:wp-pcf-4-bridging a cardano:WorkPackage ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "wp-pcf-4-bridging" ;
+  rdfs:label "PCF WP4 — Cardano Bridging Technology" ;
+  gb:group gbgroup:concepts ;
+  cardano:wpAdaAmount "3316655"^^xsd:decimal ;
+  cardano:proposalNature "Technical" ;
+  cardano:initiativeStatus "New Initiative" ;
+  dcterms:description "The largest WP at 35 person-months. Production-grade open-source Cardano⇄Tachýs⇄EVM bridge: lock/burn + mint/unlock logic reviewed by ES/WT, protocol-level threat model, independent security audit with all critical/high resolved, UTXO-to-EVM to open EVM-builder access. All code open-sourced. Bridge latency target ≤60s. Led by Ethernal." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+n:wp-pcf-4-bridging cardano:hasWorkPackageMilestone n:pcf-ms2 .
+n:wp-pcf-4-bridging cardano:hasWorkPackageMilestone n:pcf-ms4 .
+n:wp-pcf-4-bridging cardano:hasWorkPackageMilestone n:pcf-ms6 .
+n:wp-pcf-4-bridging cardano:hasWorkPackageMilestone n:pcf-ms7 .
+
+n:wp-pcf-5-tooling-standards a cardano:WorkPackage ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "wp-pcf-5-tooling-standards" ;
+  rdfs:label "PCF WP5 — Partner Chain Tooling Standards and Ecosystem Integration" ;
+  gb:group gbgroup:concepts ;
+  cardano:wpAdaAmount "1166662"^^xsd:decimal ;
+  cardano:proposalNature "Technical" ;
+  cardano:initiativeStatus "New Initiative" ;
+  dcterms:description "CPS describing tooling incompatibilities; CIP defining a machine-readable network configuration schema; interface conventions; bridge integration conventions (based on D4.1); conformance checklist; validate against Vector testnet demonstrator. ≥3 wallet/explorer teams engaged. Led by HAL8." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+n:wp-pcf-5-tooling-standards cardano:hasWorkPackageMilestone n:pcf-ms3 .
+n:wp-pcf-5-tooling-standards cardano:hasWorkPackageMilestone n:pcf-ms7 .
+
+n:wp-pcf-6-documentation a cardano:WorkPackage ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "wp-pcf-6-documentation" ;
+  rdfs:label "PCF WP6 — Documentation and Knowledge Management" ;
+  gb:group gbgroup:concepts ;
+  cardano:wpAdaAmount "562497.75"^^xsd:decimal ;
+  cardano:proposalNature "Non-technical" ;
+  cardano:initiativeStatus "New Initiative" ;
+  dcterms:description "Unified documentation portal from M1; formal spec PR to cardano-ledger; protocol design docs; developer/implementation docs in machine-readable formats (for agentic AI); end-to-end builder manuals (D6.5) tested by an external builder; portal handover to Intersect at project close. Led by HAL8." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+n:wp-pcf-6-documentation cardano:hasWorkPackageMilestone n:pcf-ms2 .
+n:wp-pcf-6-documentation cardano:hasWorkPackageMilestone n:pcf-ms3 .
+n:wp-pcf-6-documentation cardano:hasWorkPackageMilestone n:pcf-ms7 .
+n:wp-pcf-6-documentation cardano:hasWorkPackageMilestone n:pcf-ms9 .
+
+n:wp-pcf-7-demonstrators a cardano:WorkPackage ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "wp-pcf-7-demonstrators" ;
+  rdfs:label "PCF WP7 — Tachýs Demonstrators" ;
+  gb:group gbgroup:concepts ;
+  cardano:wpAdaAmount "1903326"^^xsd:decimal ;
+  cardano:proposalNature "Technical" ;
+  cardano:initiativeStatus "New Initiative" ;
+  dcterms:description "Integrate Tachýs into Vector internal testnet (validate KPIs); public testnet on PreProd/Preview with explorer/bridge/CLI; gate T7.2 on ≥95% slot fill over 4 weeks + no critical RAID + audit complete; deploy to Vector mainnet; institutional reference configuration reviewed by external institutional contact. Led by HAL8." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+n:wp-pcf-7-demonstrators cardano:hasWorkPackageMilestone n:pcf-ms8 .
+n:wp-pcf-7-demonstrators cardano:hasWorkPackageMilestone n:pcf-ms9 .
+
+n:wp-pcf-8-dissemination a cardano:WorkPackage ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "wp-pcf-8-dissemination" ;
+  rdfs:label "PCF WP8 — Dissemination, Exploitation and Sustainability" ;
+  gb:group gbgroup:concepts ;
+  cardano:wpAdaAmount "809164.15"^^xsd:decimal ;
+  cardano:proposalNature "Non-technical" ;
+  cardano:initiativeStatus "New Initiative" ;
+  dcterms:description "Upstream PR to Intersect-maintained node repo; open-source bridge/tooling release; website + content programme + Cardano Foundation as amplification partner; two builder workshops (M6, M13); EVM ecosystem outreach via ETNL's Polygon/Avail/Cosmos relationships; structured exploitation analysis (RWA, DeFi, supply chain provenance, payments) reviewed externally; four-condition toolkit handover to Intersect. Led by HAL8 (T8.1 ES/WT)." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+n:wp-pcf-8-dissemination cardano:hasWorkPackageMilestone n:pcf-ms1 .
+n:wp-pcf-8-dissemination cardano:hasWorkPackageMilestone n:pcf-ms2 .
+n:wp-pcf-8-dissemination cardano:hasWorkPackageMilestone n:pcf-ms4 .
+n:wp-pcf-8-dissemination cardano:hasWorkPackageMilestone n:pcf-ms6 .
+n:wp-pcf-8-dissemination cardano:hasWorkPackageMilestone n:pcf-ms7 .
+n:wp-pcf-8-dissemination cardano:hasWorkPackageMilestone n:pcf-ms9 .
+
+n:bp-partner-chain-factory cardano:hasBudgetLineItem n:bli-pcf-intersect-fee .
+n:bli-pcf-intersect-fee a cardano:BudgetLineItem ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "bli-pcf-intersect-fee" ;
+  rdfs:label "PCF line — Intersect Budget Administration fee" ;
+  gb:group gbgroup:concepts ;
+  cardano:lineItemAdaAmount "383024"^^xsd:decimal ;
+  dcterms:description "Intersect Budget Administration fee: 383,024 ADA / $95,756 (ADA/USD 0.25)." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+n:bli-pcf-intersect-fee cardano:lineItemPerformedBy n:org-intersect .
+
+# -- Repayment clause -----------------------------------------------------
+
+n:bp-partner-chain-factory cardano:hasRepaymentClause n:repay-pcf-fx-and-unspent .
+
+n:repay-pcf-fx-and-unspent a cardano:RepaymentClause ;
+  a gb:Node ;
+  a gbkind:mechanism ;
+  gb:nodeId "repay-pcf-fx-and-unspent" ;
+  rdfs:label "PCF — surplus from FX above $0.25 + unspent ADA" ;
+  gb:group gbgroup:mechanisms ;
+  dcterms:description "Drawdown happens at actual conversion rates. Any positive difference between the assumed $0.25 rate and the rate at drawdown is identified at final reconciliation and returned in full at project close. Unspent ADA is returned at the same time." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+n:repay-pcf-fx-and-unspent cardano:repaysToTreasury n:treasury-budgeting .
+
+# -- Comment thread -------------------------------------------------------
+
+n:bp-partner-chain-factory cardano:hasComment n:comment-pcf-1 .
+
+n:comment-pcf-1 a cardano:ProposalComment ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "comment-pcf-1" ;
+  rdfs:label "Comment — Nimuë DRep on PCF (in favour)" ;
+  gb:group gbgroup:concepts ;
+  cardano:commentBy "Nimuë Lady of the Lake Pool (drep1y...6xdgl4)" ;
+  cardano:commentPostedOn "2026-04-22T13:00:00Z"^^xsd:dateTime ;
+  dcterms:description "In favor of this!" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+# -- Domain anchors and deliverables (existing structure preserved) -------
 
 n:bp-partner-chain-factory cardano:deliversArtifact n:partner-chain-factory-toolkit .
 [] a rdf:Statement ;
   rdf:subject n:bp-partner-chain-factory ;
   rdf:predicate cardano:deliversArtifact ;
   rdf:object n:partner-chain-factory-toolkit ;
-  dcterms:description "Deliverable is an open-source, Intersect-governed toolkit that lets builders deploy new Cardano-derived partner chains in hours rather than months." .
+  dcterms:description "Open-source toolkit that lets builders deploy new Cardano-derived partner chains in hours rather than months. Maintained inside the Intersect-governed Cardano codebase." .
 
 n:partner-chain-factory-toolkit cardano:builtOn n:ouroboros-tachys .
 [] a rdf:Statement ;
   rdf:subject n:partner-chain-factory-toolkit ;
   rdf:predicate cardano:builtOn ;
   rdf:object n:ouroboros-tachys ;
-  dcterms:description "The toolkit produces chains running Ouroboros Tachýs — a high-performance variant delivering 1–2 second block confirmation and ~40× mainnet throughput." .
+  dcterms:description "Toolkit ships chains running Ouroboros Tachýs — 1-2s confirmation, ~40× mainnet throughput." .
 
 n:ouroboros-tachys cardano:variantOf n:ouroboros-praos .
 [] a rdf:Statement ;
   rdf:subject n:ouroboros-tachys ;
   rdf:predicate cardano:variantOf ;
   rdf:object n:ouroboros-praos ;
-  dcterms:description "Ouroboros Tachýs is a performance-oriented variant of Ouroboros Praos, retaining Praos-equivalent security properties while increasing throughput and reducing confirmation latency." .
+  dcterms:description "Performance-oriented variant of Ouroboros Praos retaining Praos-equivalent security." .
 
 n:vector-chain cardano:builtOn n:ouroboros-tachys .
 [] a rdf:Statement ;
   rdf:subject n:vector-chain ;
   rdf:predicate cardano:builtOn ;
   rdf:object n:ouroboros-tachys ;
-  dcterms:description "Vector, launched late 2025 as the first Cardano-derived partner chain in production, is the reference validation of the Ouroboros Tachýs design the factory industrialises." .
+  dcterms:description "Vector — first Cardano-derived partner chain in production, late 2025; reference validation for the Tachýs design." .
 
 n:partner-chain-factory-toolkit cardano:produces n:partner-chain .
-[] a rdf:Statement ;
-  rdf:subject n:partner-chain-factory-toolkit ;
-  rdf:predicate cardano:produces ;
-  rdf:object n:partner-chain ;
-  dcterms:description "The factory emits partner-chain instances: application-specific chains that settle to Cardano mainnet and connect via production-grade bridging infrastructure." .
-
 n:partner-chain cardano:settlesOn n:cardano-mainnet .
-[] a rdf:Statement ;
-  rdf:subject n:partner-chain ;
-  rdf:predicate cardano:settlesOn ;
-  rdf:object n:cardano-mainnet ;
-  dcterms:description "Partner chains use Cardano mainnet as their settlement layer; their security is ultimately anchored to Cardano's consensus." .
-
 n:partner-chain cardano:requiresStakeIn n:ada .
-[] a rdf:Statement ;
-  rdf:subject n:partner-chain ;
-  rdf:predicate cardano:requiresStakeIn ;
-  rdf:object n:ada ;
-  dcterms:description "Partner chains built by the factory require ADA for stake, generating structural ADA demand independent of L1 transaction volume." .
-
 n:partner-chain cardano:connectsVia n:cardano-bridge .
-[] a rdf:Statement ;
-  rdf:subject n:partner-chain ;
-  rdf:predicate cardano:connectsVia ;
-  rdf:object n:cardano-bridge ;
-  dcterms:description "Partner chains produced by the factory ship with production-grade bridging infrastructure to move assets and messages between the partner chain and Cardano mainnet." .
-
 n:cardano-bridge gbedge:generates n:treasury-budgeting .
-[] a rdf:Statement ;
-  rdf:subject n:cardano-bridge ;
-  rdf:predicate gbedge:generates ;
-  rdf:object n:treasury-budgeting ;
-  dcterms:description "Bridging activity between partner chains and mainnet generates fees, contributing to treasury sustainability — part of the proposal's treasury-return argument." .
 
-# -- Nodes ----------------------------------------------------------------
-
-n:bp-partner-chain-factory
-  dcterms:description "Cardano Budget 2026 proposal requesting 13,150,479 ADA (USD ~3.29M @ 0.25) to build a reusable, open-source Partner Chain Factory. The factory bundles the Ouroboros Tachýs consensus variant, chain-bootstrapping tooling, and production-grade bridging so new partner chains can be deployed in hours rather than months, and started directly in the current Cardano era. The deliverable is to be open-source and maintained inside the Intersect-governed Cardano codebase. Submitted on 22/04/2026. Read Proposal: https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026/69e8c0e2ae91c89d305701f5" ;
-  gb:group gbgroup:proposals ;
-  rdfs:label "Budget 2026 Proposal — Partner Chain Factory" ;
-  gb:nodeId "bp-partner-chain-factory" ;
-  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-  a gbkind:proposal ;
-  a gb:Node ;
-  foaf:page <https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026/69e8c0e2ae91c89d305701f5> .
-
-n:org-ensurable-systems
-  dcterms:description "Ensurable Systems Ltd — proposer of the Partner Chain Factory proposal (Budget 2026). The team states it built the Cardano node, implemented Ouroboros, and delivered every hard fork from Byron through Plomin." ;
-  gb:group gbgroup:organizations ;
-  rdfs:label "Ensurable Systems Ltd" ;
-  gb:nodeId "org-ensurable-systems" ;
-  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-  a gbkind:actor ;
-  a gb:Node .
+# -- Domain nodes ---------------------------------------------------------
 
 n:partner-chain-factory-toolkit
   dcterms:description "Open-source toolkit delivered by the proposal: chain-bootstrapping templates, the Ouroboros Tachýs consensus implementation, and bridging infrastructure. Maintained within the Intersect-governed Cardano codebase; available to any builder without licence fee." ;
@@ -125,7 +475,7 @@ n:partner-chain-factory-toolkit
   a gb:Node .
 
 n:ouroboros-tachys
-  dcterms:description "A high-performance Ouroboros consensus variant targeting 1–2 second confirmation latency and ~40× Cardano mainnet throughput, while retaining Ouroboros security properties. Intended as the consensus engine for Cardano-derived partner chains produced by the factory." ;
+  dcterms:description "A high-performance Ouroboros consensus variant targeting 1-2 second confirmation latency and ~40× Cardano mainnet throughput. Designed to compose with Peras, Leios and Phalanx. Intended as the consensus engine for Cardano-derived partner chains produced by the factory." ;
   gb:group gbgroup:protocols ;
   rdfs:label "Ouroboros Tachýs" ;
   gb:nodeId "ouroboros-tachys" ;
@@ -153,7 +503,7 @@ n:partner-chain
   a gb:Node .
 
 n:vector-chain
-  dcterms:description "Vector — launched in late 2025 as the first Cardano-derived partner chain in production. Cited in the Partner Chain Factory proposal as the existence proof for the Ouroboros Tachýs design the factory industrialises." ;
+  dcterms:description "Vector — launched in late 2025 as the first Cardano-derived partner chain in production. Operated by Apex Fusion Foundation; the existence proof for the Ouroboros Tachýs design the factory industrialises." ;
   gb:group gbgroup:protocols ;
   rdfs:label "Vector Chain" ;
   gb:nodeId "vector-chain" ;

--- a/data/rdf/budget-2026/serviceplan-demand-engine.ttl
+++ b/data/rdf/budget-2026/serviceplan-demand-engine.ttl
@@ -1,5 +1,6 @@
 @prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix foaf:    <http://xmlns.com/foaf/0.1/> .
 @prefix gb:      <https://lambdasistemi.github.io/graph-browser/vocab/terms#> .
@@ -15,109 +16,278 @@
 #  https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026/69e21a177a2045bdd2281d1a
 # =========================================================================
 
-# -- Edges ----------------------------------------------------------------
+# -- Proposal-level facts --------------------------------------------------
 
-n:bp-serviceplan-demand-engine cardano:submittedBy n:org-serviceplan-group .
-[] a rdf:Statement ;
-  rdf:subject n:bp-serviceplan-demand-engine ;
-  rdf:predicate cardano:submittedBy ;
-  rdf:object n:org-serviceplan-group ;
-  dcterms:description "Serviceplan Group submitted the Marketing Powered Demand Engine proposal to Cardano Budget 2026 on 2026-04-20." .
-
-n:bp-serviceplan-demand-engine cardano:fundingFrom n:treasury-budgeting .
-[] a rdf:Statement ;
-  rdf:subject n:bp-serviceplan-demand-engine ;
-  rdf:predicate cardano:fundingFrom ;
-  rdf:object n:treasury-budgeting ;
-  dcterms:description "The proposal requests 20,871,418 ADA (~USD 3.55M at 0.17) from the Cardano Treasury via the Budget 2026 process." .
-
-n:bp-serviceplan-demand-engine cardano:deliversArtifact n:demand-engine .
-[] a rdf:Statement ;
-  rdf:subject n:bp-serviceplan-demand-engine ;
-  rdf:predicate cardano:deliversArtifact ;
-  rdf:object n:demand-engine ;
-  dcterms:description "Top-level deliverable is an enterprise demand-generation system positioning Cardano as 'The Blockchain for Serious Business'." .
-
-n:bp-serviceplan-demand-engine cardano:deliversArtifact n:cardano-hub .
-[] a rdf:Statement ;
-  rdf:subject n:bp-serviceplan-demand-engine ;
-  rdf:predicate cardano:deliversArtifact ;
-  rdf:object n:cardano-hub ;
-  dcterms:description "The proposal delivers the Cardano Hub — a central evidence-and-engagement environment for enterprise leads." .
-
-n:demand-engine cardano:targets n:enterprise-adoption .
-[] a rdf:Statement ;
-  rdf:subject n:demand-engine ;
-  rdf:predicate cardano:targets ;
-  rdf:object n:enterprise-adoption ;
-  dcterms:description "The demand engine is aimed at enterprise decision-makers — the segment the proposal argues is currently underserved by Cardano's go-to-market." .
-
-n:demand-engine cardano:implementsProcess n:demand-funnel .
-[] a rdf:Statement ;
-  rdf:subject n:demand-engine ;
-  rdf:predicate cardano:implementsProcess ;
-  rdf:object n:demand-funnel ;
-  dcterms:description "The demand engine operates through a three-stage Attention → Proof → Qualified Leads funnel." .
-
-n:demand-funnel cardano:validatesIn n:pilot-vertical-institutional-defi .
-[] a rdf:Statement ;
-  rdf:subject n:demand-funnel ;
-  rdf:predicate cardano:validatesIn ;
-  rdf:object n:pilot-vertical-institutional-defi ;
-  dcterms:description "Institutional DeFi is the V1 pilot vertical — first enterprise use case tested through the funnel." .
-
-n:demand-funnel cardano:validatesIn n:pilot-vertical-supply-chain .
-[] a rdf:Statement ;
-  rdf:subject n:demand-funnel ;
-  rdf:predicate cardano:validatesIn ;
-  rdf:object n:pilot-vertical-supply-chain ;
-  dcterms:description "Supply Chain Traceability is the V2 pilot vertical — activated after V1 KPI validation, subject to GMC / community alignment." .
-
-n:bp-serviceplan-demand-engine cardano:runsIn n:pilot-market-uk .
-[] a rdf:Statement ;
-  rdf:subject n:bp-serviceplan-demand-engine ;
-  rdf:predicate cardano:runsIn ;
-  rdf:object n:pilot-market-uk ;
-  dcterms:description "UK is one of three pilot markets for the 12-month campaign." .
-
-n:bp-serviceplan-demand-engine cardano:runsIn n:pilot-market-germany .
-[] a rdf:Statement ;
-  rdf:subject n:bp-serviceplan-demand-engine ;
-  rdf:predicate cardano:runsIn ;
-  rdf:object n:pilot-market-germany ;
-  dcterms:description "Germany is one of three pilot markets for the 12-month campaign." .
-
-n:bp-serviceplan-demand-engine cardano:runsIn n:pilot-market-switzerland .
-[] a rdf:Statement ;
-  rdf:subject n:bp-serviceplan-demand-engine ;
-  rdf:predicate cardano:runsIn ;
-  rdf:object n:pilot-market-switzerland ;
-  dcterms:description "Switzerland is one of three pilot markets for the 12-month campaign." .
-
-# -- Nodes ----------------------------------------------------------------
-
-n:bp-serviceplan-demand-engine
-  dcterms:description "Cardano Budget 2026 proposal requesting 20,871,418 ADA (USD ~3.55M @ 0.17). 12-month enterprise marketing pilot positioning Cardano as 'The Blockchain for Serious Business' through a three-stage funnel (Attention → Proof → Qualified Leads). Pilot verticals: Institutional DeFi (V1) and Supply Chain Traceability (V2). Pilot markets: UK, Germany, Switzerland. Targets 45M paid impressions, 320K native views, 300K Hub clicks. Budget €2,978,738, split 53% media / 47% agency. Submitted on 20/04/2026. Read Proposal: https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026/69e21a177a2045bdd2281d1a" ;
-  gb:group gbgroup:proposals ;
-  rdfs:label "Budget 2026 Proposal — Serviceplan Demand Engine" ;
-  gb:nodeId "bp-serviceplan-demand-engine" ;
-  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-  a gbkind:proposal ;
+n:bp-serviceplan-demand-engine a cardano:BudgetProposal ;
   a gb:Node ;
+  a gbkind:proposal ;
+  gb:nodeId "bp-serviceplan-demand-engine" ;
+  rdfs:label "Budget 2026 Proposal — Serviceplan Demand Engine" ;
+  gb:group gbgroup:proposals ;
+  cardano:proposalIdentifier "69e21a177a2045bdd2281d1a" ;
+  cardano:requestedAdaAmount "20871418"^^xsd:decimal ;
+  cardano:requestedUsdAmount "3548141"^^xsd:decimal ;
+  cardano:adaUsdRate "0.17"^^xsd:decimal ;
+  cardano:estimatedDurationMonths "12"^^xsd:integer ;
+  cardano:submittedOn "2026-04-20T06:39:00Z"^^xsd:dateTime ;
+  cardano:applicantType "Company" ;
+  dcterms:description "Cardano Budget 2026 proposal requesting 20,871,418 ADA (USD ~3.55M @ 0.17). 12-month enterprise marketing pilot positioning Cardano as 'The Blockchain for Serious Business' through a three-stage funnel (Attention → Proof → Qualified Leads). Pilot verticals: Institutional DeFi (V1) and Supply Chain Traceability (V2). Pilot markets: UK, Germany, Switzerland. Targets: 45M paid impressions, 320K native views, 300K Hub clicks. Total agency investment: €2,978,738 (53% media / 47% agency services). 30% ADA/EUR conversion buffer baked into the requested amount; surplus returns to Treasury minus FX conversion costs." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
   foaf:page <https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026/69e21a177a2045bdd2281d1a> .
 
-n:org-serviceplan-group
-  dcterms:description "Serviceplan Group — proposer of the Marketing Powered Demand Engine. A marketing-and-agency group delivering the enterprise demand-generation pilot." ;
-  gb:group gbgroup:organizations ;
-  rdfs:label "Serviceplan Group" ;
-  gb:nodeId "org-serviceplan-group" ;
-  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-  a gbkind:actor ;
+n:bp-serviceplan-demand-engine cardano:partOfBudgetProcess n:cardano-budget-2026 .
+n:bp-serviceplan-demand-engine cardano:proposedBy n:org-serviceplan-group .
+n:bp-serviceplan-demand-engine cardano:administeredBy n:org-intersect .
+
+n:bp-serviceplan-demand-engine cardano:alignsWithPillar n:pillar-2-adoption .
+n:bp-serviceplan-demand-engine cardano:alignsWithPillar n:pillar-4-community .
+n:bp-serviceplan-demand-engine cardano:alignsWithPillar n:pillar-5-sustainability .
+
+n:bp-serviceplan-demand-engine cardano:supportsKPI n:kpi-tvl .
+n:bp-serviceplan-demand-engine cardano:supportsKPI n:kpi-monthly-transactions .
+n:bp-serviceplan-demand-engine cardano:supportsKPI n:kpi-mau .
+n:bp-serviceplan-demand-engine cardano:supportsKPI n:kpi-annual-protocol-revenue .
+
+# -- Marketing KPI framework introduced by the proposal -------------------
+
+n:bp-serviceplan-demand-engine cardano:proposesNewKPI n:kpi-hub-traffic-engagement .
+n:bp-serviceplan-demand-engine cardano:proposesNewKPI n:kpi-qualified-leads .
+n:bp-serviceplan-demand-engine cardano:proposesNewKPI n:kpi-enterprise-conversations .
+n:bp-serviceplan-demand-engine cardano:proposesNewKPI n:kpi-brand-perception .
+
+n:kpi-hub-traffic-engagement a cardano:StrategyKPI ;
   a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "kpi-hub-traffic-engagement" ;
+  rdfs:label "Marketing KPI — Hub Traffic & Engagement" ;
+  gb:group gbgroup:concepts ;
+  dcterms:description "Are serious decision-makers reaching the evidence they need and spending meaningful time with it? Tracked via downloads, click-depth, time on page, demo requests." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:kpi-qualified-leads a cardano:StrategyKPI ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "kpi-qualified-leads" ;
+  rdfs:label "Marketing KPI — Qualified Leads Routed into Ecosystem" ;
+  gb:group gbgroup:concepts ;
+  dcterms:description "Are the right stakeholders with real evaluative intent being directed into appropriate working groups and partners? Tracked via handovers to Enterprise Working Group, partner matching, new business inquiries." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:kpi-enterprise-conversations a cardano:StrategyKPI ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "kpi-enterprise-conversations" ;
+  rdfs:label "Marketing KPI — Enterprise Conversations Activated" ;
+  gb:group gbgroup:concepts ;
+  dcterms:description "Are qualified signals turning into structured discussions, explorations, and adoption pathways? Tracked via retargeting uplift, content interactions, meeting conversations." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:kpi-brand-perception a cardano:StrategyKPI ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "kpi-brand-perception" ;
+  rdfs:label "Marketing KPI — Brand & Perception" ;
+  gb:group gbgroup:concepts ;
+  dcterms:description "Sentiment across X, Reddit, developer communities; coverage and share-of-voice versus a defined peer set." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+# -- Work packages and budget --------------------------------------------
+
+n:bp-serviceplan-demand-engine cardano:hasWorkPackage n:wp-serviceplan-enable .
+n:bp-serviceplan-demand-engine cardano:hasWorkPackage n:wp-serviceplan-kickoff .
+n:bp-serviceplan-demand-engine cardano:hasWorkPackage n:wp-serviceplan-scale .
+n:bp-serviceplan-demand-engine cardano:hasWorkPackage n:wp-serviceplan-supply-chain .
+
+n:wp-serviceplan-enable a cardano:WorkPackage ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "wp-serviceplan-enable" ;
+  rdfs:label "WP1 — Enable: Strategic Foundation" ;
+  gb:group gbgroup:concepts ;
+  cardano:wpAdaAmount "3817095"^^xsd:decimal ;
+  cardano:proposalNature "Non-technical" ;
+  cardano:initiativeStatus "New Initiative" ;
+  dcterms:description "Mandatory foundation work: brand positioning and narrative for 'The Blockchain for Serious Business', Hub architecture and content strategy, creative concept and visual identity, vertical journeys for Institutional DeFi and Supply Chain Traceability. Released upon DRep approval. Budget: 3,817,095 ADA / $648,906 (ADA/USD 0.17), category Engagement & Ecosystem support." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:wp-serviceplan-enable cardano:hasBudgetLineItem n:bli-serviceplan-enable .
+n:bli-serviceplan-enable a cardano:BudgetLineItem ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "bli-serviceplan-enable" ;
+  rdfs:label "Serviceplan WP1 line — Engagement & Ecosystem support" ;
+  gb:group gbgroup:concepts ;
+  cardano:lineItemAdaAmount "3817095"^^xsd:decimal ;
+  dcterms:description "Single Engagement & Ecosystem support line for WP1 Enable: 3,817,095 ADA / $648,906." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+n:bli-serviceplan-enable cardano:lineItemCategory n:cost-category-engagement-ecosystem .
+
+n:wp-serviceplan-kickoff a cardano:WorkPackage ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "wp-serviceplan-kickoff" ;
+  rdfs:label "WP2 — Kick-off: Campaign Launch & Media" ;
+  gb:group gbgroup:concepts ;
+  cardano:wpAdaAmount "3292397"^^xsd:decimal ;
+  cardano:proposalNature "Non-technical" ;
+  cardano:initiativeStatus "New Initiative" ;
+  dcterms:description "Take the V1 DeFi vertical hub live with paid media (LinkedIn + OOH); event-centric orchestration around Money20/20 Amsterdam as the blueprint anchor. Projected reach: 9.6M LinkedIn impressions, 76,000 clicks, 3.6M OOH impressions, 80,000 native views. Requires GMC sign-off on WP1. Budget: 3,292,397 ADA / $559,707." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:wp-serviceplan-kickoff cardano:hasBudgetLineItem n:bli-serviceplan-kickoff .
+n:bli-serviceplan-kickoff a cardano:BudgetLineItem ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "bli-serviceplan-kickoff" ;
+  rdfs:label "Serviceplan WP2 line — Engagement & Ecosystem support" ;
+  gb:group gbgroup:concepts ;
+  cardano:lineItemAdaAmount "3292397"^^xsd:decimal ;
+  dcterms:description "Single Engagement & Ecosystem support line for WP2 Kick-off: 3,292,397 ADA / $559,707." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+n:bli-serviceplan-kickoff cardano:lineItemCategory n:cost-category-engagement-ecosystem .
+
+n:wp-serviceplan-scale a cardano:WorkPackage ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "wp-serviceplan-scale" ;
+  rdfs:label "WP3 — Scale: V1 DeFi Growth & Optimization + Media" ;
+  gb:group gbgroup:concepts ;
+  cardano:wpAdaAmount "3919676"^^xsd:decimal ;
+  cardano:proposalNature "Non-technical" ;
+  cardano:initiativeStatus "New Initiative" ;
+  dcterms:description "Optimize V1 DeFi performance from Phase 2 data; deliver whitepapers; prepare WEF Davos billboard placement (19-23 January 2027) as a general Cardano credibility signal; execute Q3 KPI checkpoint that gates Verticals 3 and 4. Requires demonstrated WP2 performance. Budget: 3,919,676 ADA / $666,345." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:wp-serviceplan-scale cardano:hasBudgetLineItem n:bli-serviceplan-scale .
+n:bli-serviceplan-scale a cardano:BudgetLineItem ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "bli-serviceplan-scale" ;
+  rdfs:label "Serviceplan WP3 line — Engagement & Ecosystem support" ;
+  gb:group gbgroup:concepts ;
+  cardano:lineItemAdaAmount "3919676"^^xsd:decimal ;
+  dcterms:description "Single Engagement & Ecosystem support line for WP3 Scale: 3,919,676 ADA / $666,345." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+n:bli-serviceplan-scale cardano:lineItemCategory n:cost-category-engagement-ecosystem .
+
+n:wp-serviceplan-supply-chain a cardano:WorkPackage ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "wp-serviceplan-supply-chain" ;
+  rdfs:label "WP4 — V2 Supply Chain Traceability" ;
+  gb:group gbgroup:concepts ;
+  cardano:wpAdaAmount "9234345"^^xsd:decimal ;
+  cardano:proposalNature "Non-technical" ;
+  cardano:initiativeStatus "New Initiative" ;
+  dcterms:description "Activates Supply Chain Traceability vertical end-to-end (Enable → Kick-off → Scale). Anchor event: Gartner Application & Business Solutions Summit, London, 14-15 September 2026. Targets manufacturers, logistics providers, retail networks and ESG-driven brands. Requires a passed KPI checkpoint. Budget: 9,234,345 ADA / $1,569,839." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:wp-serviceplan-supply-chain cardano:hasBudgetLineItem n:bli-serviceplan-supply-chain .
+n:bli-serviceplan-supply-chain a cardano:BudgetLineItem ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "bli-serviceplan-supply-chain" ;
+  rdfs:label "Serviceplan WP4 line — Engagement & Ecosystem support" ;
+  gb:group gbgroup:concepts ;
+  cardano:lineItemAdaAmount "9234345"^^xsd:decimal ;
+  dcterms:description "Single Engagement & Ecosystem support line for WP4 Supply Chain: 9,234,345 ADA / $1,569,839." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+n:bli-serviceplan-supply-chain cardano:lineItemCategory n:cost-category-engagement-ecosystem .
+
+n:bp-serviceplan-demand-engine cardano:hasBudgetLineItem n:bli-serviceplan-intersect-fee .
+n:bli-serviceplan-intersect-fee a cardano:BudgetLineItem ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "bli-serviceplan-intersect-fee" ;
+  rdfs:label "Serviceplan line — Intersect Budget Administration fee" ;
+  gb:group gbgroup:concepts ;
+  cardano:lineItemAdaAmount "607905"^^xsd:decimal ;
+  dcterms:description "Intersect Budget Administration fee: 607,905 ADA / $103,344 (~3% of the proposal total)." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+n:bli-serviceplan-intersect-fee cardano:lineItemPerformedBy n:org-intersect .
+
+# -- Repayment clause -----------------------------------------------------
+
+n:bp-serviceplan-demand-engine cardano:hasRepaymentClause n:repay-serviceplan-fx-buffer .
+
+n:repay-serviceplan-fx-buffer a cardano:RepaymentClause ;
+  a gb:Node ;
+  a gbkind:mechanism ;
+  gb:nodeId "repay-serviceplan-fx-buffer" ;
+  rdfs:label "Serviceplan — 30% ADA/EUR conversion-buffer surplus return" ;
+  gb:group gbgroup:mechanisms ;
+  dcterms:description "The ADA amount requested includes a 30% conversion buffer applied to the current ADA/EUR rate. Should ADA and FX rates remain stable, any surplus ADA beyond the campaign budget of €2,978,738 / $3,518,917 will be returned to the Treasury, minus documented ADA-to-EUR conversion costs (exchange fees, transaction fees, slippage, banking transfer costs)." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+n:repay-serviceplan-fx-buffer cardano:repaysToTreasury n:treasury-budgeting .
+
+# -- Comment thread -------------------------------------------------------
+
+n:bp-serviceplan-demand-engine cardano:hasComment n:comment-serviceplan-1 .
+n:bp-serviceplan-demand-engine cardano:hasComment n:comment-serviceplan-2 .
+n:bp-serviceplan-demand-engine cardano:hasComment n:comment-serviceplan-3 .
+
+n:comment-serviceplan-1 a cardano:ProposalComment ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "comment-serviceplan-1" ;
+  rdfs:label "Comment — michaelmisa on Serviceplan ('Pass')" ;
+  gb:group gbgroup:concepts ;
+  cardano:commentBy "michaelmisa (stake1...k2gcc3)" ;
+  cardano:commentPostedOn "2026-04-21T08:57:00Z"^^xsd:dateTime ;
+  dcterms:description "Pass." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:comment-serviceplan-2 a cardano:ProposalComment ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "comment-serviceplan-2" ;
+  rdfs:label "Comment — crowned on Serviceplan (objects to V2 Supply Chain)" ;
+  gb:group gbgroup:concepts ;
+  cardano:commentBy "crowned (stake1...mjrr8g)" ;
+  cardano:commentPostedOn "2026-04-20T17:04:00Z"^^xsd:dateTime ;
+  dcterms:description "Serviceplan is an extremely capable and serious marketing firm. The proposal in its current form is not viable: Supply Chain Traceability is unworkable on Cardano today (immature solutions vs. competitors built around supply chain). Recommends focusing the budget on DeFi where Cardano has a real product." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:comment-serviceplan-3 a cardano:ProposalComment ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "comment-serviceplan-3" ;
+  rdfs:label "Comment — Nimuë DRep on Serviceplan (markets question)" ;
+  gb:group gbgroup:concepts ;
+  cardano:commentBy "Nimuë Lady of the Lake Pool (drep1y...6xdgl4)" ;
+  cardano:commentPostedOn "2026-04-20T09:24:00Z"^^xsd:dateTime ;
+  dcterms:description "This proposal only targets the UK, Germany and Switzerland?" ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+# -- Domain anchors and deliverables --------------------------------------
+
+n:bp-serviceplan-demand-engine cardano:deliversArtifact n:demand-engine .
+n:bp-serviceplan-demand-engine cardano:deliversArtifact n:cardano-hub .
+
+n:demand-engine cardano:targets n:enterprise-adoption .
+n:demand-engine cardano:implementsProcess n:demand-funnel .
+
+n:demand-funnel cardano:validatesIn n:pilot-vertical-institutional-defi .
+n:demand-funnel cardano:validatesIn n:pilot-vertical-supply-chain .
+
+n:bp-serviceplan-demand-engine cardano:runsIn n:pilot-market-uk .
+n:bp-serviceplan-demand-engine cardano:runsIn n:pilot-market-germany .
+n:bp-serviceplan-demand-engine cardano:runsIn n:pilot-market-switzerland .
+
+# -- Domain nodes (proposer, deliverables, verticals, markets) ------------
+
+n:org-serviceplan-group a cardano:Proposer ;
+  a gb:Node ;
+  a gbkind:actor ;
+  gb:nodeId "org-serviceplan-group" ;
+  rdfs:label "Serviceplan Group" ;
+  gb:group gbgroup:organizations ;
+  dcterms:description "Serviceplan Group — Europe's largest owner-managed agency group, 6,500 employees in 40+ countries, €866M revenue. Cannes Lions 2025 Independent Network of the Year (19 lions). Ad Age 2025 Independent Agency Network of the Year. Built the Masumi Network with NMKR (live on Cardano mainnet since November 2024, 25,000+ on-chain transactions, Cardano Foundation endorsement at WEF Davos 2025). Prior Cardano funding: Catalyst Fund 13 #1300132 (Masumi, 1.53M ADA distributed, complete) and Fund 14 #1400079 (Masumi 2.0, in progress)." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
   foaf:page <https://www.serviceplan.com/> .
 
 n:demand-engine
-  dcterms:description "Enterprise demand-generation system: the top-level artifact of the Serviceplan proposal. Positions Cardano as 'The Blockchain for Serious Business' and drives the three-stage Attention → Proof → Qualified Leads funnel across pilot verticals and markets." ;
+  dcterms:description "Enterprise demand-generation system: the top-level artifact of the Serviceplan proposal. Drives the three-stage Attention → Proof → Qualified Leads funnel across pilot verticals and markets." ;
   gb:group gbgroup:tools ;
   rdfs:label "Cardano Enterprise Demand Engine" ;
   gb:nodeId "demand-engine" ;
@@ -126,7 +296,7 @@ n:demand-engine
   a gb:Node .
 
 n:cardano-hub
-  dcterms:description "Cardano Hub — central evidence and engagement environment proposed by Serviceplan. Destination for paid media, native advertising, and event-to-digital funnels; the Hub is where qualified enterprise leads convert after exposure." ;
+  dcterms:description "Cardano Hub — central evidence and engagement environment proposed by Serviceplan. Destination for paid media, native advertising, and event-to-digital funnels." ;
   gb:group gbgroup:tools ;
   rdfs:label "Cardano Hub" ;
   gb:nodeId "cardano-hub" ;
@@ -135,7 +305,7 @@ n:cardano-hub
   a gb:Node .
 
 n:demand-funnel
-  dcterms:description "Three-stage demand-generation process: Attention (paid media, events, Out of Home), Proof (Cardano Hub evidence environment), Qualified Leads (enterprise sales hand-off). Structured in four work packages: Enable, Kick-off, Scale, V2." ;
+  dcterms:description "Three-stage demand-generation process: Attention (paid media, events, OOH), Proof (Cardano Hub evidence environment), Qualified Leads (enterprise sales hand-off). Structured in four work packages: Enable, Kick-off, Scale, V2." ;
   gb:group gbgroup:processes ;
   rdfs:label "Attention → Proof → Qualified Leads Funnel" ;
   gb:nodeId "demand-funnel" ;
@@ -144,7 +314,7 @@ n:demand-funnel
   a gb:Node .
 
 n:enterprise-adoption
-  dcterms:description "Enterprise adoption — the concept the Serviceplan proposal treats as the missing demand signal for Cardano. The proposal argues enterprise leaders currently lack three things: use-case clarity, reliable proof, and engagement paths." ;
+  dcterms:description "Enterprise adoption — the concept the Serviceplan proposal treats as the missing demand signal for Cardano. Enterprise leaders currently lack three things: use-case clarity, reliable proof, and engagement paths." ;
   gb:group gbgroup:concepts ;
   rdfs:label "Enterprise Adoption" ;
   gb:nodeId "enterprise-adoption" ;
@@ -153,7 +323,7 @@ n:enterprise-adoption
   a gb:Node .
 
 n:pilot-vertical-institutional-defi
-  dcterms:description "V1 pilot vertical: Institutional DeFi. First enterprise use case tested through the three-stage demand funnel." ;
+  dcterms:description "V1 pilot vertical: Institutional DeFi. Targets regulated banks, asset managers, and capital-market infrastructure providers." ;
   gb:group gbgroup:concepts ;
   rdfs:label "Pilot Vertical — Institutional DeFi" ;
   gb:nodeId "pilot-vertical-institutional-defi" ;
@@ -162,7 +332,7 @@ n:pilot-vertical-institutional-defi
   a gb:Node .
 
 n:pilot-vertical-supply-chain
-  dcterms:description "V2 pilot vertical: Supply Chain Traceability. Activated after V1 KPI validation; subject to GMC / community alignment." ;
+  dcterms:description "V2 pilot vertical: Supply Chain Traceability. Targets global manufacturers, logistics providers, retail networks and ESG-driven brands." ;
   gb:group gbgroup:concepts ;
   rdfs:label "Pilot Vertical — Supply Chain Traceability" ;
   gb:nodeId "pilot-vertical-supply-chain" ;
@@ -180,7 +350,7 @@ n:pilot-market-uk
   a gb:Node .
 
 n:pilot-market-germany
-  dcterms:description "Pilot market: Germany. One of three launch markets for the 12-month enterprise demand-generation campaign." ;
+  dcterms:description "Pilot market: Germany." ;
   gb:group gbgroup:concepts ;
   rdfs:label "Pilot Market — Germany" ;
   gb:nodeId "pilot-market-germany" ;
@@ -189,7 +359,7 @@ n:pilot-market-germany
   a gb:Node .
 
 n:pilot-market-switzerland
-  dcterms:description "Pilot market: Switzerland. One of three launch markets for the 12-month enterprise demand-generation campaign." ;
+  dcterms:description "Pilot market: Switzerland." ;
   gb:group gbgroup:concepts ;
   rdfs:label "Pilot Market — Switzerland" ;
   gb:nodeId "pilot-market-switzerland" ;

--- a/data/rdf/cardano.ontology.ttl
+++ b/data/rdf/cardano.ontology.ttl
@@ -284,6 +284,62 @@ cardano:L2Lifecycle a owl:Class ;
   dcterms:description "A phase in the lifecycle of a Layer 2 head or channel." .
 
 # ==============================================================================
+# Classes — Budget proposal domain
+#
+# Models the structural requirements every Cardano Budget 2026 proposal must
+# satisfy: proposer, requested amount, duration, administrator, strategic
+# pillar alignment, supported KPIs, work packages with milestones and budget
+# breakdowns, repayment terms, and community comments.
+# ==============================================================================
+
+cardano:BudgetProcess a owl:Class ;
+  rdfs:label "Cardano Budget Process" ;
+  rdfs:subClassOf cardano:TreasuryBudgeting ;
+  dcterms:description "A multi-cycle treasury budgeting process running under CIP-1694 governance — for example Cardano Budget 2026. Aggregates submitted proposals, defines submission/voting windows, and gates Treasury Withdrawal actions." .
+
+cardano:BudgetProposal a owl:Class ;
+  rdfs:label "Budget Proposal" ;
+  rdfs:subClassOf cardano:GovernanceArtifact ;
+  dcterms:description "A proposal submitted to a BudgetProcess. Carries an applicant identity, a requested ADA amount, an estimated duration, an administrator, alignment with one or more Cardano 2030 strategic pillars, the KPIs it claims to support, a structured set of work packages, and treasury repayment terms. Approved proposals are enacted via Treasury Withdrawal governance actions." .
+
+cardano:Proposer a owl:Class ;
+  rdfs:label "Proposer" ;
+  rdfs:subClassOf org:Organization ;
+  dcterms:description "The applicant submitting a Budget Proposal. May be a Company or an Individual; recorded via cardano:applicantType on the proposal." .
+
+cardano:WorkPackage a owl:Class ;
+  rdfs:label "Work Package" ;
+  dcterms:description "A discrete delivery unit within a Budget Proposal with its own budget, cost categories, milestones, and success criteria. Approved budget for the next work package is typically gated by demonstrated delivery of the previous one." .
+
+cardano:WorkPackageMilestone a owl:Class ;
+  rdfs:label "Work Package Milestone" ;
+  dcterms:description "A milestone inside a Work Package, marked by a month offset (M1, M3, M15, ...) from project start. Distinct from cardano:GovernanceAction milestones." .
+
+cardano:CostCategory a owl:Class ;
+  rdfs:label "Cost Category" ;
+  dcterms:description "A budget category used by Intersect's Budget process: Labor, Infrastructure, Security & Audits, Legal & Compliance, Engagement & Ecosystem support, Development." .
+
+cardano:BudgetLineItem a owl:Class ;
+  rdfs:label "Budget Line Item" ;
+  dcterms:description "One row in a Work Package's budget breakdown: an ADA amount in a specific Cost Category, optionally attributed to a partner organisation or named role." .
+
+cardano:StrategicPillar a owl:Class ;
+  rdfs:label "Cardano 2030 Strategic Pillar" ;
+  dcterms:description "One of the five strategic pillars of the Cardano 2030 Strategy Framework. A Budget Proposal declares which pillars it advances and explains the rationale." .
+
+cardano:StrategyKPI a owl:Class ;
+  rdfs:label "Cardano 2030 Strategy KPI" ;
+  dcterms:description "A measurable target defined by the Cardano 2030 Strategy Framework — e.g. Total Value Locked, Monthly Transactions, Annual Protocol Revenue. Proposals declare which KPIs they support and may propose new ones." .
+
+cardano:RepaymentClause a owl:Class ;
+  rdfs:label "Treasury Repayment Clause" ;
+  dcterms:description "A commitment a proposal makes about returning value to the Cardano Treasury — for example a percentage of future protocol revenue, a buffer surplus return on FX-rate movement, or unused budget at project close." .
+
+cardano:ProposalComment a owl:Class ;
+  rdfs:label "Budget Proposal Comment" ;
+  dcterms:description "A community comment posted on a Budget Proposal's discussion thread. Carries author stake or DRep ID and a timestamp." .
+
+# ==============================================================================
 # Properties — Governance
 # ==============================================================================
 
@@ -524,6 +580,192 @@ cardano:maintainedBy a owl:ObjectProperty ;
   rdfs:label "maintained by" ;
   rdfs:range foaf:Agent ;
   dcterms:description "An entity that maintains a project or tool." .
+
+# ==============================================================================
+# Properties — Budget proposal domain
+# ==============================================================================
+
+cardano:partOfBudgetProcess a owl:ObjectProperty ;
+  rdfs:label "part of budget process" ;
+  rdfs:domain cardano:BudgetProposal ;
+  rdfs:range cardano:BudgetProcess ;
+  dcterms:description "Identifies which annual budget process a proposal was submitted to." .
+
+cardano:proposedBy a owl:ObjectProperty ;
+  rdfs:label "proposed by" ;
+  rdfs:domain cardano:BudgetProposal ;
+  rdfs:range cardano:Proposer ;
+  dcterms:description "The applicant submitting the proposal." .
+
+cardano:administeredBy a owl:ObjectProperty ;
+  rdfs:label "administered by" ;
+  rdfs:domain cardano:BudgetProposal ;
+  rdfs:range org:Organization ;
+  dcterms:description "The organisation responsible for milestone oversight, smart-contract disbursement, third-party reviews and reporting (e.g. Intersect)." .
+
+cardano:alignsWithPillar a owl:ObjectProperty ;
+  rdfs:label "aligns with strategic pillar" ;
+  rdfs:domain cardano:BudgetProposal ;
+  rdfs:range cardano:StrategicPillar ;
+  dcterms:description "A Cardano 2030 Strategy Framework pillar the proposal claims to advance." .
+
+cardano:supportsKPI a owl:ObjectProperty ;
+  rdfs:label "supports KPI" ;
+  rdfs:domain cardano:BudgetProposal ;
+  rdfs:range cardano:StrategyKPI ;
+  dcterms:description "An existing Cardano 2030 Strategy Framework KPI the proposal claims to contribute to." .
+
+cardano:proposesNewKPI a owl:ObjectProperty ;
+  rdfs:label "proposes new KPI" ;
+  rdfs:domain cardano:BudgetProposal ;
+  rdfs:range cardano:StrategyKPI ;
+  dcterms:description "A novel KPI introduced by the proposal beyond the framework's defined set." .
+
+cardano:hasWorkPackage a owl:ObjectProperty ;
+  rdfs:label "has work package" ;
+  rdfs:domain cardano:BudgetProposal ;
+  rdfs:range cardano:WorkPackage ;
+  dcterms:description "A work package belonging to the proposal." .
+
+cardano:hasWorkPackageMilestone a owl:ObjectProperty ;
+  rdfs:label "has milestone" ;
+  rdfs:domain cardano:WorkPackage ;
+  rdfs:range cardano:WorkPackageMilestone ;
+  dcterms:description "A delivery milestone inside a work package." .
+
+cardano:hasBudgetLineItem a owl:ObjectProperty ;
+  rdfs:label "has budget line item" ;
+  rdfs:domain cardano:WorkPackage ;
+  rdfs:range cardano:BudgetLineItem ;
+  dcterms:description "A line in the work package's budget breakdown." .
+
+cardano:lineItemCategory a owl:ObjectProperty ;
+  rdfs:label "line item category" ;
+  rdfs:domain cardano:BudgetLineItem ;
+  rdfs:range cardano:CostCategory ;
+  dcterms:description "The cost category an individual budget line falls under." .
+
+cardano:lineItemPerformedBy a owl:ObjectProperty ;
+  rdfs:label "line item performed by" ;
+  rdfs:domain cardano:BudgetLineItem ;
+  rdfs:range foaf:Agent ;
+  dcterms:description "The partner organisation or named role responsible for delivering this line item." .
+
+cardano:hasRepaymentClause a owl:ObjectProperty ;
+  rdfs:label "has repayment clause" ;
+  rdfs:domain cardano:BudgetProposal ;
+  rdfs:range cardano:RepaymentClause ;
+  dcterms:description "A repayment commitment the proposal makes to the Cardano Treasury." .
+
+cardano:repaysToTreasury a owl:ObjectProperty ;
+  rdfs:label "repays to treasury" ;
+  rdfs:domain cardano:RepaymentClause ;
+  rdfs:range cardano:TreasuryBudgeting ;
+  dcterms:description "The treasury process that receives repaid value." .
+
+cardano:hasComment a owl:ObjectProperty ;
+  rdfs:label "has comment" ;
+  rdfs:domain cardano:BudgetProposal ;
+  rdfs:range cardano:ProposalComment ;
+  dcterms:description "A community comment on the proposal's discussion thread." .
+
+# -- Datatype properties for budget proposals ----------------------------------
+
+cardano:requestedAdaAmount a owl:DatatypeProperty ;
+  rdfs:label "requested ADA amount" ;
+  rdfs:domain cardano:BudgetProposal ;
+  rdfs:range xsd:decimal ;
+  dcterms:description "ADA amount requested from the treasury." .
+
+cardano:requestedUsdAmount a owl:DatatypeProperty ;
+  rdfs:label "requested USD equivalent" ;
+  rdfs:domain cardano:BudgetProposal ;
+  rdfs:range xsd:decimal ;
+  dcterms:description "USD equivalent of the requested ADA amount, computed at the proposer-specified ADA/USD rate." .
+
+cardano:adaUsdRate a owl:DatatypeProperty ;
+  rdfs:label "ADA/USD conversion rate" ;
+  rdfs:domain cardano:BudgetProposal ;
+  rdfs:range xsd:decimal ;
+  dcterms:description "Conversion rate (USD per 1 ADA) the proposer used to derive the USD equivalent." .
+
+cardano:estimatedDurationMonths a owl:DatatypeProperty ;
+  rdfs:label "estimated duration (months)" ;
+  rdfs:domain cardano:BudgetProposal ;
+  rdfs:range xsd:integer ;
+  dcterms:description "Total project duration in months." .
+
+cardano:submittedOn a owl:DatatypeProperty ;
+  rdfs:label "submitted on" ;
+  rdfs:domain cardano:BudgetProposal ;
+  rdfs:range xsd:dateTime ;
+  dcterms:description "Submission timestamp on the Hydra Voting site." .
+
+cardano:proposalIdentifier a owl:DatatypeProperty ;
+  rdfs:label "proposal identifier" ;
+  rdfs:domain cardano:BudgetProposal ;
+  rdfs:range xsd:string ;
+  dcterms:description "Stable identifier on the Hydra Voting site." .
+
+cardano:applicantType a owl:DatatypeProperty ;
+  rdfs:label "applicant type" ;
+  rdfs:domain cardano:BudgetProposal ;
+  rdfs:range xsd:string ;
+  dcterms:description "Whether the applicant is registered as a Company or as an Individual." .
+
+cardano:proposalNature a owl:DatatypeProperty ;
+  rdfs:label "proposal nature" ;
+  rdfs:domain cardano:WorkPackage ;
+  rdfs:range xsd:string ;
+  dcterms:description "Whether the work package is Technical or Non-technical, per the application form." .
+
+cardano:initiativeStatus a owl:DatatypeProperty ;
+  rdfs:label "initiative status" ;
+  rdfs:domain cardano:WorkPackage ;
+  rdfs:range xsd:string ;
+  dcterms:description "Whether the work is a 'New Initiative' or a 'Continuation of existing work', per the application form." .
+
+cardano:wpAdaAmount a owl:DatatypeProperty ;
+  rdfs:label "work package ADA amount" ;
+  rdfs:domain cardano:WorkPackage ;
+  rdfs:range xsd:decimal ;
+  dcterms:description "Total ADA budget for a work package." .
+
+cardano:lineItemAdaAmount a owl:DatatypeProperty ;
+  rdfs:label "line item ADA amount" ;
+  rdfs:domain cardano:BudgetLineItem ;
+  rdfs:range xsd:decimal ;
+  dcterms:description "ADA amount for a single budget line item." .
+
+cardano:milestoneMonth a owl:DatatypeProperty ;
+  rdfs:label "milestone month" ;
+  rdfs:domain cardano:WorkPackageMilestone ;
+  rdfs:range xsd:integer ;
+  dcterms:description "Month offset (M1, M3, M15) from project start at which the milestone is due." .
+
+cardano:kpiCurrentValue a owl:DatatypeProperty ;
+  rdfs:label "KPI current value" ;
+  rdfs:domain cardano:StrategyKPI ;
+  rdfs:range xsd:string ;
+  dcterms:description "Current measured value of the KPI, as cited in the proposal." .
+
+cardano:kpiTargetValue a owl:DatatypeProperty ;
+  rdfs:label "KPI target value" ;
+  rdfs:domain cardano:StrategyKPI ;
+  rdfs:range xsd:string ;
+  dcterms:description "Target value the KPI is meant to reach (typically by 2030)." .
+
+cardano:commentBy a owl:DatatypeProperty ;
+  rdfs:label "comment by" ;
+  rdfs:domain cardano:ProposalComment ;
+  rdfs:range xsd:string ;
+  dcterms:description "Display name or stake/DRep alias of the commenter." .
+
+cardano:commentPostedOn a owl:DatatypeProperty ;
+  rdfs:label "comment posted on" ;
+  rdfs:domain cardano:ProposalComment ;
+  rdfs:range xsd:dateTime ;
+  dcterms:description "Timestamp at which the comment was posted." .
 
 # ==============================================================================
 # Alignment — bridge gbkind: classes to cardano: classes

--- a/data/rdf/cardano.ttl
+++ b/data/rdf/cardano.ttl
@@ -126,3 +126,189 @@ n:cip-108 dcterms:requires n:cip-100 .
   dcterms:description "Conway began with a bootstrap phase where only CC could approve parameter changes and CC + SPOs could approve hard forks. DRep participation was not required. This phased rollout prevented governance deadlocks while DRep registration ramped up. Ended with the Plomin hard fork in December 2024." .
 
 n:cip-1694 cardano:implementedIn n:conway-era .
+
+# =========================================================================
+#  Cardano Budget 2026 — process anchors shared by every proposal TTL
+#  (process node, strategic pillars, framework KPIs, cost categories,
+#  the Intersect administrator)
+# =========================================================================
+
+# -- Process node ---------------------------------------------------------
+
+n:cardano-budget-2026 a cardano:BudgetProcess ;
+  a gb:Node ;
+  a gbkind:process ;
+  gb:nodeId "cardano-budget-2026" ;
+  rdfs:label "Cardano Budget 2026" ;
+  gb:group gbgroup:processes ;
+  dcterms:description "The 2026 cycle of Cardano's CIP-1694 treasury budgeting process. Submission window opened 16 April 2026 and closes 8 May 2026 (UTC). Approved proposals enact via Treasury Withdrawal governance actions gated by Net Change Limit and Budget Info Actions (DRep 50% + CC 2/3)." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026> .
+
+n:cardano-budget-2026 cardano:succeeds n:treasury-budgeting .
+[] a rdf:Statement ;
+  rdf:subject n:cardano-budget-2026 ;
+  rdf:predicate cardano:succeeds ;
+  rdf:object n:treasury-budgeting ;
+  dcterms:description "The 2026 cycle is one instance of the broader Cardano Treasury Budgeting process formalised by CIP-1694." .
+
+# -- Cardano 2030 strategic pillars ---------------------------------------
+
+n:pillar-1-infrastructure a cardano:StrategicPillar ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "pillar-1-infrastructure" ;
+  rdfs:label "Pillar 1 — Infrastructure & Research Excellence" ;
+  gb:group gbgroup:concepts ;
+  dcterms:description "Keep Cardano secure, fast, and interoperable so it can host more economic activity. Covers L1 protocol improvements, L2/cross-chain interop, formal methods, and research-led delivery." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:pillar-2-adoption a cardano:StrategicPillar ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "pillar-2-adoption" ;
+  rdfs:label "Pillar 2 — Adoption & Utility" ;
+  gb:group gbgroup:concepts ;
+  dcterms:description "Drive widespread, non-speculative utility by focusing on high-value industry verticals (DeFi, RWA, Supply Chain, Payments), superior UX, and enterprise-grade security." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:pillar-3-talent a cardano:StrategicPillar ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "pillar-3-talent" ;
+  rdfs:label "Pillar 3 — Talent & Builder Ecosystem" ;
+  gb:group gbgroup:concepts ;
+  dcterms:description "Cultivate a skilled developer base and the tooling, documentation, and onboarding pathways that retain and grow it." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:pillar-4-community a cardano:StrategicPillar ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "pillar-4-community" ;
+  rdfs:label "Pillar 4 — Community & Ecosystem Growth" ;
+  gb:group gbgroup:concepts ;
+  dcterms:description "Drive global engagement through a market-centric approach, cultivate a skilled developer base, and proactively demonstrate ecosystem value." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:pillar-5-sustainability a cardano:StrategicPillar ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "pillar-5-sustainability" ;
+  rdfs:label "Pillar 5 — Ecosystem Sustainability & Resilience" ;
+  gb:group gbgroup:concepts ;
+  dcterms:description "Ensure the long-term financial health and operational integrity of the network: structural ADA demand, treasury sustainability, diversified SPO economics, L2/L1 value retention." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+# -- Cardano 2030 framework KPIs ------------------------------------------
+
+n:kpi-tvl a cardano:StrategyKPI ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "kpi-tvl" ;
+  rdfs:label "KPI — Total Value Locked" ;
+  gb:group gbgroup:concepts ;
+  cardano:kpiCurrentValue "$200M" ;
+  cardano:kpiTargetValue "$3B by 2030" ;
+  dcterms:description "Total Value Locked across Cardano DeFi and RWA protocols. Adoption KPI in the Cardano 2030 Strategy Framework." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:kpi-monthly-transactions a cardano:StrategyKPI ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "kpi-monthly-transactions" ;
+  rdfs:label "KPI — Monthly Transactions" ;
+  gb:group gbgroup:concepts ;
+  cardano:kpiCurrentValue "800k" ;
+  cardano:kpiTargetValue "27M by 2030" ;
+  dcterms:description "Monthly on-chain transactions on Cardano mainnet. Adoption KPI in the Cardano 2030 Strategy Framework." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:kpi-mau a cardano:StrategyKPI ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "kpi-mau" ;
+  rdfs:label "KPI — Monthly Active Users" ;
+  gb:group gbgroup:concepts ;
+  cardano:kpiCurrentValue "100k–300k" ;
+  cardano:kpiTargetValue "1M by 2030" ;
+  dcterms:description "Monthly active users (distinct active wallets) on Cardano. Adoption KPI in the Cardano 2030 Strategy Framework." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:kpi-annual-protocol-revenue a cardano:StrategyKPI ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "kpi-annual-protocol-revenue" ;
+  rdfs:label "KPI — Annual Protocol Revenue" ;
+  gb:group gbgroup:concepts ;
+  cardano:kpiCurrentValue "3.5M ADA" ;
+  cardano:kpiTargetValue "≥16M ADA by 2030" ;
+  dcterms:description "Annual protocol fee revenue. Primary KPI in the Cardano 2030 Strategy Framework — implies ~4.6× growth from the current baseline." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+# -- Budget cost categories ----------------------------------------------
+
+n:cost-category-labor a cardano:CostCategory ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "cost-category-labor" ;
+  rdfs:label "Cost Category — Resources (Labor)" ;
+  gb:group gbgroup:concepts ;
+  dcterms:description "Person-time spent by named contributors. The dominant cost category in technical proposals." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:cost-category-development a cardano:CostCategory ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "cost-category-development" ;
+  rdfs:label "Cost Category — Development" ;
+  gb:group gbgroup:concepts ;
+  dcterms:description "Development effort, treated as a single line by some proposals (e.g. Indigo) instead of broken out as Labor." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:cost-category-infrastructure a cardano:CostCategory ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "cost-category-infrastructure" ;
+  rdfs:label "Cost Category — Infrastructure" ;
+  gb:group gbgroup:concepts ;
+  dcterms:description "Hosting, build/test platforms, hardware-equivalent infrastructure spend." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:cost-category-security-audits a cardano:CostCategory ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "cost-category-security-audits" ;
+  rdfs:label "Cost Category — Security & Audits" ;
+  gb:group gbgroup:concepts ;
+  dcterms:description "Independent security reviews and audits of the deliverables." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:cost-category-legal-compliance a cardano:CostCategory ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "cost-category-legal-compliance" ;
+  rdfs:label "Cost Category — Legal & Compliance" ;
+  gb:group gbgroup:concepts ;
+  dcterms:description "Legal, regulatory and compliance work — including third-party audit oversight." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+n:cost-category-engagement-ecosystem a cardano:CostCategory ;
+  a gb:Node ;
+  a gbkind:concept ;
+  gb:nodeId "cost-category-engagement-ecosystem" ;
+  rdfs:label "Cost Category — Engagement & Ecosystem support" ;
+  gb:group gbgroup:concepts ;
+  dcterms:description "Workshops, community events, marketing, ecosystem outreach. The umbrella category for the Serviceplan marketing proposal." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> .
+
+# -- Administrator: Intersect --------------------------------------------
+
+n:org-intersect a cardano:GovernanceOrganization ;
+  a gb:Node ;
+  a gbkind:actor ;
+  gb:nodeId "org-intersect" ;
+  rdfs:label "Intersect" ;
+  gb:group gbgroup:actors ;
+  dcterms:description "The Intersect member-based organisation: the canonical administrator for Cardano Budget 2026 proposals. Provides milestone oversight, smart-contract-based disbursement, third-party reviews and reporting; takes a percentage budget administration fee on each proposal it administers." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://www.intersectmbo.org/> .


### PR DESCRIPTION
## Summary

Extends the Cardano domain ontology with the structural requirements of a Cardano Budget proposal, and rewrites each Budget 2026 proposal TTL to use the new vocabulary at full depth.

## Ontology — \`cardano.ontology.ttl\` (commit 1)

New classes: \`BudgetProcess\`, \`BudgetProposal\`, \`Proposer\`, \`WorkPackage\`, \`WorkPackageMilestone\`, \`CostCategory\`, \`BudgetLineItem\`, \`StrategicPillar\`, \`StrategyKPI\`, \`RepaymentClause\`, \`ProposalComment\`.

New object properties: \`partOfBudgetProcess\`, \`proposedBy\`, \`administeredBy\`, \`alignsWithPillar\`, \`supportsKPI\`, \`proposesNewKPI\`, \`hasWorkPackage\`, \`hasWorkPackageMilestone\`, \`hasBudgetLineItem\`, \`lineItemCategory\`, \`lineItemPerformedBy\`, \`hasRepaymentClause\`, \`repaysToTreasury\`, \`hasComment\`.

New datatype properties: \`requestedAdaAmount\`, \`requestedUsdAmount\`, \`adaUsdRate\`, \`estimatedDurationMonths\`, \`submittedOn\`, \`proposalIdentifier\`, \`applicantType\`, \`proposalNature\`, \`initiativeStatus\`, \`wpAdaAmount\`, \`lineItemAdaAmount\`, \`milestoneMonth\`, \`kpiCurrentValue\`, \`kpiTargetValue\`, \`commentBy\`, \`commentPostedOn\`.

## Canonical anchors — \`cardano.ttl\` (commit 2)

Shared instance nodes referenced by every proposal:
- \`n:cardano-budget-2026\` — the BudgetProcess instance
- five strategic pillars (\`pillar-1\` through \`pillar-5\`)
- four framework KPIs (TVL, Monthly Transactions, MAU, Annual Protocol Revenue) with current and target values
- six cost categories (Labor, Development, Infrastructure, Security & Audits, Legal & Compliance, Engagement & Ecosystem support)
- \`n:org-intersect\` — the canonical administrator

## Per-proposal enrichment — \`budget-2026/*.ttl\` (commit 3)

| Proposal | Triples (was → now) | Work packages | Programme milestones | Comments |
|---|---|---|---|---|
| Partner Chain Factory | 139 → 446 | 8 + 6-partner consortium | 9 (MS1–MS9) | 1 |
| Indigo V2030RS | 125 → 218 | 1 + repayment clause | — | 1 |
| Serviceplan Demand Engine | 145 → 289 | 4 + Intersect fee | — | 3 |

Each proposal carries: requested ADA + USD + rate + duration; pillar alignments; KPI supports + any new KPIs introduced; full work-package decomposition with budgets and cost categories; repayment clause; community comments (author + timestamp).

## Queries (commit 4)

- \"Budget 2026 — Work Packages\" — WPs + milestones + line items + categories + performers
- \"Budget 2026 — Strategy & KPIs\" — pillar / KPI coverage
- \"Budget 2026 — Treasury Flow\" — process / proposals / repayment / treasury
- The existing \"Budget 2026 Proposals\" view now uses the new vocabulary

## Verification

\`\`\`
total triples: 4068
gb:Node subjects: 200
cardano:BudgetProposal: 3
cardano:WorkPackage: 13
\`\`\`

## Test plan

- [ ] CI green
- [ ] All four Budget 2026 SPARQL views render meaningful subgraphs
- [ ] Work-package query shows the 6-partner consortium grouped under PCF