### PR TITLE
Budget 2026: IO slate + Critical Integrations + SKOS classification

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -7,9 +7,20 @@
     { "label": "Cardano Domain",                          "format": "text/turtle", "path": "data/rdf/cardano.ttl" },
     { "label": "Governance",                              "format": "text/turtle", "path": "data/rdf/governance.ttl" },
     { "label": "Smart Contracts",                         "format": "text/turtle", "path": "data/rdf/smart-contracts.ttl" },
+    { "label": "Budget 2026 — Proposers",                 "format": "text/turtle", "path": "data/rdf/budget-2026/proposers.ttl" },
     { "label": "Budget 2026 — Partner Chain Factory",     "format": "text/turtle", "path": "data/rdf/budget-2026/partner-chain-factory.ttl" },
     { "label": "Budget 2026 — Indigo V2030RS",            "format": "text/turtle", "path": "data/rdf/budget-2026/indigo-v2030rs.ttl" },
-    { "label": "Budget 2026 — Serviceplan Demand Engine", "format": "text/turtle", "path": "data/rdf/budget-2026/serviceplan-demand-engine.ttl" }
+    { "label": "Budget 2026 — Serviceplan Demand Engine", "format": "text/turtle", "path": "data/rdf/budget-2026/serviceplan-demand-engine.ttl" },
+    { "label": "Budget 2026 — IO Developer Experience",   "format": "text/turtle", "path": "data/rdf/budget-2026/io-developer-experience.ttl" },
+    { "label": "Budget 2026 — IO Cardano Upgrades",       "format": "text/turtle", "path": "data/rdf/budget-2026/io-cardano-upgrades.ttl" },
+    { "label": "Budget 2026 — IO Consensus (Leios)",      "format": "text/turtle", "path": "data/rdf/budget-2026/io-consensus-leios.ttl" },
+    { "label": "Budget 2026 — IO L2 Scalability",         "format": "text/turtle", "path": "data/rdf/budget-2026/io-l2-scalability.ttl" },
+    { "label": "Budget 2026 — IO High Assurance",         "format": "text/turtle", "path": "data/rdf/budget-2026/io-high-assurance.ttl" },
+    { "label": "Budget 2026 — IO Maintenance",            "format": "text/turtle", "path": "data/rdf/budget-2026/io-maintenance.ttl" },
+    { "label": "Budget 2026 — IO Plutus",                 "format": "text/turtle", "path": "data/rdf/budget-2026/io-plutus.ttl" },
+    { "label": "Budget 2026 — IO Pogun",                  "format": "text/turtle", "path": "data/rdf/budget-2026/io-pogun.ttl" },
+    { "label": "Budget 2026 — IO Blockfrost",             "format": "text/turtle", "path": "data/rdf/budget-2026/io-blockfrost.ttl" },
+    { "label": "Budget 2026 — Critical Integrations",     "format": "text/turtle", "path": "data/rdf/budget-2026/critical-integrations.ttl" }
   ],
   "kinds": {
     "actor": {

--- a/data/config.json
+++ b/data/config.json
@@ -3,13 +3,13 @@
   "description": "Interactive knowledge maps of the Cardano ecosystem — governance, smart contracts, and more.",
   "sourceUrl": "https://github.com/lambdasistemi/cardano-knowledge-maps",
   "graphSources": [
-    { "format": "text/turtle", "path": "data/rdf/cardano.ontology.ttl" },
-    { "format": "text/turtle", "path": "data/rdf/cardano.ttl" },
-    { "format": "text/turtle", "path": "data/rdf/governance.ttl" },
-    { "format": "text/turtle", "path": "data/rdf/smart-contracts.ttl" },
-    { "format": "text/turtle", "path": "data/rdf/budget-2026/partner-chain-factory.ttl" },
-    { "format": "text/turtle", "path": "data/rdf/budget-2026/indigo-v2030rs.ttl" },
-    { "format": "text/turtle", "path": "data/rdf/budget-2026/serviceplan-demand-engine.ttl" }
+    { "label": "Cardano Ontology",                        "format": "text/turtle", "path": "data/rdf/cardano.ontology.ttl" },
+    { "label": "Cardano Domain",                          "format": "text/turtle", "path": "data/rdf/cardano.ttl" },
+    { "label": "Governance",                              "format": "text/turtle", "path": "data/rdf/governance.ttl" },
+    { "label": "Smart Contracts",                         "format": "text/turtle", "path": "data/rdf/smart-contracts.ttl" },
+    { "label": "Budget 2026 — Partner Chain Factory",     "format": "text/turtle", "path": "data/rdf/budget-2026/partner-chain-factory.ttl" },
+    { "label": "Budget 2026 — Indigo V2030RS",            "format": "text/turtle", "path": "data/rdf/budget-2026/indigo-v2030rs.ttl" },
+    { "label": "Budget 2026 — Serviceplan Demand Engine", "format": "text/turtle", "path": "data/rdf/budget-2026/serviceplan-demand-engine.ttl" }
   ],
   "kinds": {
     "actor": {

--- a/data/rdf/budget-2026/critical-integrations.ttl
+++ b/data/rdf/budget-2026/critical-integrations.ttl
@@ -1,0 +1,42 @@
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+@prefix gb:      <https://lambdasistemi.github.io/graph-browser/vocab/terms#> .
+@prefix gbkind:  <https://lambdasistemi.github.io/graph-browser/vocab/kinds#> .
+@prefix gbgroup: <https://lambdasistemi.github.io/graph-browser/vocab/groups#> .
+@prefix cardano: <https://lambdasistemi.github.io/cardano-knowledge-maps/vocab/cardano#> .
+@prefix n:       <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/> .
+
+# =========================================================================
+#  Cardano Budget 2026 — Proposal: Critical Integrations Budget
+#  Coalition: Input | Output Global + EMURGO + Cardano Foundation
+#             + Intersect + Midnight Foundation
+#  Request: 70,000,000 ADA
+#  Reference:
+#    https://intersectmbo.org/news/priming-cardano-for-2026-through-the-critical-integrations-budget-proposal
+# =========================================================================
+
+n:bp-critical-integrations a cardano:BudgetProposal ;
+  a gb:Node ;
+  a gbkind:proposal ;
+  gb:nodeId "bp-critical-integrations" ;
+  rdfs:label "Budget 2026 — Cardano Critical Integrations Budget" ;
+  gb:group gbgroup:proposals ;
+  cardano:applicantType "Company" ;
+  cardano:requestedAdaAmount "70000000"^^xsd:decimal ;
+  dcterms:description "₳70M coalition proposal funding ecosystem-critical integrations across the Cardano stack — wallet connectors, governance metadata pipelines, partner-chain bridges, Midnight cross-protocol plumbing, and shared infrastructure that no single proposer would shoulder alone. Submitted by a five-organisation coalition: IOG, EMURGO, Cardano Foundation, Intersect, and the Midnight Foundation." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://intersectmbo.org/news/priming-cardano-for-2026-through-the-critical-integrations-budget-proposal> ;
+  dcterms:subject cardano:Workstream-Infrastructure ,
+                  cardano:Workstream-Ecosystem ,
+                  cardano:Status-Voting .
+
+n:bp-critical-integrations cardano:partOfBudgetProcess n:cardano-budget-2026 .
+n:bp-critical-integrations cardano:administeredBy n:org-intersect .
+n:bp-critical-integrations cardano:proposedBy n:org-input-output .
+n:bp-critical-integrations cardano:proposedBy n:org-emurgo .
+n:bp-critical-integrations cardano:proposedBy n:org-cardano-foundation .
+n:bp-critical-integrations cardano:proposedBy n:org-intersect .
+n:bp-critical-integrations cardano:proposedBy n:org-midnight-foundation .

--- a/data/rdf/budget-2026/indigo-v2030rs.ttl
+++ b/data/rdf/budget-2026/indigo-v2030rs.ttl
@@ -33,7 +33,9 @@ n:bp-indigo-v2030rs a cardano:BudgetProposal ;
   cardano:applicantType "Company" ;
   dcterms:description "Cardano Budget 2026 proposal requesting 3,965,500 ADA (USD ~1.19M @ 0.30). Four-track scope: (1) iUSDt — institutional-grade tokenized RWA stablecoin linking Cardano with institutional liquidity funds; (2) Bitcoin DeFi markets on Indigo; (3) shielded iAssets on partner-chain ecosystems; (4) V2030RS — a landmark revenue-sharing model with the Cardano Treasury. Submitted on 2026-04-20." ;
   dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-  foaf:page <https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026/69e63a4ed6a29288536b11fc> .
+  foaf:page <https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026/69e63a4ed6a29288536b11fc> ;
+  dcterms:subject cardano:Workstream-DeFi ,
+                  cardano:Status-Voting .
 
 n:bp-indigo-v2030rs cardano:partOfBudgetProcess n:cardano-budget-2026 .
 n:bp-indigo-v2030rs cardano:proposedBy n:org-indigo-foundation .

--- a/data/rdf/budget-2026/io-blockfrost.ttl
+++ b/data/rdf/budget-2026/io-blockfrost.ttl
@@ -1,0 +1,32 @@
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+@prefix gb:      <https://lambdasistemi.github.io/graph-browser/vocab/terms#> .
+@prefix gbkind:  <https://lambdasistemi.github.io/graph-browser/vocab/kinds#> .
+@prefix gbgroup: <https://lambdasistemi.github.io/graph-browser/vocab/groups#> .
+@prefix cardano: <https://lambdasistemi.github.io/cardano-knowledge-maps/vocab/cardano#> .
+@prefix n:       <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/> .
+
+# =========================================================================
+#  Cardano Budget 2026 — Proposal: Blockfrost (Project Cayley + free-tier subsidy)
+#  Proposer: Blockfrost team (delivered as part of the IO slate)
+#  Reference: https://www.iog.io/news/io-treasury-proposals-the-5-minute-overview
+# =========================================================================
+
+n:bp-io-blockfrost a cardano:BudgetProposal ;
+  a gb:Node ;
+  a gbkind:proposal ;
+  gb:nodeId "bp-io-blockfrost" ;
+  rdfs:label "Budget 2026 — Blockfrost (Project Cayley)" ;
+  gb:group gbgroup:proposals ;
+  cardano:applicantType "Company" ;
+  dcterms:description "Decentralised data infrastructure for Cardano scaled to Leios throughput. Two parts: Project Cayley — a new indexing architecture rebuilt for higher tx rates and richer query semantics — and an operational subsidy keeping the free-tier API endpoint open during the funding period. Delivered by the Blockfrost team as part of the IO slate." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://www.iog.io/news/io-treasury-proposals-the-5-minute-overview> ;
+  dcterms:subject cardano:Workstream-Infrastructure ,
+                  cardano:Status-Voting .
+
+n:bp-io-blockfrost cardano:partOfBudgetProcess n:cardano-budget-2026 .
+n:bp-io-blockfrost cardano:proposedBy n:org-blockfrost-team .
+n:bp-io-blockfrost cardano:administeredBy n:org-intersect .

--- a/data/rdf/budget-2026/io-cardano-upgrades.ttl
+++ b/data/rdf/budget-2026/io-cardano-upgrades.ttl
@@ -1,0 +1,32 @@
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+@prefix gb:      <https://lambdasistemi.github.io/graph-browser/vocab/terms#> .
+@prefix gbkind:  <https://lambdasistemi.github.io/graph-browser/vocab/kinds#> .
+@prefix gbgroup: <https://lambdasistemi.github.io/graph-browser/vocab/groups#> .
+@prefix cardano: <https://lambdasistemi.github.io/cardano-knowledge-maps/vocab/cardano#> .
+@prefix n:       <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/> .
+
+# =========================================================================
+#  Cardano Budget 2026 — IO Proposal: Cardano Upgrades
+#  Proposer: Input | Output Global  |  Lead: Alexey Kuleshevich
+#  Reference: https://www.iog.io/news/io-treasury-proposals-the-5-minute-overview
+# =========================================================================
+
+n:bp-io-cardano-upgrades a cardano:BudgetProposal ;
+  a gb:Node ;
+  a gbkind:proposal ;
+  gb:nodeId "bp-io-cardano-upgrades" ;
+  rdfs:label "Budget 2026 — IO Cardano Upgrades" ;
+  gb:group gbgroup:proposals ;
+  cardano:applicantType "Company" ;
+  dcterms:description "Three platform-level ledger upgrades bundled into a single proposal: CIP-159 native micro-fee support, CPS-23 multi-asset on-chain treasury, and Babel Fees (paying transaction fees in non-ADA assets without holding ADA). All three target user-onboarding friction and treasury flexibility. Lead: Alexey Kuleshevich." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://www.iog.io/news/io-treasury-proposals-the-5-minute-overview> ;
+  dcterms:subject cardano:Workstream-SmartContracts ,
+                  cardano:Status-Voting .
+
+n:bp-io-cardano-upgrades cardano:partOfBudgetProcess n:cardano-budget-2026 .
+n:bp-io-cardano-upgrades cardano:proposedBy n:org-input-output .
+n:bp-io-cardano-upgrades cardano:administeredBy n:org-intersect .

--- a/data/rdf/budget-2026/io-consensus-leios.ttl
+++ b/data/rdf/budget-2026/io-consensus-leios.ttl
@@ -1,0 +1,33 @@
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+@prefix gb:      <https://lambdasistemi.github.io/graph-browser/vocab/terms#> .
+@prefix gbkind:  <https://lambdasistemi.github.io/graph-browser/vocab/kinds#> .
+@prefix gbgroup: <https://lambdasistemi.github.io/graph-browser/vocab/groups#> .
+@prefix cardano: <https://lambdasistemi.github.io/cardano-knowledge-maps/vocab/cardano#> .
+@prefix n:       <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/> .
+
+# =========================================================================
+#  Cardano Budget 2026 — IO Proposal: Consensus / Leios
+#  Proposer: Input | Output Global  |  Lead: Carlos Lopez De Lara
+#  Joint delivery: IOG + Intersect + multi-vendor consortium
+#  Reference: https://www.iog.io/news/io-treasury-proposals-the-5-minute-overview
+# =========================================================================
+
+n:bp-io-consensus-leios a cardano:BudgetProposal ;
+  a gb:Node ;
+  a gbkind:proposal ;
+  gb:nodeId "bp-io-consensus-leios" ;
+  rdfs:label "Budget 2026 — IO Consensus (Leios)" ;
+  gb:group gbgroup:proposals ;
+  cardano:applicantType "Company" ;
+  dcterms:description "Delivery of the Leios consensus upgrade — Ouroboros throughput-focused extension targeting a 10–65× sustained transaction-rate increase. Includes formal specification, reference implementation, security analysis, and mainnet-readiness work, with end-of-2026 mainnet activation as the headline milestone. Joint delivery between IOG, Intersect, and a multi-vendor consortium. Lead: Carlos Lopez De Lara." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://www.iog.io/news/io-treasury-proposals-the-5-minute-overview> ;
+  dcterms:subject cardano:Workstream-Consensus ,
+                  cardano:Status-Voting .
+
+n:bp-io-consensus-leios cardano:partOfBudgetProcess n:cardano-budget-2026 .
+n:bp-io-consensus-leios cardano:proposedBy n:org-input-output .
+n:bp-io-consensus-leios cardano:administeredBy n:org-intersect .

--- a/data/rdf/budget-2026/io-developer-experience.ttl
+++ b/data/rdf/budget-2026/io-developer-experience.ttl
@@ -1,0 +1,32 @@
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+@prefix gb:      <https://lambdasistemi.github.io/graph-browser/vocab/terms#> .
+@prefix gbkind:  <https://lambdasistemi.github.io/graph-browser/vocab/kinds#> .
+@prefix gbgroup: <https://lambdasistemi.github.io/graph-browser/vocab/groups#> .
+@prefix cardano: <https://lambdasistemi.github.io/cardano-knowledge-maps/vocab/cardano#> .
+@prefix n:       <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/> .
+
+# =========================================================================
+#  Cardano Budget 2026 — IO Proposal: Developer Experience
+#  Proposer: Input | Output Global  |  Lead: Robertino Martinez
+#  Reference: https://www.iog.io/news/io-treasury-proposals-the-5-minute-overview
+# =========================================================================
+
+n:bp-io-developer-experience a cardano:BudgetProposal ;
+  a gb:Node ;
+  a gbkind:proposal ;
+  gb:nodeId "bp-io-developer-experience" ;
+  rdfs:label "Budget 2026 — IO Developer Experience" ;
+  gb:group gbgroup:proposals ;
+  cardano:applicantType "Company" ;
+  dcterms:description "Six-month IO programme to improve Cardano developer experience: tooling consolidation, documentation overhaul, structured onboarding paths, and zero-to-MVP acceleration. Targets 30%+ growth in active developer adoption over the funding period. Lead: Robertino Martinez." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://www.iog.io/news/io-treasury-proposals-the-5-minute-overview> ;
+  dcterms:subject cardano:Workstream-Tooling ,
+                  cardano:Status-Voting .
+
+n:bp-io-developer-experience cardano:partOfBudgetProcess n:cardano-budget-2026 .
+n:bp-io-developer-experience cardano:proposedBy n:org-input-output .
+n:bp-io-developer-experience cardano:administeredBy n:org-intersect .

--- a/data/rdf/budget-2026/io-high-assurance.ttl
+++ b/data/rdf/budget-2026/io-high-assurance.ttl
@@ -1,0 +1,32 @@
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+@prefix gb:      <https://lambdasistemi.github.io/graph-browser/vocab/terms#> .
+@prefix gbkind:  <https://lambdasistemi.github.io/graph-browser/vocab/kinds#> .
+@prefix gbgroup: <https://lambdasistemi.github.io/graph-browser/vocab/groups#> .
+@prefix cardano: <https://lambdasistemi.github.io/cardano-knowledge-maps/vocab/cardano#> .
+@prefix n:       <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/> .
+
+# =========================================================================
+#  Cardano Budget 2026 — IO Proposal: Cardano High Assurance
+#  Proposer: Input | Output Global  |  Lead: Stefano Leone
+#  Reference: https://www.iog.io/news/io-treasury-proposals-the-5-minute-overview
+# =========================================================================
+
+n:bp-io-high-assurance a cardano:BudgetProposal ;
+  a gb:Node ;
+  a gbkind:proposal ;
+  gb:nodeId "bp-io-high-assurance" ;
+  rdfs:label "Budget 2026 — IO Cardano High Assurance" ;
+  gb:group gbgroup:proposals ;
+  cardano:applicantType "Company" ;
+  dcterms:description "An automated formal-verification toolkit aimed at making it economical for everyday smart-contract developers — not just specialists — to prove correctness properties of their Plutus contracts. Multi-language: covers Aiken, Plinth, and other Cardano contract languages. Lead: Stefano Leone." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://www.iog.io/news/io-treasury-proposals-the-5-minute-overview> ;
+  dcterms:subject cardano:Workstream-SmartContracts ,
+                  cardano:Status-Voting .
+
+n:bp-io-high-assurance cardano:partOfBudgetProcess n:cardano-budget-2026 .
+n:bp-io-high-assurance cardano:proposedBy n:org-input-output .
+n:bp-io-high-assurance cardano:administeredBy n:org-intersect .

--- a/data/rdf/budget-2026/io-l2-scalability.ttl
+++ b/data/rdf/budget-2026/io-l2-scalability.ttl
@@ -1,0 +1,34 @@
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+@prefix gb:      <https://lambdasistemi.github.io/graph-browser/vocab/terms#> .
+@prefix gbkind:  <https://lambdasistemi.github.io/graph-browser/vocab/kinds#> .
+@prefix gbgroup: <https://lambdasistemi.github.io/graph-browser/vocab/groups#> .
+@prefix cardano: <https://lambdasistemi.github.io/cardano-knowledge-maps/vocab/cardano#> .
+@prefix n:       <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/> .
+
+# =========================================================================
+#  Cardano Budget 2026 — IO Proposal: L2 Scalability
+#  Proposer: Input | Output Global  |  Lead: Sharan Koneria
+#  Joint delivery: IOG + Midgard Labs (+ Hydra team)
+#  Reference: https://www.iog.io/news/io-treasury-proposals-the-5-minute-overview
+# =========================================================================
+
+n:bp-io-l2-scalability a cardano:BudgetProposal ;
+  a gb:Node ;
+  a gbkind:proposal ;
+  gb:nodeId "bp-io-l2-scalability" ;
+  rdfs:label "Budget 2026 — IO L2 Scalability" ;
+  gb:group gbgroup:proposals ;
+  cardano:applicantType "Company" ;
+  dcterms:description "Production-readiness package for Cardano's L2 stack: Hydra Head hardening (operational tooling, bridges, observability), Midgard optimistic-rollup mainnet launch, and a shared L2 primitives library that future L2 projects can reuse. Joint delivery between IOG, Midgard Labs, and the Hydra team. Lead: Sharan Koneria." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://www.iog.io/news/io-treasury-proposals-the-5-minute-overview> ;
+  dcterms:subject cardano:Workstream-L2 ,
+                  cardano:Status-Voting .
+
+n:bp-io-l2-scalability cardano:partOfBudgetProcess n:cardano-budget-2026 .
+n:bp-io-l2-scalability cardano:proposedBy n:org-input-output .
+n:bp-io-l2-scalability cardano:administeredBy n:org-intersect .
+n:bp-io-l2-scalability cardano:proposedBy n:org-midgard-labs .

--- a/data/rdf/budget-2026/io-maintenance.ttl
+++ b/data/rdf/budget-2026/io-maintenance.ttl
@@ -1,0 +1,35 @@
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+@prefix gb:      <https://lambdasistemi.github.io/graph-browser/vocab/terms#> .
+@prefix gbkind:  <https://lambdasistemi.github.io/graph-browser/vocab/kinds#> .
+@prefix gbgroup: <https://lambdasistemi.github.io/graph-browser/vocab/groups#> .
+@prefix cardano: <https://lambdasistemi.github.io/cardano-knowledge-maps/vocab/cardano#> .
+@prefix n:       <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/> .
+
+# =========================================================================
+#  Cardano Budget 2026 — IO Proposal: Maintenance
+#  Proposer: Input | Output Global  |  Lead: Michael Karg
+#  Request: 62,100,000 ADA (single largest line in the IO slate)
+#  Reference: https://www.iog.io/news/io-treasury-proposals-the-5-minute-overview
+# =========================================================================
+
+n:bp-io-maintenance a cardano:BudgetProposal ;
+  a gb:Node ;
+  a gbkind:proposal ;
+  gb:nodeId "bp-io-maintenance" ;
+  rdfs:label "Budget 2026 — IO Maintenance" ;
+  gb:group gbgroup:proposals ;
+  cardano:applicantType "Company" ;
+  cardano:requestedAdaAmount "62100000"^^xsd:decimal ;
+  dcterms:description "Core platform maintenance for cardano-node, cardano-cli, cardano-ledger, and the supporting infrastructure: bug fixes, security patches, performance regressions, operational reliability, and SPO/exchange release support. The single largest line item in the IO slate at 62.1M ADA. Lead: Michael Karg." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://www.iog.io/news/io-treasury-proposals-the-5-minute-overview> ;
+  dcterms:subject cardano:Workstream-Maintenance ,
+                  cardano:Status-Voting .
+
+n:bp-io-maintenance cardano:partOfBudgetProcess n:cardano-budget-2026 .
+n:bp-io-maintenance cardano:proposedBy n:org-input-output .
+n:bp-io-maintenance cardano:administeredBy n:org-intersect .

--- a/data/rdf/budget-2026/io-plutus.ttl
+++ b/data/rdf/budget-2026/io-plutus.ttl
@@ -1,0 +1,34 @@
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+@prefix gb:      <https://lambdasistemi.github.io/graph-browser/vocab/terms#> .
+@prefix gbkind:  <https://lambdasistemi.github.io/graph-browser/vocab/kinds#> .
+@prefix gbgroup: <https://lambdasistemi.github.io/graph-browser/vocab/groups#> .
+@prefix cardano: <https://lambdasistemi.github.io/cardano-knowledge-maps/vocab/cardano#> .
+@prefix n:       <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/> .
+
+# =========================================================================
+#  Cardano Budget 2026 — IO Proposal: Plutus
+#  Proposer: Input | Output Global  |  Lead: Ziyang Liu
+#  Joint delivery: IOG + VacuumLabs
+#  Reference: https://www.iog.io/news/io-treasury-proposals-the-5-minute-overview
+# =========================================================================
+
+n:bp-io-plutus a cardano:BudgetProposal ;
+  a gb:Node ;
+  a gbkind:proposal ;
+  gb:nodeId "bp-io-plutus" ;
+  rdfs:label "Budget 2026 — IO Plutus" ;
+  gb:group gbgroup:proposals ;
+  cardano:applicantType "Company" ;
+  dcterms:description "Three Plutus-platform workstreams: developer-experience improvements (errors, traces, profiling), execution-efficiency work targeting roughly 25% reduction in script preparation overhead, and continued formal-specification effort for the Plutus Core language. Joint delivery between IOG and VacuumLabs. Lead: Ziyang Liu." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://www.iog.io/news/io-treasury-proposals-the-5-minute-overview> ;
+  dcterms:subject cardano:Workstream-SmartContracts ,
+                  cardano:Status-Voting .
+
+n:bp-io-plutus cardano:partOfBudgetProcess n:cardano-budget-2026 .
+n:bp-io-plutus cardano:proposedBy n:org-input-output .
+n:bp-io-plutus cardano:administeredBy n:org-intersect .
+n:bp-io-plutus cardano:proposedBy n:org-vacuumlabs .

--- a/data/rdf/budget-2026/io-pogun.ttl
+++ b/data/rdf/budget-2026/io-pogun.ttl
@@ -1,0 +1,33 @@
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+@prefix gb:      <https://lambdasistemi.github.io/graph-browser/vocab/terms#> .
+@prefix gbkind:  <https://lambdasistemi.github.io/graph-browser/vocab/kinds#> .
+@prefix gbgroup: <https://lambdasistemi.github.io/graph-browser/vocab/groups#> .
+@prefix cardano: <https://lambdasistemi.github.io/cardano-knowledge-maps/vocab/cardano#> .
+@prefix n:       <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/> .
+
+# =========================================================================
+#  Cardano Budget 2026 — IO Proposal: Pogun (Bitcoin DeFi)
+#  Proposer: Input | Output Global  |  Lead: Omer Husain
+#  Repayment: investment-style, 20% earnings return to Treasury
+#  Reference: https://www.iog.io/news/io-treasury-proposals-the-5-minute-overview
+# =========================================================================
+
+n:bp-io-pogun a cardano:BudgetProposal ;
+  a gb:Node ;
+  a gbkind:proposal ;
+  gb:nodeId "bp-io-pogun" ;
+  rdfs:label "Budget 2026 — IO Pogun (Bitcoin DeFi)" ;
+  gb:group gbgroup:proposals ;
+  cardano:applicantType "Company" ;
+  dcterms:description "End-to-end Bitcoin DeFi solution for Cardano comprising three components: a non-margin BTC credit market, BTC yield infrastructure, and a trust-minimised Bitcoin bridge. Structured as a treasury investment with a 20% earnings-return clause back to the Cardano Treasury rather than a pure grant. Lead: Omer Husain." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://www.iog.io/news/io-treasury-proposals-the-5-minute-overview> ;
+  dcterms:subject cardano:Workstream-DeFi ,
+                  cardano:Status-Voting .
+
+n:bp-io-pogun cardano:partOfBudgetProcess n:cardano-budget-2026 .
+n:bp-io-pogun cardano:proposedBy n:org-input-output .
+n:bp-io-pogun cardano:administeredBy n:org-intersect .

--- a/data/rdf/budget-2026/partner-chain-factory.ttl
+++ b/data/rdf/budget-2026/partner-chain-factory.ttl
@@ -35,7 +35,10 @@ n:bp-partner-chain-factory a cardano:BudgetProposal ;
   dcterms:description "15-month, six-partner consortium delivering an open-source Partner Chain Factory built on the Ouroboros Tachýs consensus variant: 1-2s confirmation, ~40× mainnet throughput, formal security analysis, automated deployment ≤4h, Cardano⇄partner-chain bridge with independent security audit, complete tooling and documentation, and two demonstrators (Vector internal testnet then Vector mainnet). Toolkit handed over to Intersect-maintained Cardano repositories at project close. Surplus ADA from FX above $0.25 returned to treasury." ;
   dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
   foaf:page <https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026/69e8c0e2ae91c89d305701f5> ;
-  rdfs:seeAlso <https://github.com/cardano-foundation/CIPs/pull/1149> .
+  rdfs:seeAlso <https://github.com/cardano-foundation/CIPs/pull/1149> ;
+  dcterms:subject cardano:Workstream-L2 ,
+                  cardano:Workstream-Infrastructure ,
+                  cardano:Status-Voting .
 
 n:bp-partner-chain-factory cardano:partOfBudgetProcess n:cardano-budget-2026 .
 n:bp-partner-chain-factory cardano:proposedBy n:org-ensurable-systems .

--- a/data/rdf/budget-2026/proposers.ttl
+++ b/data/rdf/budget-2026/proposers.ttl
@@ -1,0 +1,85 @@
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+@prefix gb:      <https://lambdasistemi.github.io/graph-browser/vocab/terms#> .
+@prefix gbkind:  <https://lambdasistemi.github.io/graph-browser/vocab/kinds#> .
+@prefix gbgroup: <https://lambdasistemi.github.io/graph-browser/vocab/groups#> .
+@prefix cardano: <https://lambdasistemi.github.io/cardano-knowledge-maps/vocab/cardano#> .
+@prefix n:       <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/> .
+
+# =========================================================================
+#  Shared proposer / co-lead organisation nodes referenced by multiple
+#  Budget 2026 proposals. Co-located here so individual proposal files
+#  stay focused on their own facts.
+# =========================================================================
+
+n:org-input-output a cardano:Proposer ;
+  a gb:Node ;
+  a gbkind:actor ;
+  gb:nodeId "org-input-output" ;
+  rdfs:label "Input | Output Global" ;
+  gb:group gbgroup:actors ;
+  dcterms:description "Engineering organisation behind Cardano (formerly IOHK / IOG). Submitter of nine of the Budget 2026 treasury proposals (Developer Experience, Cardano Upgrades, Consensus / Leios, L2 Scalability, High Assurance, Maintenance, Plutus, Pogun, Blockfrost) and a coalition partner on the Critical Integrations Budget." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://www.iog.io/> .
+
+n:org-emurgo a cardano:Proposer ;
+  a gb:Node ;
+  a gbkind:actor ;
+  gb:nodeId "org-emurgo" ;
+  rdfs:label "EMURGO" ;
+  gb:group gbgroup:actors ;
+  dcterms:description "Founding entity of Cardano focused on commercial adoption, enterprise partnerships, and ecosystem investments. Coalition partner on the Cardano Critical Integrations Budget 2026 proposal." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://www.emurgo.io/> .
+
+n:org-cardano-foundation a cardano:Proposer ;
+  a gb:Node ;
+  a gbkind:actor ;
+  gb:nodeId "org-cardano-foundation" ;
+  rdfs:label "Cardano Foundation" ;
+  gb:group gbgroup:actors ;
+  dcterms:description "Independent, Swiss-based standards organisation overseeing the Cardano protocol, ecosystem coordination, and adoption. Coalition partner on the Critical Integrations Budget 2026 proposal." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://cardanofoundation.org/> .
+
+n:org-midnight-foundation a cardano:Proposer ;
+  a gb:Node ;
+  a gbkind:actor ;
+  gb:nodeId "org-midnight-foundation" ;
+  rdfs:label "Midnight Foundation" ;
+  gb:group gbgroup:actors ;
+  dcterms:description "Steward of the Midnight partner chain — Cardano's confidentiality-focused L2 network. Coalition partner on the Critical Integrations Budget 2026 proposal." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://midnight.network/> .
+
+n:org-blockfrost-team a cardano:Proposer ;
+  a gb:Node ;
+  a gbkind:actor ;
+  gb:nodeId "org-blockfrost-team" ;
+  rdfs:label "Blockfrost Team" ;
+  gb:group gbgroup:actors ;
+  dcterms:description "Team behind the Blockfrost API platform — the dominant indexing and JSON-RPC layer for Cardano. Submitter of the Budget 2026 Blockfrost proposal (Project Cayley + free-tier API operational subsidy)." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://blockfrost.io/> .
+
+n:org-midgard-labs a cardano:Proposer ;
+  a gb:Node ;
+  a gbkind:actor ;
+  gb:nodeId "org-midgard-labs" ;
+  rdfs:label "Midgard Labs" ;
+  gb:group gbgroup:actors ;
+  dcterms:description "Team building Midgard, an optimistic-rollup L2 for Cardano. Co-leads the Budget 2026 L2 Scalability proposal alongside IOG and the Hydra team." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://midgard.xyz/> .
+
+n:org-vacuumlabs a cardano:Proposer ;
+  a gb:Node ;
+  a gbkind:actor ;
+  gb:nodeId "org-vacuumlabs" ;
+  rdfs:label "VacuumLabs" ;
+  gb:group gbgroup:actors ;
+  dcterms:description "Cardano-focused engineering partner, long-time contributor to wallet, ledger, and Plutus tooling. Co-lead on the Budget 2026 Plutus proposal alongside IOG." ;
+  dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
+  foaf:page <https://vacuumlabs.com/> .

--- a/data/rdf/budget-2026/serviceplan-demand-engine.ttl
+++ b/data/rdf/budget-2026/serviceplan-demand-engine.ttl
@@ -33,7 +33,9 @@ n:bp-serviceplan-demand-engine a cardano:BudgetProposal ;
   cardano:applicantType "Company" ;
   dcterms:description "Cardano Budget 2026 proposal requesting 20,871,418 ADA (USD ~3.55M @ 0.17). 12-month enterprise marketing pilot positioning Cardano as 'The Blockchain for Serious Business' through a three-stage funnel (Attention → Proof → Qualified Leads). Pilot verticals: Institutional DeFi (V1) and Supply Chain Traceability (V2). Pilot markets: UK, Germany, Switzerland. Targets: 45M paid impressions, 320K native views, 300K Hub clicks. Total agency investment: €2,978,738 (53% media / 47% agency services). 30% ADA/EUR conversion buffer baked into the requested amount; surplus returns to Treasury minus FX conversion costs." ;
   dcterms:isPartOf <https://github.com/lambdasistemi/cardano-knowledge-maps/rdf> ;
-  foaf:page <https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026/69e21a177a2045bdd2281d1a> .
+  foaf:page <https://hydra-voting.intersectmbo.org/votes/cardano-budget-2026/69e21a177a2045bdd2281d1a> ;
+  dcterms:subject cardano:Workstream-Ecosystem ,
+                  cardano:Status-Voting .
 
 n:bp-serviceplan-demand-engine cardano:partOfBudgetProcess n:cardano-budget-2026 .
 n:bp-serviceplan-demand-engine cardano:proposedBy n:org-serviceplan-group .

--- a/data/rdf/cardano.ontology.ttl
+++ b/data/rdf/cardano.ontology.ttl
@@ -41,6 +41,78 @@ cardano:CardanoSmartContractScheme a skos:ConceptScheme ;
   rdfs:label "Cardano Smart Contracts" ;
   dcterms:description "Plutus platform, languages, EUTxO model, and tooling." .
 
+cardano:BudgetProposalScheme a skos:ConceptScheme ;
+  rdfs:label "Budget Proposal Classification" ;
+  dcterms:description "Two-axis classification for cardano:BudgetProposal instances: Workstream (what the proposal builds) and Status (lifecycle stage). Proposals declare membership via dcterms:subject; the two axes are independent and may both be set." .
+
+# -- Workstream axis (what the proposal builds) -------------------------------
+# 8 workstreams covering the Budget 2026 cycle. A proposal MAY carry more
+# than one if it spans domains.
+
+cardano:Workstream-Consensus a skos:Concept ;
+  skos:inScheme cardano:BudgetProposalScheme ;
+  skos:prefLabel "Consensus" ;
+  dcterms:description "Ouroboros consensus protocol research, design, and implementation — Leios, Peras, Tachýs, certificate aggregation, header diffusion." .
+
+cardano:Workstream-L2 a skos:Concept ;
+  skos:inScheme cardano:BudgetProposalScheme ;
+  skos:prefLabel "L2 Scalability" ;
+  dcterms:description "Layer 2 scaling: Hydra, Midgard, partner chains, isomorphic state channels, sidechains, optimistic rollups." .
+
+cardano:Workstream-SmartContracts a skos:Concept ;
+  skos:inScheme cardano:BudgetProposalScheme ;
+  skos:prefLabel "Smart Contracts" ;
+  dcterms:description "Plutus core: language design, runtime, cost model, builtins, formal specification, formal verification toolkits." .
+
+cardano:Workstream-DeFi a skos:Concept ;
+  skos:inScheme cardano:BudgetProposalScheme ;
+  skos:prefLabel "DeFi" ;
+  dcterms:description "Application-layer DeFi: lending, AMMs, stablecoins, oracles, BTC bridges, cross-chain liquidity, dApp protocols." .
+
+cardano:Workstream-Tooling a skos:Concept ;
+  skos:inScheme cardano:BudgetProposalScheme ;
+  skos:prefLabel "Tooling" ;
+  dcterms:description "Developer experience: SDKs, IDE plugins, CLIs, transaction builders, simulators, documentation, onboarding paths." .
+
+cardano:Workstream-Maintenance a skos:Concept ;
+  skos:inScheme cardano:BudgetProposalScheme ;
+  skos:prefLabel "Maintenance" ;
+  dcterms:description "Core platform maintenance: cardano-node, cardano-cli, ledger, security patches, performance regressions, operational reliability." .
+
+cardano:Workstream-Infrastructure a skos:Concept ;
+  skos:inScheme cardano:BudgetProposalScheme ;
+  skos:prefLabel "Infrastructure" ;
+  dcterms:description "Infrastructure providers and indexers: Blockfrost, db-sync, Ogmios, Kupo, chain-following, RPC layers, monitoring." .
+
+cardano:Workstream-Ecosystem a skos:Concept ;
+  skos:inScheme cardano:BudgetProposalScheme ;
+  skos:prefLabel "Ecosystem" ;
+  dcterms:description "Ecosystem development: marketing, demand generation, partnerships, events, education, community programs." .
+
+# -- Status axis (lifecycle stage) --------------------------------------------
+# 4-state lifecycle per Decision 6: Submitted → Voting → Approved → Rejected.
+# Approved collapses Ratified+Enacted; Rejected covers withdrawn-or-failed.
+
+cardano:Status-Submitted a skos:Concept ;
+  skos:inScheme cardano:BudgetProposalScheme ;
+  skos:prefLabel "Submitted" ;
+  dcterms:description "Proposal is published on Intersect and open for community comment, but the on-chain DRep voting window has not opened yet." .
+
+cardano:Status-Voting a skos:Concept ;
+  skos:inScheme cardano:BudgetProposalScheme ;
+  skos:prefLabel "Voting" ;
+  dcterms:description "Proposal is live on-chain as a Treasury Withdrawal governance action; DReps, SPOs, and the Constitutional Committee are voting within the action lifetime." .
+
+cardano:Status-Approved a skos:Concept ;
+  skos:inScheme cardano:BudgetProposalScheme ;
+  skos:prefLabel "Approved" ;
+  dcterms:description "Proposal cleared all voting thresholds and is ratified or already enacted. Treasury funds are released per the proposal's milestone schedule." .
+
+cardano:Status-Rejected a skos:Concept ;
+  skos:inScheme cardano:BudgetProposalScheme ;
+  skos:prefLabel "Rejected" ;
+  dcterms:description "Proposal failed to clear voting thresholds, expired, or was withdrawn before enactment. No treasury funds released." .
+
 # ==============================================================================
 # Classes — Governance domain
 # ==============================================================================

--- a/flake.lock
+++ b/flake.lock
@@ -55,11 +55,11 @@
         "purescript-overlay": "purescript-overlay"
       },
       "locked": {
-        "lastModified": 1776955065,
-        "narHash": "sha256-E71ilz7dbJvh/jp3583+5vjkDByxGBmJPvBGM4eG17s=",
+        "lastModified": 1777050988,
+        "narHash": "sha256-bDytuW5xINbk75tgnp1J9v1qps3xlNJotAu7n+erUE8=",
         "owner": "lambdasistemi",
         "repo": "graph-browser",
-        "rev": "51ee6891fc90affcba6231c570bd2bd5c27c31ed",
+        "rev": "cbf9affc8a641ea5245c2d13619d4d8b9852260e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Closes #48.

## Scope

Five-commit stack rolling out the Budget 2026 cycle in the graph and putting every proposal under a SKOS classification.

| commit | what |
|--------|------|
| 686867d | Bumps graph-browser flake input to cbf9aff so the new Composed-graphs UI (Sources sidebar with per-source toggle) is available downstream. Upstream issue: https://github.com/lambdasistemi/graph-browser/issues/70 |
| 332220d | Adds a `label` to every `graphSources` entry in `data/config.json` so the new Sources sidebar reads as a domain table of contents instead of raw paths. |
| f9ccf8c | Adds `cardano:BudgetProposalScheme` SKOS concept scheme to the ontology with two independent axes: Workstream (8 concepts) and Status (4 concepts). Risk axis intentionally excluded — it is a judgment, not a description, and will live with technical assessments when those land. |
| 2eb3f11 | Tags the 3 existing proposals (Partner Chain Factory, Indigo V2030RS, Serviceplan Demand Engine) with `dcterms:subject` triples for workstream + status. |
| 0bdae60 | Scaffolds the rest of the cycle: the 9-proposal IO slate plus the 70M-ADA coalition Critical Integrations Budget. Stub-grade per-proposal TTLs co-located with shared proposer / co-lead nodes in `budget-2026/proposers.ttl`. |

## Result

13 proposals now visible in the graph, each as its own `graphSource` toggle. SPARQL summary verified locally:

| workstream | proposals |
|------------|-----------|
| Consensus | Leios |
| L2 | Partner Chain Factory, IO L2 Scalability |
| SmartContracts | Cardano Upgrades, High Assurance, Plutus |
| DeFi | Indigo V2030RS, Pogun |
| Tooling | IO Developer Experience |
| Maintenance | IO Maintenance |
| Infrastructure | Partner Chain Factory, Blockfrost, Critical Integrations |
| Ecosystem | Serviceplan Demand Engine, Critical Integrations |

All proposals are currently `Status-Voting` (DRep window open, deadline 2026-05-24).

## Design decisions encoded

The implementation reflects the design discussion captured in the issue:

- **A — Per-proposal source granularity**: each proposal lives in its own TTL and gets its own toggle in the Sources sidebar.
- **C — Hybrid assessment shape**: deferred (assessment ontology dropped from this PR; will be a follow-up).
- **A — Workstream + Status only**: no Risk axis on proposals. Risk is a judgment that will live with assessment nodes.
- **B — 8 workstreams**: Consensus, L2, SmartContracts, DeFi, Tooling, Maintenance, Infrastructure, Ecosystem.
- **B — 4 statuses**: Submitted, Voting, Approved, Rejected (Approved collapses ratified+enacted).

## Out of scope (follow-up issues)

- Technical-assessment ontology (separate node, attribution, signatures)
- Per-proposal ADA amounts / milestone breakdowns where not yet published
- SPARQL views surfacing the new taxonomy (`Proposals by Workstream`, `Proposals in Voting`)

## Stale PR

PR #32 is fully obsolete — its description still talks about migrating away from `graph.ttl`, which has long since been split. Will close it after this lands.

## Validation

```
nix build                                                # OK
riot --validate on every TTL touched                     # all 16 OK
SPARQL listing of every BudgetProposal + ws + status     # 13 rows
```

## Sources

- https://www.iog.io/news/io-treasury-proposals-the-5-minute-overview
- https://intersectmbo.org/news/priming-cardano-for-2026-through-the-critical-integrations-budget-proposal
- https://intersectmbo.org/news/building-a-2026-ecosystem-budget-for-cardano