### PR TITLE
Guided tours for the Cardano Budget 2026 cycle

### DIFF
--- a/data/tutorials/budget-2026-indigo-v2030rs.json
+++ b/data/tutorials/budget-2026-indigo-v2030rs.json
@@ -1,0 +1,67 @@
+{
+  "id": "budget-2026-indigo-v2030rs",
+  "title": "Indigo V2030RS — Deep Dive",
+  "description": "What Indigo Foundation is asking the Treasury to fund, the four products that come out of it, the perpetual revenue-share that frames the ask, and the timing concern the community has raised.",
+  "stops": [
+    {
+      "node": "bp-indigo-v2030rs",
+      "depth": 1,
+      "title": "The pitch in one sentence",
+      "narrative": "**3.97M ADA, 12 months, one work package** to deliver four interlocking products — and to commit, perpetually, to returning **10% of all net protocol revenue** from those products to the Cardano Treasury via the [V2030RS](node:v2030rs-revenue-share) framework.\n\nThe ADA ask is the third-smallest on the slate (after PCF and Serviceplan), but the framing is unusual: Indigo isn't asking for a grant, it's asking the Treasury to become a **perpetual co-beneficiary** of the products it's funding. That framing matters more than the dollar amount."
+    },
+    {
+      "node": "org-indigo-foundation",
+      "depth": 1,
+      "title": "Why Indigo is the proposer",
+      "narrative": "[Indigo Foundation](node:org-indigo-foundation) operates Indigo Protocol on Cardano: an over-collateralised synthetic-asset platform that has, since the launch of Indigo 2.0 in April 2024, generated **>$8.55M USD in cumulative protocol revenue** from mint/burn fees, redemptions, and loan-interest payments. That revenue stream is what makes the V2030RS commitment credible — Indigo isn't promising to share future hypothetical revenue, it's pointing at an existing stream and saying 'we'll route 10% of the new product revenue through that same machinery'.\n\nIndigo has also previously received funding through Cardano Catalyst across multiple rounds. That is both a credibility signal (the team has shipped before) and a concern (some past Catalyst projects sit at 'awaiting final milestone approval', as the proposal acknowledges)."
+    },
+    {
+      "node": "iusdt",
+      "depth": 1,
+      "title": "Product 1 — iUSDt, Cardano's first institutional RWA stablecoin",
+      "narrative": "[iUSDt](node:iusdt) is the central deliverable: an institutional-grade stablecoin backed not by on-chain over-collateralisation (like [Djed](node:djed)) but by **short-duration U.S. Treasuries** held through institutional liquidity funds. The proposal positions this as filling Cardano's RWA gap — today, a corporate treasury or DAO that wants tokenised yield-bearing dollar exposure has to leave Cardano to get it.\n\nThe entire WP1 (Legal & Compliance) exists because tokenising real treasuries means setting up Indigo Finance Corp and any subsidiaries, securing jurisdictional licensing, building compliant custody and Proof-of-Reserves structures. **2.3M of the 3.85M work-package budget is Legal & Compliance**, not engineering. That ratio tells you what kind of proposal this really is."
+    },
+    {
+      "node": "btc-fi-market",
+      "depth": 1,
+      "title": "Product 2 — BTC-Fi via xBTC collateral",
+      "narrative": "The [BTC-Fi market](node:btc-fi-market) is the second product: an Indigo-hosted DeFi venue where positions are denominated in [BTC](node:btc), brought into the Cardano stack via xBTC collateral.\n\nThis is the proposal's bid to **bring external Bitcoin liquidity into Cardano DeFi** — the argument being that BTC holders looking for yield currently leave for Ethereum/Solana, and a Cardano-native BTC venue closes that leak. The ecosystem case is that BTC liquidity follows venue, not chain loyalty, and Cardano needs the venue."
+    },
+    {
+      "node": "shielded-iasset",
+      "depth": 1,
+      "title": "Product 3 — Shielded iAssets on partner chains",
+      "narrative": "The third product is privacy: [shielded iAssets](node:shielded-iasset) deployed on partner-chain ecosystems (Midnight specifically, per the proposal text). These are confidentiality-preserving synthetic assets — institutional participants want the public verifiability of on-chain settlement without exposing position sizes, counterparties or trading patterns to public mempool observers.\n\nThis stop also creates a **cross-proposal dependency** that's worth pausing on: shielded iAssets need [partner chains](node:partner-chain), which (in the high-performance variant) is what the [Partner Chain Factory](node:bp-partner-chain-factory) proposal is funding. In the merged graph store, that dependency is a real edge — both proposals failing or both passing changes Indigo's delivery picture."
+    },
+    {
+      "node": "v2030rs-revenue-share",
+      "depth": 1,
+      "title": "Product 4 — V2030RS, the framing piece",
+      "narrative": "[V2030RS](node:v2030rs-revenue-share) is the fourth and most distinctive deliverable. It is **not a product** in the technical sense — it's a **structural commitment** to route 10% of net protocol revenue from the funded products (iUSDt, BTC-Fi, shielded iAssets) back to the Cardano Treasury **perpetually from day one of each product go-live**, via quarterly auditable on-chain transfers, with no sunset clause and no cap.\n\nThe proposal explicitly claims this 'shifts the Treasury from passive funder to active beneficiary'. The mechanism leverages Indigo's existing yield-distribution architecture (which currently distributes to INDY stakers and stability providers, primarily in ADA). V2030RS extends the same pipe to a new beneficiary: the [Treasury budgeting process](node:treasury-budgeting) itself."
+    },
+    {
+      "node": "wp-indigo-rwa-compliance",
+      "depth": 1,
+      "title": "Why there is only one work package",
+      "narrative": "Unlike PCF (8 WPs) and Serviceplan (4 WPs), Indigo bundles everything under a single work package: [WP1 — RWA Compliance: Legal, Compliance & Entity Setup](node:wp-indigo-rwa-compliance), at 3.85M ADA. The cost split:\n\n- **Legal & Compliance**: 2.3M ADA / $690,000 (60% of WP)\n- **Development**: 1.55M ADA / $465,000 (40% of WP)\n\nThis single-WP structure is honest about where the risk is. The technical work (RWA core, BTC DeFi, Midnight integration, audits, open tooling) is all rolled into the Development line — Indigo is treating the engineering as well-understood, with the entity-formation and licensing as the unknown. That's the opposite of how PCF distributes risk."
+    },
+    {
+      "node": "kpi-annual-protocol-revenue",
+      "depth": 1,
+      "title": "The KPI argument",
+      "narrative": "The proposal supports four framework KPIs ([TVL](node:kpi-tvl), [Monthly Transactions](node:kpi-monthly-transactions), [MAU](node:kpi-mau), [Annual Protocol Revenue](node:kpi-annual-protocol-revenue)) but the central one is the last. Indigo's existing protocol generates ~4.66M ADA average annual revenue. **10% of that, routed via V2030RS, is by itself ~466k ADA/year** to the Treasury — measurable against a current 3.5M ADA total annual protocol revenue.\n\nIf the new products (iUSDt, BTC-Fi, shielded iAssets) reach even modest scale, the share grows proportionally. The proposal provides per-scenario forecasts (V2030RS Forecast Summary) showing payback paths from base to growth scenarios. The community can disagree on the forecast inputs, but the mechanism — quarterly auditable on-chain transfers — is verifiable from day one."
+    },
+    {
+      "node": "repay-indigo-v2030rs",
+      "depth": 1,
+      "title": "The repayment commitment in clause form",
+      "narrative": "[V2030RS as a repayment clause](node:repay-indigo-v2030rs) has three commitments worth distinguishing:\n\n1. **10% of net new protocol revenue** from the funded products — not gross, not gated by payback completion\n2. **Perpetually from day one of each product go-live** — no sunset clause, no cap\n3. **Quarterly auditable on-chain transfers** — the mechanism is verifiable each quarter, not at year-end\n\nThe contrast with PCF's repayment is sharp. PCF returns the *FX surplus and unspent ADA* — a one-time true-up. Indigo returns *protocol revenue forever*. That difference is the proposal's distinguishing feature on the slate."
+    },
+    {
+      "node": "comment-indigo-1",
+      "depth": 1,
+      "title": "The substantive critique — timing",
+      "narrative": "The single comment so far (commenter [-256](node:comment-indigo-1), 21 Apr 2026) acknowledges the proposal is 'much needed' and that BTC-Fi integration could bring liquidity — but argues the **timing is wrong**:\n\n> 'ADA is at multiyear low and selling ADA at these levels to fund these developments will be throwing away money. I think we should wait at least for next year when prices are little improved.'\n\nThis is a structural objection that affects every Budget 2026 proposal at $0.30 or below: every ADA the Treasury disburses for fiat-denominated work is being sold (or hedged via forward contracts, with their own costs) into a depressed market. The proposal's repayment clause partially counters this — perpetual 10% revenue share *is* upside if ADA recovers — but it doesn't undo the immediate ADA outflow. This will be the cycle's most-debated question, and it's not specific to Indigo."
+    }
+  ]
+}

