### PR TITLE
feat(vocab): Phase A.4 — cardano:decodeError predicate (companion to cardano-tx-tools#50)

### DIFF
--- a/data/rdf/transactions.ttl
+++ b/data/rdf/transactions.ttl
@@ -188,6 +188,11 @@ cardano:decodedAs a rdf:Property ;
   rdfs:label "decodedAs" ;
   dcterms:description "The decoded structured form of a datum or redeemer, when available." .
 
+cardano:decodeError a owl:DatatypeProperty ;
+  rdfs:label "decodeError" ;
+  rdfs:range  xsd:string ;
+  dcterms:description "Human-readable error message attached to a subject whose CBOR payload was present but failed CIP-57 blueprint typed-decoding (malformed bytes, wrong shape, missing schema, or unresolved $ref). Emitted alongside the opaque-bytes fallback (cardano:hasRawBytes) so a SPARQL view can detect decode failures without parsing emitter logs. Domain intentionally left open: any subject that could carry an opaque-bytes payload (Datum, Redeemer, Script, OpaqueLeaf, …) may also carry a decodeError when blueprint decoding fails — mirrors the permissive shape of cardano:hasRawBytes." .
+
 cardano:hasHash a rdf:Property ;
   rdfs:label "hasHash" ;
   dcterms:description "The hash of a datum, redeemer, script, or other hashable artifact." .

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Pre-push and pre-commit gate for PR backing issue #58
+# (Phase A.4 vocab: declare cardano:decodeError predicate; companion to
+#  lambdasistemi/cardano-tx-tools#50 / T106 in epic #46).
+# Subagents MUST run ./gate.sh and observe success before returning a commit.
+# Removed in the final `chore: drop gate.sh (ready for review)` commit before
+# the PR is marked ready.
+set -euo pipefail
+
+git diff --check
+
+nix develop --quiet -c just ci


### PR DESCRIPTION
## Summary

Phase A.4 of the Cardano transaction vocabulary. Adds a single OWL
`DatatypeProperty` — `cardano:decodeError` — that the CIP-57
blueprint-driven typed-emit walker in
[cardano-tx-tools#50](https://github.com/lambdasistemi/cardano-tx-tools/issues/50)
(PR [#79](https://github.com/lambdasistemi/cardano-tx-tools/pull/79))
needs to surface decode failures as RDF without losing them in
stderr.

Resolves [#58](https://github.com/lambdasistemi/cardano-knowledge-maps/issues/58).
Companion to cardano-tx-tools#50 / T106 under epic
[cardano-tx-tools#46](https://github.com/lambdasistemi/cardano-tx-tools/issues/46).

## What changes

`data/rdf/transactions.ttl`: one new term beside the existing
`cardano:hasRawBytes` / `cardano:decodedAs` block:

- `cardano:decodeError` — `owl:DatatypeProperty`, range
  `xsd:string`, no `rdfs:domain` restriction (mirrors the permissive
  shape of `cardano:hasRawBytes`: any subject that could carry an
  opaque-bytes payload may also carry a decode-error string when
  blueprint decoding fails).

Downstream the emitter pairs the opaque fallback with the new
error string, e.g.:

```turtle
_:datumX cardano:hasRawBytes "5901a3..."^^xsd:hexBinary ;
         cardano:decodeError "CBOR decode failed at offset 17: expected Bytes, got List" .
```

…so a SPARQL view (cardano-tx-tools#51) can surface decode failures
without parsing logs.

## Phase A pattern

Follows the precedent set by
[#55](https://github.com/lambdasistemi/cardano-knowledge-maps/pull/55) (Phase A.1),
[#56](https://github.com/lambdasistemi/cardano-knowledge-maps/pull/56) (Phase A.2),
[#57](https://github.com/lambdasistemi/cardano-knowledge-maps/pull/57) (Phase A.3):
single-file append-only edit to `data/rdf/transactions.ttl`; no edits
to `data/rdf/cardano.ttl`; OWL 2 RL profile preserved.

## Verification

- `nix develop -c just ci` green locally (build + validate +
  owl-smoke).
- `validate-graph-sources` parses the patched
  `data/rdf/transactions.ttl` clean.
- `owl-smoke` (EYE reasoner over the baseline + sameas-key fixtures)
  still passes — no new inconsistency.

## Out of scope

- Any other vocab terms (e.g. `cardano:partialDecode`,
  `cardano:schemaVersion`). Defer to Phase A.5+ tickets.
- Edits to `data/rdf/cardano.ttl` — `xsd:string` is already
  imported by `transactions.ttl`.
- SPARQL views exercising the new term — cardano-tx-tools#51.

## PR status

Draft until the feat commit lands and the gate is re-run at the
post-feat HEAD.