### PR TITLE
docs: align README with repo state and add agent layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Repository Agent Guide
+
+## What this repo is
+
+Cardano Knowledge Maps is a **data-only** repository: Turtle RDF graph sources, a SPARQL query catalog, and guided tours describing the Cardano ecosystem (CIP-1694 governance, Plutus smart contracts, Conway transactions, Budget 2026 proposals). The viewer is [graph-browser](https://github.com/lambdasistemi/graph-browser); CI assembles and deploys the site to GitHub Pages at <https://lambdasistemi.github.io/cardano-knowledge-maps/>. There is no application code here — changes are RDF triples, SPARQL queries, tutorial stops, and viewer configuration.
+
+## How to work here
+
+- Enter the dev shell first: `nix develop` (provides Python with rdflib, `just`, `jq`, and the EYE reasoner)
+- Validate all graph sources: `nix develop --quiet -c just validate`
+- Run OWL 2 RL inference smoke: `nix develop --quiet -c just owl-smoke`
+- Build the deployable site: `nix build` (output in `./result`)
+- Full local gate: `nix develop --quiet -c just ci`
+- Data-authoring rules live in `.specify/memory/constitution.md`: every node needs a `cardano:` type in `data/rdf/cardano.ontology.ttl`, every edge predicate needs a `cardano:` property definition and a `gbedge:` alignment, and nodes shared between topic files are promoted to `data/rdf/cardano.ttl`.
+- `data/rdf/transactions.ttl` is vendored from cardano-ledger-rdf — never edit it here; refresh it per `data/rdf/PINNED.md`.
+- All changes go through PRs; never push to main.
+
+## Skills
+
+Activatable procedures live under `skills/`. Load the one whose description matches your task:
+
+- `skills/cardano-knowledge-maps-guide/` — repository map, verified build/test/run commands, how the data layer composes, and where answers live when users ask about the knowledge maps.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,66 @@ Interactive knowledge maps of the Cardano ecosystem — governance, smart contra
 
 **Live:** https://lambdasistemi.github.io/cardano-knowledge-maps/
 
-## What is this?
+## What is this
 
-A browsable graph that maps the relationships between entities, processes, and concepts across the Cardano ecosystem. Click any node to see its description and links to source documentation. Use **Views** to focus on a specific topic.
+A browsable knowledge graph mapping the relationships between entities, processes, and concepts across the Cardano ecosystem: CIP-1694 governance, the Plutus smart-contract stack, the Conway transaction vocabulary, and the Cardano Budget 2026 proposals. Click any node to see its description and links to source documentation; use **Views** to focus on a specific topic.
 
-## How to use
+This repository is **data-only**. It holds Turtle RDF graph sources, a SPARQL query catalog, and guided tours; it contains no application code. The viewer is provided by [graph-browser](https://github.com/lambdasistemi/graph-browser), and CI assembles the site from pinned graph-browser releases with zero build tools in this repo.
+
+All instance data is grounded in a hand-authored OWL ontology built on standard W3C vocabularies (PROV-O, ORG, SKOS, OWL-Time, FOAF, Dublin Core), so the same triples can be queried by graph-browser, Protégé, Oxigraph, or any SPARQL endpoint.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  subgraph Data["data/ (this repo)"]
+    Config["config.json<br/>viewer config, kinds, graphSources"]
+    Graphs["rdf/*.ttl<br/>ontology + topic graphs"]
+    Queries["queries.json<br/>SPARQL query catalog"]
+    Tours["tutorials/*.json<br/>guided tours"]
+  end
+  subgraph Deploy["pages.yml (push to main)"]
+    Validate["validate-action<br/>JSON schemas + RDF parse"]
+    Build["build-action<br/>viewer + data → site/"]
+    Vocab["vocab-publish-action<br/>cardano.ontology.ttl → site/vocab/cardano"]
+  end
+  Site["GitHub Pages<br/>lambdasistemi.github.io/cardano-knowledge-maps"]
+  Data --> Validate
+  Validate --> Build
+  Build --> Vocab
+  Vocab --> Site
+```
+
+The instance graph is split by topic; the runtime composes the 19 sources listed in `data/config.json::graphSources` (sources marked `"background": true` are always loaded and hidden from the viewer's Sources toggle list).
+
+- `data/rdf/cardano.ontology.ttl` — Cardano domain ontology (OWL classes + object properties, W3C vocabularies); also published as a dereferenceable namespace document at [`/vocab/cardano`](https://lambdasistemi.github.io/cardano-knowledge-maps/vocab/cardano)
+- `data/rdf/cardano.ttl` — shared cross-cutting instance nodes (Plutus, Conway era, ExUnits, ...) referenced by multiple focuses
+- `data/rdf/transactions.ttl` — Conway transaction vocabulary, vendored from [cardano-ledger-rdf](https://github.com/lambdasistemi/cardano-ledger-rdf); pinned per [`data/rdf/PINNED.md`](data/rdf/PINNED.md)
+- `data/rdf/governance.ttl` — CIP-1694 governance: actors, action types, processes, treasury, parameters
+- `data/rdf/smart-contracts.ttl` — Plutus stack, languages, runtimes, dApps, Vasil features, Hydra L2
+- `data/rdf/budget-2026/*.ttl` — one TTL per Cardano Budget 2026 proposal, plus shared `proposers.ttl`
+- `data/config.json` — viewer configuration (kinds, colors, shapes, source labels)
+- `data/queries.json` — SPARQL query catalog (35 queries; entries tagged `"view"` drive the Views menu)
+- `data/tutorials/` — 19 guided tours listed in `data/tutorials/index.json`
+
+## Quickstart
+
+Browse the [live site](https://lambdasistemi.github.io/cardano-knowledge-maps/), or load the data through the hosted universal viewer:
+
+```
+https://lambdasistemi.github.io/graph-browser/?repo=lambdasistemi/cardano-knowledge-maps
+```
+
+To serve the site locally:
+
+```sh
+nix build                  # assembles viewer + data into ./result
+npx serve result -p 10001  # or: just serve
+```
+
+## Usage
+
+In the viewer:
 
 - **Views** button — switch between topic-specific lenses
 - **Click** a node to re-center and see its description
@@ -16,26 +71,31 @@ A browsable graph that maps the relationships between entities, processes, and c
 - **Depth buttons** (1, 2, 3, All) control neighborhood size
 - **Guided Tours** — narrative walkthroughs per view
 
-## Architecture
+The graph can also be queried outside the viewer: every `data/rdf/*.ttl` file is plain Turtle, parseable by any RDF toolchain.
 
-This repo is **data-only**. The viewer is provided by [graph-browser](https://github.com/lambdasistemi/graph-browser). CI validates and deploys with zero build tools.
+## Documentation
 
-### Data files
+- [`data/rdf/PINNED.md`](data/rdf/PINNED.md) — provenance and refresh procedure for the vendored transaction vocabulary
+- [`.specify/memory/constitution.md`](.specify/memory/constitution.md) — the project's data-authoring principles (RDF-first, ontology alignment, semantic completeness)
+- For AI agents, start at [AGENTS.md](AGENTS.md)
 
-The instance graph is split by topic; the runtime composes them through `graphSources` in `data/config.json`.
+## Development
 
-- `data/rdf/cardano.ontology.ttl` — Cardano domain ontology (OWL classes + object properties, W3C vocabularies)
-- `data/rdf/cardano.ttl` — shared cross-cutting instance nodes (Plutus, Conway era, ExUnits, ...) referenced by both governance and smart-contracts focuses
-- `data/rdf/governance.ttl` — CIP-1694 governance: actors, action types, processes, treasury, parameters
-- `data/rdf/smart-contracts.ttl` — Plutus stack, languages, runtimes, dApps, Vasil features, Hydra L2
-- `data/rdf/budget-2026/*.ttl` — one TTL per Cardano Budget 2026 proposal
-- `data/config.json` — viewer configuration (kinds, colors, shapes, source labels)
-- `data/queries.json` — SPARQL query catalog
-- `data/tutorials/` — guided tours
+The dev shell provides Python with rdflib, `just`, `jq`, and the [EYE](https://github.com/eyereasoner/eye) reasoner:
 
-## Contributing
+```sh
+nix develop
+just validate   # parse every graphSources TTL via rdflib
+just owl-smoke  # OWL 2 RL inference smoke fixtures via EYE
+just build      # nix build of the deployable site
+just ci         # build + validate + owl-smoke
+```
 
-Edit the topic TTL whose subject your statements concern. If a node is genuinely shared between focuses (referenced as a subject from one and as a target from another, or both), promote it to `cardano.ttl`. Edit `data/queries.json` for queries, `data/tutorials/` for tours. CI validates schemas and RDF syntax automatically.
+CI runs the graph-browser `validate-action` (JSON schemas, RDF parsing, referential integrity) on every PR and publishes a static preview of the assembled site as a PR comment.
+
+### Contributing
+
+Edit the topic TTL whose subject your statements concern. If a node is genuinely shared between focuses (referenced as a subject from one and as a target from another, or both), promote it to `cardano.ttl`. Every node needs a `cardano:` type and every edge predicate a `cardano:` property definition in `cardano.ontology.ttl`. Edit `data/queries.json` for queries, `data/tutorials/` for tours.
 
 ## Disclaimer
 

--- a/skills/cardano-knowledge-maps-guide/SKILL.md
+++ b/skills/cardano-knowledge-maps-guide/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: cardano-knowledge-maps-guide
+description: Orientation guide for the cardano-knowledge-maps repository — interactive RDF knowledge maps of the Cardano ecosystem rendered by graph-browser. Load when working with data/config.json, graphSources, data/rdf/*.ttl Turtle files (cardano.ontology.ttl, cardano.ttl, governance.ttl, smart-contracts.ttl, transactions.ttl, budget-2026/*.ttl), data/queries.json SPARQL queries, data/tutorials/ guided tours, the vendored cardano-ledger-rdf transaction vocabulary (data/rdf/PINNED.md), `just validate`, `just owl-smoke`, the EYE reasoner, rdflib validation, the GitHub Pages deployment, or when answering questions about Cardano governance (CIP-1694), Plutus smart contracts, Conway transactions, or Budget 2026 proposals as modeled in this graph.
+---
+
+# cardano-knowledge-maps guide
+
+## Repository map
+
+- `data/config.json` — viewer entry point: title, node kinds (colors/shapes), and the ordered `graphSources` list (19 Turtle files). Sources with `"background": true` are always loaded and hidden from the viewer's Sources toggle.
+- `data/rdf/cardano.ontology.ttl` — hand-authored OWL domain ontology grounding all nodes in W3C vocabularies (PROV-O, ORG, SKOS, OWL-Time, FOAF, Dublin Core). Published as a dereferenceable document at `<site>/vocab/cardano`.
+- `data/rdf/cardano.ttl` — shared instance nodes referenced by multiple topic files.
+- `data/rdf/transactions.ttl` — Conway transaction vocabulary, **vendored** from `lambdasistemi/cardano-ledger-rdf` (do not edit; see `data/rdf/PINNED.md` for the pinned commit and refresh procedure).
+- `data/rdf/governance.ttl` — CIP-1694 governance instance graph.
+- `data/rdf/smart-contracts.ttl` — Plutus stack, languages, dApps, Vasil features, Hydra.
+- `data/rdf/budget-2026/*.ttl` — one file per Budget 2026 proposal, plus shared `proposers.ttl`.
+- `data/rdf/core-ontology.{ttl,mmd}`, `data/rdf/application-ontology.{ttl,mmd}` — legacy graph-browser vocabulary exports; **not** listed in `graphSources`, not loaded by the viewer.
+- `data/queries.json` — 35 named SPARQL queries; entries tagged `"view"` become the viewer's Views menu.
+- `data/tutorials/` — 19 guided tours; `index.json` is the catalog.
+- `.specify/` — speckit scaffolding; `memory/constitution.md` holds the data-authoring principles, `scripts/validate-graph-sources.py` and `scripts/owl-smoke.py` are the local validation gates.
+- `specs/` — spec/plan/tasks records of past features, including the OWL 2 RL smoke fixtures under `specs/053-vocab-transactions/smoke/`.
+- `flake.nix` + `nix/eye.nix` — dev shell (Python+rdflib, just, jq, EYE reasoner) and site package; `justfile` — task runner.
+- `.github/workflows/` — `ci.yml` (validate + PR preview), `pages.yml` (validate + build + vocab publish + deploy).
+
+## Build, test, run
+
+All commands run from the repo root:
+
+```sh
+nix develop                              # dev shell: python3+rdflib, just, jq, eye
+nix develop --quiet -c just validate     # parse all 19 graphSources TTLs via rdflib
+nix develop --quiet -c just owl-smoke    # EYE OWL 2 RL inference smoke fixtures
+nix develop --quiet -c just ci           # build + validate + owl-smoke
+nix build                                # assemble viewer + data into ./result
+npx serve result -p 10001                # serve locally (or: just serve)
+```
+
+## Navigating the code
+
+There is no application code. The "logic" lives in the data layer:
+
+- Which graphs load, and in what order: `data/config.json::graphSources`.
+- What a node *is* (class, label, description): the topic TTL that owns it; its `cardano:` type is declared in `data/rdf/cardano.ontology.ttl`.
+- Why an edge renders with a given label: the `gbedge:` predicate alignment in `cardano.ontology.ttl`.
+- What the Views menu shows: `data/queries.json` entries tagged `"view"`.
+- What a guided tour says: the matching `data/tutorials/<id>.json` stops and narratives.
+- How validation works: `.specify/scripts/validate-graph-sources.py` (syntax) and `.specify/scripts/owl-smoke.py` (inference); CI additionally runs graph-browser's `validate-action` (JSON schemas + referential integrity).
+
+To find a concept, grep the TTLs for its label or IRI: node IRIs use the `n:` prefix (`https://github.com/lambdasistemi/cardano-knowledge-maps/rdf/node/`), vocabulary terms use `cardano:` (`https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#`).
+
+## Using the knowledge maps
+
+- Browse: <https://lambdasistemi.github.io/cardano-knowledge-maps/> — Views to switch topic, click to re-center, hover edges for rationale, depth buttons (1/2/3/All), Guided Tours for narratives.
+- Load through the universal viewer: `https://lambdasistemi.github.io/graph-browser/?repo=lambdasistemi/cardano-knowledge-maps` (add `&branch=<ref>` to preview a non-main ref).
+- Query outside the viewer: every TTL parses with any RDF toolchain, e.g. in the dev shell:
+
+  ```sh
+  python3 -c "import rdflib; g = rdflib.Graph(); g.parse('data/rdf/governance.ttl'); print(len(g))"
+  ```
+
+To add a node: add triples to the owning topic TTL, type it in `cardano.ontology.ttl`, align new edge predicates there too, include it in relevant `queries.json` queries and at least one tour, then run `just ci`. Promote nodes referenced by two or more topic files to `cardano.ttl`.
+
+## Answering questions
+
+- "What is this project?" — README **What is this**; one-line answer: interactive, ontology-grounded knowledge maps of the Cardano ecosystem, rendered by graph-browser, deployed on GitHub Pages.
+- "How do I run/see it?" — README **Quickstart** (live site, universal viewer, `nix build` + serve).
+- "How do I add a node/edge/tour?" — README **Contributing** plus `.specify/memory/constitution.md` (the semantic-completeness checklist).
+- "Where does the transaction vocabulary come from?" — `data/rdf/PINNED.md` (vendored from cardano-ledger-rdf at a pinned commit).
+- "How is the site built/deployed?" — README **Architecture** diagram; the source of truth is `.github/workflows/pages.yml` and `flake.nix`.
+- "Is the graph content authoritative?" — No: README **Disclaimer** — AI-generated from public documentation, verify against CIP-1694 and docs.cardano.org.


### PR DESCRIPTION
## What was inaccurate or missing

- The README data-file list omitted `data/rdf/transactions.ttl` (1,145 triples, the vendored Conway transaction vocabulary) and its provenance contract `data/rdf/PINNED.md`. Both are now documented.
- The local development workflow was entirely undocumented: the `nix develop` shell (rdflib, just, jq, EYE) and the `just validate` / `just owl-smoke` / `just ci` / `just serve` recipes. Added a Development section.
- No architecture diagram. Added a mermaid diagram of the deployment pipeline (validate-action -> build-action -> vocab-publish-action -> GitHub Pages), drawn from `.github/workflows/pages.yml`.
- The dereferenceable ontology publication at `/vocab/cardano` was undocumented.
- No agent layer: added `AGENTS.md` and `skills/cardano-knowledge-maps-guide/SKILL.md` (agentskills.io layout) so agents can onboard onto the data conventions without rediscovering them.

The README now follows the org-wide standard section order (What is this / Architecture / Quickstart / Usage / Documentation / Development); pre-existing accurate content (viewer interactions, contributing rules, disclaimer) is preserved.

## Verification

- `nix develop --quiet -c just validate` — all 19 graphSources parsed, 5797 triples.
- `nix develop --quiet -c just owl-smoke` — 2/2 fixtures passed.
- `nix build` — output contains `index.html`, `index.js`, `data/`, `vocab/cardano` as documented.
- Viewer feature claims (Views, depth controls, tours, `?repo=` universal viewer, `background` source flag) checked against the graph-browser README, `schema/config.schema.json`, and `validate-action/action.yml` at v1.1.0.
- Counts (19 sources, 35 queries, 19 tours) checked against `data/config.json`, `data/queries.json`, `data/tutorials/index.json`.
- Mermaid diagram nodes/edges map 1:1 to the steps in `pages.yml`.

## Observations left out of scope

- `data/rdf/core-ontology.{ttl,mmd}` and `data/rdf/application-ontology.{ttl,mmd}` are not referenced by `data/config.json::graphSources`, and the application ontology predates the `proposal` kind — candidates for removal or regeneration.
- The GitHub repo description ("Interactive knowledge graph of Cardano governance (CIP-1694, Conway era)") is narrower than the current content (smart contracts, transactions vocab, Budget 2026).
- `gate.sh` at the repo root references closed issue #58 and per its own header was meant to be dropped before review.