--- a/data/tutorials/budget-2026-overview.json
+++ b/data/tutorials/budget-2026-overview.json
@@ -1,0 +1,43 @@
+{
+  "id": "budget-2026-overview",
+  "title": "Cardano Budget 2026 — the Process and the Slate",
+  "description": "How Cardano's CIP-1694 treasury budgeting process works, and a quick tour of the three proposals submitted to the 2026 cycle.",
+  "stops": [
+    {
+      "node": "cardano-budget-2026",
+      "depth": 1,
+      "title": "What Cardano Budget 2026 actually is",
+      "narrative": "Before there were Cardano Budgets, there was [CIP-1694](node:cip-1694) — Cardano's on-chain governance constitution — which defined a [Treasury Withdrawal](node:action-treasury) governance action but said nothing about how the community should *plan* what to ask for. Cardano Budget 2026 is the second annual cycle of a process layered *on top* of CIP-1694 to make those treasury asks coherent.\n\nThe cycle this tour follows runs from **16 April → 8 May 2026 (UTC)** for submissions. Anyone can submit a proposal through Intersect's Hydra Voting site. After submission, every proposal goes through public comment, DRep review, and a vote. Approved proposals are then enacted via [Treasury Withdrawal](node:action-treasury) actions that are themselves gated by Net Change Limit and Budget [Info Actions](node:action-info) — the on-chain mechanism the [Constitution](node:constitution) requires before any ada leaves the treasury."
+    },
+    {
+      "node": "treasury-budgeting",
+      "depth": 1,
+      "title": "Why budget proposals exist at all",
+      "narrative": "On the Cardano ledger, the treasury is just a pool of ADA. The [TreasuryBudgeting](node:treasury-budgeting) process exists because a Treasury Withdrawal alone is too coarse: it says 'send N ADA to address X', and that's it. There is no on-chain way to express 'this is funding a 15-month engineering programme with eight work packages and a 60-second bridge latency target'.\n\nThe Cardano Budget process is the off-chain layer that produces those structured commitments — proposers, work packages, milestones, KPIs, repayment terms — and then derives the on-chain Treasury Withdrawal once the community ratifies them. The 2026 cycle adds an explicit revenue-share track (proposals can commit to returning a share of future protocol revenue), a strategic-pillar alignment requirement, and Intersect-mediated milestone disbursement."
+    },
+    {
+      "node": "bp-partner-chain-factory",
+      "depth": 1,
+      "title": "Proposal 1 — Partner Chain Factory (Ouroboros Tachýs)",
+      "narrative": "**Ensurable Systems Ltd**, leading a consortium of six engineering organisations, asks for **13,150,479 ADA** ($3.29M @ $0.25) over **15 months** to build a reusable, open-source toolkit that lets any builder spin up a Cardano-derived partner chain in hours instead of months. The technical foundation is [Ouroboros Tachýs](node:ouroboros-tachys) — a high-performance variant of [Ouroboros Praos](node:ouroboros-praos) targeting 1–2 second confirmation and ~40× mainnet throughput.\n\nThis is the largest, most technical proposal of the slate. It is also the most architecturally consequential: if it lands, Cardano gains the same kind of builder framework that Substrate gave Polkadot and Cosmos SDK gave Cosmos. There is a dedicated tour for this proposal — load **Partner Chain Factory — Deep Dive**."
+    },
+    {
+      "node": "bp-indigo-v2030rs",
+      "depth": 1,
+      "title": "Proposal 2 — Indigo V2030RS / iUSDt / BTC-Fi / Privacy",
+      "narrative": "**Indigo Foundation** asks for **3,965,500 ADA** ($1.19M @ $0.30) over **12 months** to deliver four interlocking products: [iUSDt](node:iusdt) (Cardano's first institutional-grade RWA stablecoin backed by short-duration U.S. Treasuries), a Bitcoin-DeFi market on Indigo, [shielded iAssets](node:shielded-iasset) on Midnight, and — the framing piece — [V2030RS](node:v2030rs-revenue-share), a perpetual 10% revenue share back to the Cardano Treasury.\n\nThe proposal's pitch is not 'fund our product' — it's 'fund our product and the Treasury becomes a perpetual revenue beneficiary, not a one-shot grantmaker'. There is a dedicated tour for this proposal — load **Indigo V2030RS — Deep Dive**."
+    },
+    {
+      "node": "bp-serviceplan-demand-engine",
+      "depth": 1,
+      "title": "Proposal 3 — Serviceplan Marketing Powered Demand Engine",
+      "narrative": "**Serviceplan Group** — Europe's largest owner-managed agency group, and the team that built the [Masumi Network](node:demand-engine) on Cardano — asks for **20,871,418 ADA** ($3.55M @ $0.17) over **12 months** to run an enterprise marketing pilot that repositions Cardano as 'The Blockchain for Serious Business'.\n\nThis is the largest ADA ask on the slate. It is also the only non-technical proposal: every cost line is **Engagement & Ecosystem support**, not Labor or Development. The work splits into four packages around two pilot verticals (Institutional DeFi, Supply Chain Traceability) and three pilot markets (UK, Germany, Switzerland). Load **Serviceplan Demand Engine — Deep Dive** for the full picture, including the substantive critique it received."
+    },
+    {
+      "node": "org-intersect",
+      "depth": 1,
+      "title": "Why every proposal lists the same administrator",
+      "narrative": "Every Budget 2026 proposal names [Intersect](node:org-intersect) as its administrator. This isn't decoration — Intersect is the member-based organisation that operates the canonical milestone-oversight, smart-contract-based disbursement, and third-party-review service for the Cardano budget process. Each proposal pays a percentage fee for this oversight (3% on Serviceplan, ~3% on Indigo, ~3% on PCF).\n\nIntersect's role is structural: it gates the next work package's funding on demonstrated delivery of the previous one. WP1 → WP2 → WP3 → WP4 only progresses when the previous work package's success criteria are documented and signed off. This is how the process turns a single Treasury Withdrawal into something that resembles staged contract work."
+    }
+  ]
+}

