### PR TITLE
feat(vocab): Phase A.1 — load-bearing tx-semantic predicates (companion to cardano-tx-tools#70)

### DIFF
--- a/data/rdf/transactions.ttl
+++ b/data/rdf/transactions.ttl
@@ -333,6 +333,12 @@ cardano:mintsAsset a rdf:Property ;
   dcterms:description "Binds a mint entry to the (policy, asset-name) pair it touches." .
 
 # ==============================================================================
+
+cardano:hasAssetValue a rdf:Property ;
+  rdfs:label "hasAssetValue" ;
+  rdfs:domain cardano:Output ;
+  dcterms:description "Binds an Output (or any value-bearing subject) to its multi-asset value list head (an rdf:List of asset-quantity entries). Distinct from cardano:mintsAsset which is mint-context-scoped." .
+
 # Properties — Reward-account / Withdrawal (Phase A.1)
 # ==============================================================================
 

--- a/data/rdf/transactions.ttl
+++ b/data/rdf/transactions.ttl
@@ -301,3 +301,82 @@ cardano:DRepKey    skos:related cardano:DRepScript .
 cardano:Identifier owl:hasKey ( cardano:leafType cardano:bytesHex ) .
 
 cardano:resolvedTo  owl:inverseOf  cardano:hasResolution .
+
+# ==============================================================================
+# Properties — Input position (Phase A.1)
+# ==============================================================================
+
+cardano:fromTxOutRef a rdf:Property ;
+  rdfs:label "fromTxOutRef" ;
+  rdfs:domain cardano:Input ;
+  rdfs:range  rdfs:Literal ;
+  dcterms:description "The TxIn reference '<txid>#<ix>' for a spending or reference or collateral input." .
+
+# ==============================================================================
+# Properties — Value semantics (Phase A.1)
+# ==============================================================================
+
+cardano:lovelace a rdf:Property ;
+  rdfs:label "lovelace" ;
+  rdfs:range  xsd:integer ;
+  dcterms:description "An ADA-denominated value, in lovelace (1 ADA = 1_000_000 lovelace). Used on Output, Withdrawal, and any value-bearing subject." .
+
+cardano:quantity a rdf:Property ;
+  rdfs:label "quantity" ;
+  rdfs:range  xsd:integer ;
+  dcterms:description "A signed integer quantity (negative values denote burns in a mint context)." .
+
+cardano:mintsAsset a rdf:Property ;
+  rdfs:label "mintsAsset" ;
+  rdfs:domain cardano:Mint ;
+  dcterms:description "Binds a mint entry to the (policy, asset-name) pair it touches." .
+
+# ==============================================================================
+# Properties — Reward-account / Withdrawal (Phase A.1)
+# ==============================================================================
+
+cardano:withdrawalAccount a rdf:Property ;
+  rdfs:label "withdrawalAccount" ;
+  rdfs:domain cardano:Withdrawal ;
+  dcterms:description "Binds a withdrawal to its reward-account identifier (a stake credential)." .
+
+# ==============================================================================
+# Properties — Body-root extra fields (Phase A.1)
+# ==============================================================================
+
+cardano:networkId a rdf:Property ;
+  rdfs:label "networkId" ;
+  rdfs:domain cardano:Transaction ;
+  rdfs:range  xsd:integer ;
+  dcterms:description "The network id (0 = testnet, 1 = mainnet) declared on the transaction body when present." .
+
+cardano:scriptDataHash a rdf:Property ;
+  rdfs:label "scriptDataHash" ;
+  rdfs:domain cardano:Transaction ;
+  dcterms:description "The script-data hash declared on the transaction body when any Plutus scripts are exercised." .
+
+cardano:auxiliaryDataHash a rdf:Property ;
+  rdfs:label "auxiliaryDataHash" ;
+  rdfs:domain cardano:Transaction ;
+  dcterms:description "The auxiliary-data hash declared on the transaction body when metadata or auxiliary data is attached." .
+
+# ==============================================================================
+# Properties — Validity interval sub-fields (Phase A.1)
+# ==============================================================================
+#
+# Per D-001 in cardano-tx-tools specs/070-body-emit-conway-semantic/plan.md,
+# the validity interval emits as an object-shape sub-block under the existing
+# cardano:hasValidityInterval predicate:
+#   _:tx cardano:hasValidityInterval _:interval1 .
+#   _:interval1 cardano:intervalStart <slot> ;
+#               cardano:intervalEnd   <slot> .
+
+cardano:intervalStart a rdf:Property ;
+  rdfs:label "intervalStart" ;
+  rdfs:range  xsd:integer ;
+  dcterms:description "The inclusive lower slot bound of a validity interval (Conway 'validityIntervalStart')." .
+
+cardano:intervalEnd a rdf:Property ;
+  rdfs:label "intervalEnd" ;
+  rdfs:range  xsd:integer ;
+  dcterms:description "The exclusive upper slot bound of a validity interval (Conway 'invalidHereafter' / TTL)." .

--- a/data/rdf/transactions.ttl
+++ b/data/rdf/transactions.ttl
@@ -4,6 +4,7 @@
 @prefix owl:     <http://www.w3.org/2002/07/owl#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
 
 # ==============================================================================
 # Ontology header


### PR DESCRIPTION
## Summary

Companion to [cardano-tx-tools#70](https://github.com/lambdasistemi/cardano-tx-tools/issues/70) — the body-emitter Conway semantic-completeness ticket.

Adds **ten properties** the cardano-tx-tools#70 emitter requires to surface real Conway semantic content. Append-only patch — no edits to the existing Phase A header or any declared term.

| Property | Domain (when meaningful) | Range | Purpose |
|---|---|---|---|
| `cardano:fromTxOutRef` | `cardano:Input` | `rdfs:Literal` | TxIn reference \`<txid>#<ix>\` for spending / reference / collateral inputs |
| `cardano:lovelace` | (any value-bearing) | `xsd:integer` | ADA-denominated value (1 ADA = 1\_000\_000 lovelace) |
| `cardano:quantity` | (any quantity-bearing) | `xsd:integer` | Signed integer (negative = burn in mint context) |
| `cardano:mintsAsset` | `cardano:Mint` | (subject) | Binds a mint entry to its `(policy, asset-name)` pair |
| `cardano:withdrawalAccount` | `cardano:Withdrawal` | (subject) | Binds a withdrawal to its reward-account identifier |
| `cardano:networkId` | `cardano:Transaction` | `xsd:integer` | Network id (0 testnet, 1 mainnet) |
| `cardano:scriptDataHash` | `cardano:Transaction` | (bytes-hex) | Script-data hash on Plutus-bearing bodies |
| `cardano:auxiliaryDataHash` | `cardano:Transaction` | (bytes-hex) | Auxiliary-data hash on metadata-bearing bodies |
| `cardano:intervalStart` | (validity-interval object) | `xsd:integer` | Inclusive lower slot bound — Conway \`validityIntervalStart\` |
| `cardano:intervalEnd` | (validity-interval object) | `xsd:integer` | Exclusive upper slot bound — Conway \`invalidHereafter\` / TTL |

The two interval sub-predicates support the existing `cardano:hasValidityInterval` predicate's object-shape sub-block per [D-001 in cardano-tx-tools#70's plan](https://github.com/lambdasistemi/cardano-tx-tools/blob/070-body-emit-conway-semantic/specs/070-body-emit-conway-semantic/spec.md):

\`\`\`turtle
_:tx cardano:hasValidityInterval _:interval1 .
_:interval1 cardano:intervalStart <slot> ;
            cardano:intervalEnd   <slot> .
\`\`\`

## Why now

cardano-tx-tools#70 closes the **Completeness — non-negotiable** gate of [epic cardano-tx-tools#46](https://github.com/lambdasistemi/cardano-tx-tools/issues/46). The merged predecessor #58 shipped a body emitter whose output surfaces structural stubs — \`_:inputK a cardano:Input .\` — because its acceptance contract gated byte-equivalence and reproducibility but not operator-visible semantic content. #70 closes that gap; these ten predicates are the load-bearing names the #70 emitter requires.

The #70 CI gate parses a **vendored pin** of \`transactions.ttl\` under \`test/fixtures/canonical-vocab/\` rather than fetching the live file, so #70's lifecycle is decoupled from this PR's lifecycle. When this PR merges, #70's pin refreshes to that commit. Until then, #70's implementation slices stage against the additions named here.

## Out of scope (separate ticket when ready)

- Certificate class subtypes: `CertificateStakeRegistration`, `CertificatePoolRegistration`, etc.
- Governance-procedure classes: `Proposal`, `Vote`, `DRepRegistration`, etc.
- cardano-tx-tools#58-inherited drift: `cardano:Mint`, `cardano:Policy`, `cardano:Withdrawal`, `cardano:StakeDelegation`, `cardano:VoteDelegation`, `cardano:Pool`, `cardano:DRep`, `cardano:onCredential`, `cardano:withAmount`, `cardano:toPool`, `cardano:toDRep` — used by the #58 emitter but not declared in canonical `transactions.ttl`. cardano-tx-tools#70 partially cleans the drift inline (`onCredential` / `withAmount` → `withdrawalAccount` / `lovelace`); the rest is a future kmaps ticket.

## Base pin

Branched from `main` @ \`8597fbd571188b42999ee0b24a8247bda7e717b9\` (Phase A header `0.1.0-phaseA`, 303 lines). Append-only patch — no edits to existing declarations.

## Test plan

- [ ] Visual review of the ten property declarations (rdfs:domain / rdfs:range / dcterms:description shape matches Phase A style)
- [ ] Verify no collision with existing declared terms (`grep -n '^cardano:' data/rdf/transactions.ttl` shows the new properties cleanly appended)
- [ ] Confirm the interval-object shape (D-001) is the right call vs separate \`hasTtl\` + \`hasValidityRangeStart\` flat predicates
- [ ] After merge, cardano-tx-tools#70 refreshes its vendored pin (single bisect-safe \`chore(070): refresh canonical-vocab pin\` commit on PR #77)