--- a/data/tutorials/budget-2026-partner-chain-factory.json
+++ b/data/tutorials/budget-2026-partner-chain-factory.json
@@ -1,0 +1,73 @@
+{
+  "id": "budget-2026-partner-chain-factory",
+  "title": "Partner Chain Factory — Deep Dive",
+  "description": "What the Partner Chain Factory proposal is actually building, why it matters for Cardano's competitive position, who's building it, and what could go wrong.",
+  "stops": [
+    {
+      "node": "bp-partner-chain-factory",
+      "depth": 1,
+      "title": "The pitch in one sentence",
+      "narrative": "**13.15M ADA, 15 months, six partners** to make 'spin up a new Cardano-derived chain' a sub-day toolkit operation rather than a multi-year, multi-million-dollar project.\n\nThe proposal's core argument is structural: today, building a high-performance partner chain on Cardano means independently solving every problem that the first team (Apex Fusion's [Vector chain](node:vector-chain), late 2025) solved — consensus tuning, deployment automation, bridging, observability. Builders on Ethereum have Optimism Stack and Polygon CDK; on Cosmos they have Cosmos SDK; on Polkadot they have Substrate. **Cardano has nothing equivalent**. The factory is meant to fix that."
+    },
+    {
+      "node": "ouroboros-tachys",
+      "depth": 1,
+      "title": "Ouroboros Tachýs — what makes the chains different",
+      "narrative": "Cardano mainnet runs [Ouroboros Praos](node:ouroboros-praos), with a 20-second block time and a public mempool. That's a deliberate design — those parameters give Cardano its security guarantees and its predictable settlement. But they make mainnet **unsuitable as the execution layer for sub-2-second institutional settlement** (RWA, securities, regulated treasuries).\n\n[Ouroboros Tachýs](node:ouroboros-tachys) is a high-performance Ouroboros variant that aims for **1–2 second confirmation** and **~40× mainnet throughput**, while retaining the underlying security properties. It is designed to compose with Peras, Leios and Phalanx. The proposal does *not* propose changing mainnet — it proposes making Tachýs available as the consensus engine for partner chains that anchor back to mainnet."
+    },
+    {
+      "node": "vector-chain",
+      "depth": 1,
+      "title": "Why this isn't speculative — Vector already exists",
+      "narrative": "Apex Fusion launched [Vector](node:vector-chain) in late 2025 as the first Cardano-derived partner chain in production. The core ideas the proposal is asking funding to *industrialise* have been validated through a chain that real users use today.\n\nThis is the proposal's strongest credibility anchor. The team behind it — Ensurable Systems, Well Typed, PNSol, HAL8, Ethernal, plus AFF (which operates Vector) — has experience including: building the Cardano node, implementing Ouroboros, delivering every hard fork from Byron through Plomin, and running Vector in production. The treasury is being asked to fund the **toolkit** that turns a one-off success into a repeatable platform."
+    },
+    {
+      "node": "partner-chain",
+      "depth": 1,
+      "title": "What 'partner chain' actually means here",
+      "narrative": "[Partner chains](node:partner-chain) are not Layer 2s. They are sovereign chains derived from the Cardano codebase that:\n\n- **Settle to mainnet** for finality and dispute resolution\n- **Require ADA for stake** (the SPO economics flow back to mainnet)\n- **Connect to mainnet via a bridge** for asset and message transfer\n\nThe bridge is critical and is funded as its own work package — see [PCF WP4](node:wp-pcf-4-bridging). The economic argument the proposal makes is that partner chains create **structural ADA demand** even though they execute application traffic off mainnet: every chain that exists adds ADA stake requirements, mainnet bridging fees, and mainnet settlement transactions."
+    },
+    {
+      "node": "wp-pcf-4-bridging",
+      "depth": 1,
+      "title": "WP4 — the most expensive work package, for good reason",
+      "narrative": "**3,316,655 ADA / 35 person-months** — this is by far the largest work package, and it builds the production-grade Cardano⇄Tachýs⇄EVM bridge. Lock/burn + mint/unlock logic reviewed by Ensurable Systems and Well Typed; protocol-level threat model; **independent security audit with all critical/high resolved by M12**; UTXO-to-EVM path to give EVM-builders direct access; bridge latency target ≤60s.\n\nAll bridge code is open-sourced. The audit is line-itemed at $100,000. This is the work package that determines whether partner chains are a real ecosystem extension or a sandbox curiosity — without a trustworthy bridge, value can flow in but not back out, and the proposal's whole 'capture not cannibalise' argument collapses."
+    },
+    {
+      "node": "wp-pcf-2-tachys-design",
+      "depth": 1,
+      "title": "WP2 — getting the consensus protocol right",
+      "narrative": "The technical heart: [WP2](node:wp-pcf-2-tachys-design) at **1.33M ADA**, led by Well Typed. Outputs: a CIP for Tachýs accepted by M3; a production-quality implementation that compiles into the existing node; a Praos↔Tachýs consensus selector with **no Praos regressions**; and — crucially — a **formal security analysis (D2.7) published by M12**.\n\nA new consensus variant on a chain like Cardano is a high-stakes technical claim. The proposal acknowledges this by gating Vector mainnet deployment ([MS9 — M15](node:pcf-ms9)) on having both the formal analysis and PNSol's empirical adversarial validation in hand. The risk of being wrong here doesn't shrink because the team is experienced — it just means the verification cost is built into the budget."
+    },
+    {
+      "node": "pcf-ms9",
+      "depth": 1,
+      "title": "The 9-milestone delivery rhythm",
+      "narrative": "The 15-month programme is structured against nine programme milestones (MS1–MS9). Each work package's internal milestones map to these — so [MS1](node:pcf-ms1) at M1 is project kickoff for everyone, MS5 at M8 is when genesis quick-start has to work, **MS9 at M15** is project close: Tachýs deployed to Vector mainnet, upstream PR submitted to the Intersect-maintained node repo, documentation portal handed over, ≥3 external builder teams engaged.\n\nThe milestones create a coordination contract across six partners. If MS5 slips, MS7 (audit complete) slips, which slips MS8 (testnet KPIs validated), which slips MS9 (mainnet deployment). The proposal's [WP1 (Project Management)](node:wp-pcf-1-management) is explicitly framed as the 16% insurance premium that keeps that coordination from collapsing — multi-partner technical programmes 'fail through under-resourced coordination, not under-resourced engineering'."
+    },
+    {
+      "node": "kpi-active-partner-chains",
+      "depth": 1,
+      "title": "The KPIs the proposal asks the framework to adopt",
+      "narrative": "The Cardano 2030 Strategy Framework defines KPIs like [TVL](node:kpi-tvl), [MAU](node:kpi-mau) and [Annual Protocol Revenue](node:kpi-annual-protocol-revenue). The proposal supports all of those, but argues the framework **lacks the KPIs needed to track partner-chain ecosystem health**:\n\n- [Active Partner Chains](node:kpi-active-partner-chains) — currently 2 (Vector, Midnight); target 10 by 2030\n- [Cross-chain Bridge Volume](node:kpi-cross-chain-bridge-volume) — currently not tracked; target ≥$50M monthly by 2030\n- [Ecosystem Builder Pipeline](node:kpi-ecosystem-builder-pipeline) — currently 1 (AFF/Vector); target 20 by 2030\n\nThe Bridge Volume KPI is the substantive one: without it, the framework cannot tell a thriving partner-chain ecosystem from one where value leaks to fragmented L2s. This is a deliberate ask — adopt these and you can measure whether the factory worked."
+    },
+    {
+      "node": "kpi-annual-protocol-revenue",
+      "depth": 1,
+      "title": "The financial argument — does this pay back?",
+      "narrative": "The framework targets [≥16M ADA in annual protocol revenue](node:kpi-annual-protocol-revenue) by 2030, up from 3.5M today (~4.6× growth). The proposal's direct contribution per active partner chain: bridge transactions, settlement anchoring, SPO registration. A chain processing 100,000 bridge+settlement transactions per month — conservative for an institutional RWA chain — generates ~30,000–50,000 ADA in additional annual mainnet fee revenue.\n\n**Five active partner chains at the base estimate would contribute 150,000–250,000 ADA annually in direct fee revenue** — 4–7% of the current baseline as a floor that grows non-linearly with chain activity. The broader ADA-demand case (staking requirements, ecosystem capture, RWA market participation) is bigger but harder to quantify; the proposal puts the quantifiable floor on the table and argues the rest qualitatively."
+    },
+    {
+      "node": "repay-pcf-fx-and-unspent",
+      "depth": 1,
+      "title": "What goes back to the Treasury",
+      "narrative": "This proposal does *not* commit to a perpetual revenue share like Indigo's V2030RS. Its repayment commitment is narrower but unconditional:\n\n- ADA is drawn down at actual rates, not the assumed $0.25\n- Any positive difference between $0.25 and the rate at drawdown is identified at final reconciliation and **returned in full at project close (M15)**\n- Unspent ADA is returned at the same time\n\nThis is a pure conservative-buffer return — it doesn't promise Cardano upside if Tachýs becomes a hit, but it forecloses the FX-windfall scenario where ADA appreciates and the proposers keep the surplus."
+    },
+    {
+      "node": "comment-pcf-1",
+      "depth": 1,
+      "title": "What the community has said so far",
+      "narrative": "At the time of writing, one comment: a DRep ('Nimuë Lady of the Lake Pool') saying 'In favor of this!'. The proposal was submitted late in the cycle (22 April vs. an 8 May close), so substantive comment has not yet accumulated.\n\nThe critical questions to expect, given the structure: (1) Why is WP4 (bridging) so much larger than the others — is the audit cost realistic? (2) Does formal security analysis at M12 give the community enough time to scrutinise before mainnet deployment at M15? (3) How does this proposal coordinate with Midnight, the *other* in-production partner chain — is Midnight's bridge being deprecated or supported?"
+    }
+  ]
+}

--- a/data/tutorials/budget-2026-serviceplan-demand-engine.json
+++ b/data/tutorials/budget-2026-serviceplan-demand-engine.json
@@ -1,0 +1,73 @@
+{
+  "id": "budget-2026-serviceplan-demand-engine",
+  "title": "Serviceplan Demand Engine — Deep Dive",
+  "description": "What the Marketing Powered Demand Engine proposal actually delivers, why it's the largest ADA ask on the slate despite being non-technical, and the substantive criticisms that have already landed.",
+  "stops": [
+    {
+      "node": "bp-serviceplan-demand-engine",
+      "depth": 1,
+      "title": "The pitch in one sentence",
+      "narrative": "**20.87M ADA, 12 months, four work packages** to run an enterprise marketing pilot in three European markets that repositions Cardano as 'The Blockchain for Serious Business' — the high-integrity, mission-critical blockchain network for systems that must not fail.\n\nThis is the **largest ADA ask on the Budget 2026 slate**. It is also the only **non-technical** proposal: every cost line falls under [Engagement & Ecosystem support](node:cost-category-engagement-ecosystem) — there is no Labor line, no Development line, no Audit line. Every dollar is enterprise-marketing spend, split 53% media to 47% agency services."
+    },
+    {
+      "node": "org-serviceplan-group",
+      "depth": 1,
+      "title": "Why Serviceplan",
+      "narrative": "[Serviceplan Group](node:org-serviceplan-group) is Europe's largest owner-managed agency group: 6,500 employees in 40+ countries, €866M revenue, Cannes Lions 2025 Independent Network of the Year. Their unique credibility for *this* proposal is that they're the only major marketing agency that has actually **shipped Cardano infrastructure**: the [Masumi Network](node:demand-engine), built with NMKR, has been live on Cardano mainnet since November 2024 with 25,000+ on-chain transactions and a Cardano Foundation endorsement at WEF Davos 2025.\n\nPrior Cardano funding through Catalyst: Fund 13 #1300132 (Masumi, 1.53M ADA distributed, complete) and Fund 14 #1400079 (Masumi 2.0, in progress). Both were technology grants — this proposal is the agency saying 'we already proved we can build on Cardano; now let us run the *marketing*'."
+    },
+    {
+      "node": "demand-funnel",
+      "depth": 1,
+      "title": "The architecture — Attention → Proof → Qualified Leads",
+      "narrative": "The system the proposal builds is a [three-stage demand funnel](node:demand-funnel):\n\n- **Attention**: paid media (LinkedIn, OOH, podcasts, native advertising), event-centric activation around enterprise venues like Money20/20 and Gartner summits\n- **Proof**: the [Cardano Hub](node:cardano-hub) — a central evidence-and-engagement environment built around four enterprise questions: *Why Cardano? Why for me? Under which conditions? With which next steps?*\n- **Qualified Leads**: enterprise-sales hand-off into Intersect's Enterprise Working Group, partner matching, structured discussions\n\nEach vertical journey through the funnel follows: *Problem → Capability → Proof → Next Step*. The proposal's central claim is that Cardano's enterprise problem isn't technical capability but **demand-side legibility** — enterprises can't tell if Cardano is for them, and the Hub is the bet on fixing that."
+    },
+    {
+      "node": "wp-serviceplan-enable",
+      "depth": 1,
+      "title": "WP1 — Enable: build the foundation, gate everything else",
+      "narrative": "[WP1 Enable](node:wp-serviceplan-enable) at **3.82M ADA / $649k** is the foundation that every other work package depends on: brand positioning, Hub architecture, creative concept and visual identity, vertical journeys for the two pilot verticals.\n\nThis is the only WP funded *unconditionally* — the rest are explicitly gated:\n- WP1 → released upon DRep approval\n- WP2 → requires GMC sign-off on WP1\n- WP3 → requires demonstrated WP2 performance\n- WP4 → requires a passed KPI checkpoint\n\nThe accountability ladder is tight by construction. If the Hub doesn't ship, nothing else triggers. If WP2's first event activation doesn't demonstrate funnel performance, WP3's optimisation budget doesn't unlock."
+    },
+    {
+      "node": "wp-serviceplan-kickoff",
+      "depth": 1,
+      "title": "WP2 — Kick-off: the V1 DeFi event-centric blueprint",
+      "narrative": "[WP2 Kick-off](node:wp-serviceplan-kickoff) at **3.29M ADA / $560k** activates the first vertical (Institutional DeFi) with paid media and event-centric orchestration. The proposal models the activation around **Money20/20 Amsterdam** as a blueprint, with three phases: before (LinkedIn targeting, Hub pages live, SEA), during (venue-proximate OOH, geo-targeted ads, executive roundtables), after (4+ weeks of retargeting, whitepaper distribution, native recap articles).\n\nProjected reach for a Money20/20-comparable event: 9.6M LinkedIn impressions, 76,000 clicks, 3.6M OOH impressions, 80,000 native views. The 'flywheel' the proposal describes: on-site CTO interviews → published Hub case studies within a week → paid native advertorials on premium publishers → drive qualified traffic back to Hub → routing logic converts visitors to leads. By week eight post-event, third-party editorial coverage exists that compliance teams can reference."
+    },
+    {
+      "node": "wp-serviceplan-scale",
+      "depth": 1,
+      "title": "WP3 — Scale: the Q3 KPI checkpoint",
+      "narrative": "[WP3 Scale](node:wp-serviceplan-scale) at **3.92M ADA / $666k** is the optimisation phase: refine V1 DeFi based on Phase 2 data, deliver whitepapers, prepare the **WEF Davos billboard placement (19–23 January 2027)** as a general Cardano credibility signal — *not* vertical-specific.\n\nMost importantly, WP3 contains the **Q3 KPI checkpoint**: KPIs and routing performance are evaluated, and only then is budget unlocked for Verticals 3 and 4 (AI Business and Real World Assets, recommended for Year 2). Read this carefully — **WP4's 9.23M ADA is itself gated by this checkpoint**, even though it's in the proposal as a fully-funded line. Approval funds the *option* on V2; passing the checkpoint funds the *exercise*."
+    },
+    {
+      "node": "wp-serviceplan-supply-chain",
+      "depth": 1,
+      "title": "WP4 — V2 Supply Chain Traceability — the contested package",
+      "narrative": "[WP4 V2 Supply Chain](node:wp-serviceplan-supply-chain) at **9.23M ADA / $1.57M** — by far the largest WP — activates the second vertical end-to-end (Enable → Kick-off → Scale). Anchor event: **Gartner Application & Business Solutions Summit, London, 14–15 September 2026**.\n\nThe proposal claims a **16% efficiency gain vs. baseline** because the foundational system established in WP1 is reused. The targeting: global manufacturers, logistics providers, retail networks, ESG-driven brands. This is also the work package the community has explicitly criticised — see the comment thread in the next stop."
+    },
+    {
+      "node": "comment-serviceplan-2",
+      "depth": 1,
+      "title": "The substantive critique — wrong vertical",
+      "narrative": "The most substantive comment ([crowned](node:comment-serviceplan-2), 20 Apr 2026) supports Serviceplan as a marketing firm but objects sharply to the V2 Supply Chain Traceability vertical:\n\n> 'The verticals proposed are insane and would provide no value to the ecosystem. The bulk of the funding is for marketing V2 Supply Chain Traceability solutions on Cardano which is insane since there is zero market for this, our supply chain tracking solutions are stone-age crap and it's competing against chains that are designed from the ground up with supply chain traceability as the core use case.'\n\nThe critique is directional: it's not against the funnel architecture or the agency, it's that **9.23M ADA — the biggest line item on the slate — is being aimed at a vertical where Cardano has no competitive product**. Restructuring to focus everything on Institutional DeFi would address this critique without rewriting the rest of the proposal."
+    },
+    {
+      "node": "comment-serviceplan-3",
+      "depth": 1,
+      "title": "The other critique — market scope",
+      "narrative": "A DRep ([Nimuë Lady of the Lake Pool](node:comment-serviceplan-3)) asked: *'This proposal only targets the UK, Germany and Switzerland?'*\n\nThe pilot markets are explicitly UK / Germany / Switzerland (Brazil and Argentina noted on a LATAM watchlist for Year 2). The proposal's defence is that enterprise marketing is hub-centric and these are the highest-density enterprise-decision-maker markets in Europe. The implicit acknowledgement is that **a 12-month Treasury investment funds three rich markets**, deferring the global majority to whether the Year 2 verticals (V3/V4) get funded at all.\n\nThis is a real strategic question for ada holders: is enterprise marketing in three rich markets the right shape of bet? Or should the same ADA fund a less ambitious campaign across more markets?"
+    },
+    {
+      "node": "kpi-hub-traffic-engagement",
+      "depth": 1,
+      "title": "The new marketing KPI framework",
+      "narrative": "Beyond supporting all four [framework](node:kpi-tvl) [KPIs](node:kpi-monthly-transactions), the proposal introduces a **marketing-specific KPI framework** because the Strategy Framework explicitly notes that 'Marketing KPIs to broaden reach and engagement' are expected to be developed.\n\nThe four new KPIs:\n- [Hub Traffic & Engagement](node:kpi-hub-traffic-engagement) — qualified actions, downloads, click-depth\n- [Qualified Leads](node:kpi-qualified-leads) — handovers to Enterprise Working Group\n- [Enterprise Conversations](node:kpi-enterprise-conversations) — retargeting uplift, meeting conversions\n- [Brand & Perception](node:kpi-brand-perception) — sentiment in X/Reddit/dev communities, share-of-voice\n\nThese are operationally tractable and let the community measure whether the funnel is delivering. Whether they should be elevated to Strategy Framework Primary KPIs is a separate governance question."
+    },
+    {
+      "node": "repay-serviceplan-fx-buffer",
+      "depth": 1,
+      "title": "The FX-buffer repayment",
+      "narrative": "The 20.87M ADA request includes a **30% conversion buffer** applied to the current ADA/EUR rate. Should ADA and FX rates remain stable, **any surplus ADA beyond €2,978,738 / $3,518,917 will be returned to the Treasury**, minus documented ADA-to-EUR conversion costs (exchange fees, transaction fees, slippage, banking transfer costs).\n\nThis is the same pattern as PCF's repayment — a buffer-surplus return — but with a much larger buffer (30%) because all the spend is fiat-denominated agency and media work. If ADA strengthens during the campaign, that whole buffer comes back. If ADA weakens, the buffer covers the shortfall and nothing returns. This is the proposal's structural answer to the 'selling ADA at multi-year low' concern that hits every fiat-denominated proposal in the cycle."
+    }
+  ]
+}

--- a/data/tutorials/index.json
+++ b/data/tutorials/index.json
@@ -82,5 +82,29 @@
     "title": "Life of a Hydra Head",
     "description": "Follow a head from initialization through fan-out: the five phases, the on-chain state machine, and what happens when things go wrong.",
     "file": "data/tutorials/hydra-lifecycle.json"
+  },
+  {
+    "id": "budget-2026-overview",
+    "title": "Cardano Budget 2026 — the Process and the Slate",
+    "description": "How Cardano's CIP-1694 treasury budgeting process works, and a quick tour of the three proposals submitted to the 2026 cycle.",
+    "file": "data/tutorials/budget-2026-overview.json"
+  },
+  {
+    "id": "budget-2026-partner-chain-factory",
+    "title": "Partner Chain Factory — Deep Dive",
+    "description": "What the Partner Chain Factory proposal is actually building, why it matters for Cardano's competitive position, who's building it, and what could go wrong.",
+    "file": "data/tutorials/budget-2026-partner-chain-factory.json"
+  },
+  {
+    "id": "budget-2026-indigo-v2030rs",
+    "title": "Indigo V2030RS — Deep Dive",
+    "description": "What Indigo Foundation is asking the Treasury to fund, the four products that come out of it, the perpetual revenue-share that frames the ask, and the timing concern the community has raised.",
+    "file": "data/tutorials/budget-2026-indigo-v2030rs.json"
+  },
+  {
+    "id": "budget-2026-serviceplan-demand-engine",
+    "title": "Serviceplan Demand Engine — Deep Dive",
+    "description": "What the Marketing Powered Demand Engine proposal actually delivers, why it's the largest ADA ask on the slate despite being non-technical, and the substantive criticisms that have already landed.",
+    "file": "data/tutorials/budget-2026-serviceplan-demand-engine.json"
   }
 ]


### PR DESCRIPTION
## Summary

Four guided tours built on the Budget Proposal ontology added in PR #45. Each is deep enough to take a non-expert through goals, mechanics, money, and known objections.

| Tour | Stops | Audience |
|---|---|---|
| Cardano Budget 2026 — the Process and the Slate | 6 | Newcomer entry point: the budgeting process + the slate |
| Partner Chain Factory — Deep Dive | 11 | Anyone evaluating the largest technical proposal |
| Indigo V2030RS — Deep Dive | 10 | Anyone evaluating the perpetual revenue-share framing |
| Serviceplan Demand Engine — Deep Dive | 11 | Anyone evaluating the largest ADA ask + its critiques |

## Coverage per tour

Every tour explicitly covers: the pitch, the proposer's track record, the work-package decomposition, the financial structure, the repayment commitment, and the substantive community critique. Inline \`[label](node:nodeId)\` links keep the narrative connected to the underlying graph.

## Verification

Every tour stop targets a real \`gb:Node\` and every inline \`node:X\` link resolves — verified against the full merged store (cardano.ontology.ttl + cardano.ttl + governance.ttl + smart-contracts.ttl + the three budget-2026/*.ttl):

\`\`\`
ALL TOUR REFERENCES VALID
\`\`\`

## Test plan

- [ ] CI green
- [ ] All four tours appear under \"Tours\" in the sidebar
- [ ] Stops navigate the graph view and inline links resolve